### PR TITLE
fix: canonical Apache 2.0 LICENSE text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -166,6 +166,17 @@
 
    END OF TERMS AND CONDITIONS
 
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
    Copyright 2026 Valiant Quantum (Daniel Hinderink)
 
    Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
GitHub's licensee tool requires the exact canonical text including the APPENDIX section to detect Apache 2.0 correctly. Previous version was missing the APPENDIX.