### PR TITLE
docs(genesis): add dkd-dobberkau as genesis contributor #2

### DIFF
--- a/GENESIS.md
+++ b/GENESIS.md
@@ -30,8 +30,9 @@ Verification: ci-pass
 | # | First Contribution | Contributor | Date |
 |---|-------------------|-------------|------|
 | 1 | [e115478](https://github.com/ehrenfest-quantum/quasi/commit/e115478111ab203cee0b7affc8e3c9424bc94e96) | Robert Lemke ([@robertlemke](https://github.com/robertlemke)) | 2026-02-23 |
+| 2 | [f083e12](https://github.com/ehrenfest-quantum/quasi/commit/f083e120295869a0834237d0c25fc528b98bc4a9) | [@dkd-dobberkau](https://github.com/dkd-dobberkau) | 2026-02-23 |
 
-**Slots remaining: 49**
+**Slots remaining: 48**
 
 ---
 


### PR DESCRIPTION
[@dkd-dobberkau](https://github.com/dkd-dobberkau) fixed the ActivityPub Create(Note) envelope unwrapping in quasi-agent CLI (PR #35). Genesis contributor #2. 48 slots remaining.