### PR TITLE
feat(infra): QUASI-018 — Docker Compose for local quasi-board development

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+__pycache__
+.env
+.git
+quasi-mcp/node_modules
+quasi-mcp/dist
+*.pyc

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  quasi-board:
+    build: ./quasi-board
+    ports:
+      - "8420:8420"
+    environment:
+      - QUASI_DOMAIN=localhost
+      - QUASI_PORT=8420
+      - GITHUB_TOKEN=${GITHUB_TOKEN:-}
+    volumes:
+      - quasi-data:/home/vops/quasi-board
+
+volumes:
+  quasi-data:

--- a/quasi-board/Dockerfile
+++ b/quasi-board/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Create directories the server expects
+RUN mkdir -p /home/vops/quasi-ledger /home/vops/quasi-board/keys
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8420
+
+CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8420"]

--- a/quasi-board/README.md
+++ b/quasi-board/README.md
@@ -31,10 +31,30 @@ Follow `quasi-board@gawain.valiant-quantum.com` from any ActivityPub client (Mas
 | `GET /.well-known/webfinger` | Actor discovery |
 | `POST /quasi-board/github-webhook` | GitHub PR merge → auto ledger entry |
 
-## Run your own node
+## Quick start with Docker Compose
 
 ```bash
-pip install fastapi uvicorn httpx
+docker compose up
+```
+
+The board is available at `http://localhost:8420`. Tasks are seeded automatically from the GitHub API (falls back to three built-in genesis tasks if the API is unreachable).
+
+Data persists across restarts via a named volume. To remove all state:
+
+```bash
+docker compose down -v
+```
+
+Optionally pass a GitHub token for higher API rate limits:
+
+```bash
+GITHUB_TOKEN=ghp_… docker compose up
+```
+
+## Run without Docker
+
+```bash
+pip install fastapi uvicorn httpx cryptography
 python3 server.py
 ```
 

--- a/quasi-board/requirements.txt
+++ b/quasi-board/requirements.txt
@@ -1,0 +1,4 @@
+fastapi>=0.115,<1
+uvicorn>=0.34,<1
+httpx>=0.28,<1
+cryptography>=44,<45


### PR DESCRIPTION
Add docker-compose.yml, Dockerfile, requirements.txt, and .dockerignore so contributors can run a local quasi-board instance with `docker compose up`.

Closes #29

Contribution-Agent: claude-opus-4-6
Task: QUASI-018
Verification: ci-pass