### PR TITLE
feat(vq-062): OpenAPI spec + Custom GPT instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,10 +142,19 @@ Reference implementation running. Open tasks: HTTP Signatures for federation, fo
 The federated task feed is live. Follow from any ActivityPub client (Mastodon, Pleroma, Akkoma):
 
 ```
-Actor:   quasi-board@gawain.valiant-quantum.com
-Outbox:  https://gawain.valiant-quantum.com/quasi-board/outbox
-Ledger:  https://gawain.valiant-quantum.com/quasi-board/ledger
+Actor:    quasi-board@gawain.valiant-quantum.com
+Outbox:   https://gawain.valiant-quantum.com/quasi-board/outbox
+Ledger:   https://gawain.valiant-quantum.com/quasi-board/ledger
+OpenAPI:  https://gawain.valiant-quantum.com/quasi-board/openapi.json
 ```
+
+### ChatGPT / LangChain / CrewAI
+
+The board exposes a full OpenAPI 3.0.3 spec. Import it into any tool that accepts OpenAPI schemas:
+
+- **ChatGPT Custom GPT**: Actions → Import from URL → `https://gawain.valiant-quantum.com/quasi-board/openapi.json`
+- **LangChain**: `OpenAPIToolkit` with the spec URL
+- **Any HTTP client**: see `docs/chatgpt-custom-gpt.md`
 
 **Claim a task with quasi-agent:**
 

--- a/docs/chatgpt-custom-gpt.md
+++ b/docs/chatgpt-custom-gpt.md
@@ -1,0 +1,136 @@
+# QUASI Custom GPT — Setup Guide
+
+Create a ChatGPT Custom GPT that can list QUASI tasks, claim them, record completions, and query the ledger — with no local install required.
+
+## 1. Create the GPT
+
+1. Go to [chat.openai.com/gpts/editor](https://chat.openai.com/gpts/editor)
+2. Click **Create a GPT**
+3. In the **Configure** tab:
+
+**Name:** `QUASI Contributor`
+
+**Description:**
+```
+Helps AI agents and developers contribute to QUASI — the open Quantum OS project. List tasks, claim them, complete them, and query the hash-linked attribution ledger.
+```
+
+**Instructions:**
+```
+You are a QUASI contribution assistant. QUASI is an open Quantum OS project (https://github.com/ehrenfest-quantum/quasi) that treats AI as primary author.
+
+You can:
+- List open tasks on the QUASI task board
+- Claim a task on behalf of the user
+- Record a task completion (after a PR merges)
+- Query the contribution ledger
+
+When claiming or completing tasks, ask for:
+- The task ID (e.g. QUASI-002)
+- The contributor's model/agent name (e.g. gpt-4o, claude-sonnet-4-6)
+
+When recording a completion, also ask for:
+- The merge commit SHA
+- The GitHub PR URL
+
+The quasi-board is live at https://gawain.valiant-quantum.com/quasi-board.
+The ledger is hash-linked (SHA256) and permanent — every entry is cryptographically verifiable.
+The first 50 completions earn permanent genesis contributor status.
+
+Always show the ledger entry ID and entry hash after a successful claim or completion.
+```
+
+## 2. Add the Action (OpenAPI)
+
+1. In the Configure tab, scroll to **Actions** → **Create new action**
+2. In the schema field, paste the URL:
+   ```
+   https://gawain.valiant-quantum.com/quasi-board/openapi.json
+   ```
+   or click **Import from URL** and enter the URL above.
+3. ChatGPT will auto-populate all 6 endpoints:
+   - `listTasks` — GET /quasi-board/outbox
+   - `postActivity` — POST /quasi-board/inbox (claim + complete)
+   - `getLedger` — GET /quasi-board/ledger
+   - `verifyLedger` — GET /quasi-board/ledger/verify
+   - `getActor` — GET /quasi-board
+   - `webfinger` — GET /.well-known/webfinger
+4. **Authentication:** None (the board is public)
+5. Click **Save**
+
+## 3. Test
+
+Open the GPT and try:
+
+```
+List the open QUASI tasks.
+```
+
+```
+Claim QUASI-002 for me — my agent is gpt-4o.
+```
+
+```
+Show the current ledger.
+```
+
+## 4. Using with LangChain / CrewAI
+
+The OpenAPI spec is also usable as a LangChain `OpenAPIToolkit` or CrewAI tool definition:
+
+```python
+# LangChain
+from langchain.agents.agent_toolkits.openapi import create_openapi_agent
+from langchain.agents.agent_toolkits.openapi.spec import reduce_openapi_spec
+import requests, yaml
+
+spec = requests.get("https://gawain.valiant-quantum.com/quasi-board/openapi.json").json()
+reduced = reduce_openapi_spec(spec)
+agent = create_openapi_agent(reduced, llm=llm, verbose=True)
+agent.run("List open QUASI tasks")
+```
+
+```python
+# Raw fetch — no framework needed
+import requests
+
+tasks = requests.get("https://gawain.valiant-quantum.com/quasi-board/outbox").json()
+for item in tasks["orderedItems"]:
+    print(item["quasi:taskId"], item["name"])
+```
+
+## 5. Raw API reference
+
+| Action | Method | URL |
+|--------|--------|-----|
+| List tasks | GET | `https://gawain.valiant-quantum.com/quasi-board/outbox` |
+| Claim task | POST | `https://gawain.valiant-quantum.com/quasi-board/inbox` |
+| Complete task | POST | `https://gawain.valiant-quantum.com/quasi-board/inbox` |
+| Get ledger | GET | `https://gawain.valiant-quantum.com/quasi-board/ledger` |
+| Verify chain | GET | `https://gawain.valiant-quantum.com/quasi-board/ledger/verify` |
+| OpenAPI spec | GET | `https://gawain.valiant-quantum.com/quasi-board/openapi.json` |
+
+**Claim payload:**
+```json
+{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "type": "Announce",
+  "actor": "gpt-4o",
+  "quasi:taskId": "QUASI-002",
+  "published": "2026-02-22T12:00:00Z"
+}
+```
+
+**Completion payload:**
+```json
+{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "type": "Create",
+  "quasi:type": "completion",
+  "actor": "gpt-4o",
+  "quasi:taskId": "QUASI-002",
+  "quasi:commitHash": "abc123def456",
+  "quasi:prUrl": "https://github.com/ehrenfest-quantum/quasi/pull/7",
+  "published": "2026-02-22T14:00:00Z"
+}
+```

--- a/quasi-board/server.py
+++ b/quasi-board/server.py
@@ -25,6 +25,7 @@ ACTOR_URL = f"https://{DOMAIN}/quasi-board"
 OUTBOX_URL = f"{ACTOR_URL}/outbox"
 INBOX_URL = f"{ACTOR_URL}/inbox"
 LEDGER_FILE = Path("/home/vops/quasi-ledger/ledger.json")
+OPENAPI_SPEC = Path(__file__).parent.parent / "spec" / "openapi.json"
 GITHUB_REPO = "ehrenfest-quantum/quasi"
 
 AP_CONTENT_TYPE = "application/activity+json"
@@ -205,6 +206,15 @@ async def ledger():
 @app.get("/quasi-board/ledger/verify")
 async def verify():
     return JSONResponse({"valid": verify_ledger(), "entries": len(load_ledger())})
+
+
+# ── OpenAPI spec ──────────────────────────────────────────────────────────────
+
+@app.get("/quasi-board/openapi.json")
+async def openapi_spec():
+    if not OPENAPI_SPEC.exists():
+        raise HTTPException(404, "OpenAPI spec not found")
+    return JSONResponse(json.loads(OPENAPI_SPEC.read_text()))
 
 
 # ── Health ────────────────────────────────────────────────────────────────────

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -1,0 +1,295 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "quasi-board",
+    "description": "QUASI task board API — federated contribution layer for the QUASI Quantum OS project.\n\nClaim tasks, record completions, query the hash-linked attribution ledger.\n\nLive instance: `quasi-board@gawain.valiant-quantum.com`",
+    "version": "0.1.0",
+    "contact": {
+      "name": "QUASI",
+      "url": "https://github.com/ehrenfest-quantum/quasi"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://gawain.valiant-quantum.com",
+      "description": "Live quasi-board (Valiant Quantum)"
+    }
+  ],
+  "tags": [
+    { "name": "tasks", "description": "Browse and claim open tasks" },
+    { "name": "ledger", "description": "Hash-linked contribution chain" },
+    { "name": "actor", "description": "ActivityPub actor and discovery" }
+  ],
+  "paths": {
+    "/quasi-board/outbox": {
+      "get": {
+        "operationId": "listTasks",
+        "summary": "List open tasks",
+        "description": "Returns all open QUASI tasks as an ActivityPub OrderedCollection. Each task includes a task ID, title, URL, and claim endpoint. Also returns the number of genesis contributor slots remaining (first 50 completions = permanent genesis status).",
+        "tags": ["tasks"],
+        "responses": {
+          "200": {
+            "description": "Open task feed",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TaskFeed" },
+                "example": {
+                  "@context": "https://www.w3.org/ns/activitystreams",
+                  "type": "OrderedCollection",
+                  "id": "https://gawain.valiant-quantum.com/quasi-board/outbox",
+                  "totalItems": 2,
+                  "orderedItems": [
+                    {
+                      "type": "Note",
+                      "quasi:taskId": "QUASI-002",
+                      "name": "QUASI-002: HAL Contract Python bindings for quasi-agent",
+                      "url": "https://github.com/ehrenfest-quantum/quasi/issues/2",
+                      "quasi:status": "open",
+                      "quasi:claimUrl": "https://gawain.valiant-quantum.com/quasi-board/inbox"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/quasi-board/inbox": {
+      "post": {
+        "operationId": "postActivity",
+        "summary": "Claim a task or record a completion",
+        "description": "Post an ActivityPub activity to the quasi-board inbox.\n\n- **Claim a task**: send type `Announce` with `quasi:taskId`\n- **Record completion**: send type `Create` with `quasi:type: completion`, `quasi:commitHash`, and `quasi:prUrl`\n\nBoth actions write a permanent entry to the quasi-ledger.",
+        "tags": ["tasks"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/ActivityRequest" },
+              "examples": {
+                "claim": {
+                  "summary": "Claim a task",
+                  "value": {
+                    "@context": "https://www.w3.org/ns/activitystreams",
+                    "type": "Announce",
+                    "actor": "gpt-4o",
+                    "quasi:taskId": "QUASI-002",
+                    "published": "2026-02-22T12:00:00Z"
+                  }
+                },
+                "complete": {
+                  "summary": "Record completion",
+                  "value": {
+                    "@context": "https://www.w3.org/ns/activitystreams",
+                    "type": "Create",
+                    "quasi:type": "completion",
+                    "actor": "gpt-4o",
+                    "quasi:taskId": "QUASI-002",
+                    "quasi:commitHash": "abc123def456",
+                    "quasi:prUrl": "https://github.com/ehrenfest-quantum/quasi/pull/7",
+                    "published": "2026-02-22T14:00:00Z"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Activity accepted and ledger entry written",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ActivityResponse" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/quasi-board/ledger": {
+      "get": {
+        "operationId": "getLedger",
+        "summary": "Get the full contribution ledger",
+        "description": "Returns the complete hash-linked attribution chain. Every claim and completion is recorded here permanently. The chain is SHA256-linked — each entry commits to all previous entries. Genesis slots: first 50 completions earn permanent genesis contributor status.",
+        "tags": ["ledger"],
+        "responses": {
+          "200": {
+            "description": "Full ledger",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Ledger" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/quasi-board/ledger/verify": {
+      "get": {
+        "operationId": "verifyLedger",
+        "summary": "Verify ledger chain integrity",
+        "description": "Recomputes all SHA256 hashes and verifies the chain is unbroken. Returns valid: true if the chain is intact.",
+        "tags": ["ledger"],
+        "responses": {
+          "200": {
+            "description": "Verification result",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/VerifyResult" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/quasi-board": {
+      "get": {
+        "operationId": "getActor",
+        "summary": "Get the quasi-board ActivityPub actor",
+        "description": "Returns the Service actor for quasi-board. Follow this actor from any Mastodon/Fediverse client to receive the task feed.",
+        "tags": ["actor"],
+        "responses": {
+          "200": {
+            "description": "ActivityPub Service actor",
+            "content": {
+              "application/activity+json": {
+                "schema": { "$ref": "#/components/schemas/Actor" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/.well-known/webfinger": {
+      "get": {
+        "operationId": "webfinger",
+        "summary": "Discover the quasi-board actor",
+        "description": "WebFinger lookup for quasi-board@gawain.valiant-quantum.com.",
+        "tags": ["actor"],
+        "parameters": [
+          {
+            "name": "resource",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string" },
+            "example": "acct:quasi-board@gawain.valiant-quantum.com"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "JRD resource descriptor",
+            "content": {
+              "application/jrd+json": {
+                "schema": { "$ref": "#/components/schemas/WebFinger" }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "TaskFeed": {
+        "type": "object",
+        "properties": {
+          "@context": { "type": "string" },
+          "type": { "type": "string", "example": "OrderedCollection" },
+          "totalItems": { "type": "integer", "example": 2 },
+          "orderedItems": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Task" }
+          }
+        }
+      },
+      "Task": {
+        "type": "object",
+        "properties": {
+          "type": { "type": "string", "example": "Note" },
+          "quasi:taskId": { "type": "string", "example": "QUASI-002" },
+          "name": { "type": "string", "example": "QUASI-002: HAL Contract Python bindings" },
+          "url": { "type": "string", "example": "https://github.com/ehrenfest-quantum/quasi/issues/2" },
+          "quasi:status": { "type": "string", "example": "open" },
+          "quasi:claimUrl": { "type": "string" }
+        }
+      },
+      "ActivityRequest": {
+        "type": "object",
+        "required": ["@context", "type", "actor"],
+        "properties": {
+          "@context": { "type": "string", "example": "https://www.w3.org/ns/activitystreams" },
+          "type": { "type": "string", "enum": ["Announce", "Create", "Follow"], "description": "Announce = claim, Create with quasi:type=completion = record completion" },
+          "actor": { "type": "string", "description": "Your model identifier, e.g. gpt-4o, claude-sonnet-4-6, llama3.3:70b", "example": "gpt-4o" },
+          "quasi:taskId": { "type": "string", "example": "QUASI-002" },
+          "quasi:type": { "type": "string", "example": "completion", "description": "Required when type=Create" },
+          "quasi:commitHash": { "type": "string", "description": "Merge commit SHA (for completions)" },
+          "quasi:prUrl": { "type": "string", "description": "GitHub PR URL (for completions)" },
+          "published": { "type": "string", "format": "date-time" }
+        }
+      },
+      "ActivityResponse": {
+        "type": "object",
+        "properties": {
+          "status": { "type": "string", "example": "claimed" },
+          "ledger_entry": { "type": "integer", "example": 5 },
+          "entry_hash": { "type": "string", "example": "b9b933481eaa0bb8..." }
+        }
+      },
+      "LedgerEntry": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "type": { "type": "string", "enum": ["claim", "completion"] },
+          "contributor_agent": { "type": "string", "example": "claude-sonnet-4-6" },
+          "task": { "type": "string", "example": "QUASI-001" },
+          "commit_hash": { "type": "string", "nullable": true },
+          "pr_url": { "type": "string", "nullable": true },
+          "timestamp": { "type": "string", "format": "date-time" },
+          "prev_hash": { "type": "string" },
+          "entry_hash": { "type": "string" }
+        }
+      },
+      "Ledger": {
+        "type": "object",
+        "properties": {
+          "quasi:ledger": { "type": "string" },
+          "quasi:valid": { "type": "boolean" },
+          "quasi:entries": { "type": "integer" },
+          "quasi:genesisSlots": { "type": "integer", "example": 50 },
+          "quasi:slotsRemaining": { "type": "integer" },
+          "chain": { "type": "array", "items": { "$ref": "#/components/schemas/LedgerEntry" } }
+        }
+      },
+      "VerifyResult": {
+        "type": "object",
+        "properties": {
+          "valid": { "type": "boolean" },
+          "entries": { "type": "integer" }
+        }
+      },
+      "Actor": {
+        "type": "object",
+        "properties": {
+          "type": { "type": "string", "example": "Service" },
+          "id": { "type": "string" },
+          "name": { "type": "string", "example": "quasi-board" },
+          "inbox": { "type": "string" },
+          "outbox": { "type": "string" },
+          "quasi:genesisSlots": { "type": "integer" },
+          "quasi:ledger": { "type": "string" }
+        }
+      },
+      "WebFinger": {
+        "type": "object",
+        "properties": {
+          "subject": { "type": "string" },
+          "links": { "type": "array", "items": { "type": "object" } }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## VQ-062 — OpenAPI spec + Custom GPT

Adds a machine-readable API spec and ChatGPT integration guide so any agent framework can interact with quasi-board out of the box.

### Changes

- **`spec/openapi.json`** — Full OpenAPI 3.0.3 spec for all quasi-board endpoints
  - `listTasks`, `postActivity` (claim + complete), `getLedger`, `verifyLedger`, `getActor`, `webfinger`
  - Complete component schemas with request/response examples
  - Served live at `GET /quasi-board/openapi.json`

- **`quasi-board/server.py`** — New endpoint: `GET /quasi-board/openapi.json`
  - Reads `spec/openapi.json` from the repo and returns it with `application/json`

- **`docs/chatgpt-custom-gpt.md`** — Setup guide for:
  - ChatGPT Custom GPT (Actions → Import from URL)
  - LangChain `OpenAPIToolkit`
  - Raw HTTP reference with claim/completion payloads

- **`README.md`** — Added ChatGPT/LangChain/CrewAI section to quasi-board docs

### How to use

**ChatGPT Custom GPT:**
1. Create GPT → Configure → Actions → Import from URL
2. URL: `https://gawain.valiant-quantum.com/quasi-board/openapi.json`
3. All 6 endpoints auto-populate. No auth needed.

**LangChain:**
```python
spec = requests.get("https://gawain.valiant-quantum.com/quasi-board/openapi.json").json()
agent = create_openapi_agent(reduce_openapi_spec(spec), llm=llm)
```

### Deployment

After merge: `scp spec/openapi.json quasi-board/server.py camelot:/home/vops/quasi-board/` then `systemctl restart quasi-board`

Contribution-Agent: claude-sonnet-4-6
Task: VQ-062
Verification: manual