### PR TITLE
feat(quasi-board): QUASI-038 — /stats endpoint

### DIFF
--- a/quasi-board/server.py
+++ b/quasi-board/server.py
@@ -791,6 +791,61 @@ async def health():
     return {"status": "ok", "domain": DOMAIN, "ledger_entries": len(load_ledger())}
 
 
+# ── Stats ──────────────────────────────────────────────────────────────────────
+
+def _fetch_open_issue_count() -> int:
+    """Return the number of open GitHub issues. Falls back to 0 on error."""
+    try:
+        resp = httpx.get(
+            f"https://api.github.com/repos/{GITHUB_REPO}/issues",
+            params={"state": "open", "per_page": 1},
+            headers={"Accept": "application/vnd.github+json"},
+            timeout=10,
+        )
+        if resp.status_code == 200:
+            link = resp.headers.get("link", "")
+            # GitHub paginates; last page number is in the Link header
+            import re as _re
+            m = _re.search(r'page=(\d+)>; rel="last"', link)
+            if m:
+                return int(m.group(1))
+            return len(resp.json())
+    except Exception:
+        pass
+    return 0
+
+
+@app.get("/quasi-board/stats")
+async def stats():
+    chain = load_ledger()
+    valid = verify_ledger()
+
+    done_tasks = {e["task"] for e in chain if e.get("type") == "completion" and e.get("task")}
+    claimed_tasks = {e["task"] for e in chain if e.get("type") == "claim" and e.get("task")} - done_tasks
+
+    seen_contributors: set[str] = set()
+    for entry in chain:
+        contrib = entry.get("contributor")
+        if contrib and isinstance(contrib, dict):
+            key = contrib.get("handle") or contrib.get("name")
+            if key:
+                seen_contributors.add(key)
+
+    genesis_limit = 50
+    total_open = _fetch_open_issue_count()
+    tasks_open = max(0, total_open - len(done_tasks) - len(claimed_tasks))
+
+    return JSONResponse({
+        "tasks_open": tasks_open,
+        "tasks_claimed": len(claimed_tasks),
+        "tasks_done": len(done_tasks),
+        "contributors_named": len(seen_contributors),
+        "genesis_slots_remaining": max(0, genesis_limit - len(done_tasks)),
+        "ledger_entries": len(chain),
+        "ledger_valid": valid,
+    })
+
+
 
 # ── GitHub webhook ────────────────────────────────────────────────────────────
 

--- a/quasi-board/tests/test_stats.py
+++ b/quasi-board/tests/test_stats.py
@@ -1,0 +1,63 @@
+from unittest.mock import patch
+
+import pytest
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+@pytest.mark.anyio
+async def test_stats_empty_ledger():
+    from httpx import ASGITransport, AsyncClient
+    from server import app
+
+    with patch("server.load_ledger", return_value=[]), \
+         patch("server.verify_ledger", return_value=True), \
+         patch("server._fetch_open_issue_count", return_value=10):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get("/quasi-board/stats")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["tasks_open"] == 10
+    assert data["tasks_claimed"] == 0
+    assert data["tasks_done"] == 0
+    assert data["contributors_named"] == 0
+    assert data["genesis_slots_remaining"] == 50
+    assert data["ledger_entries"] == 0
+    assert data["ledger_valid"] is True
+
+
+@pytest.mark.anyio
+async def test_stats_with_ledger_entries():
+    from httpx import ASGITransport, AsyncClient
+    from server import app
+
+    chain = [
+        {"id": 1, "type": "claim", "task": "QUASI-001", "contributor_agent": "bot-a",
+         "entry_hash": "a" * 64, "prev_hash": "0" * 64, "timestamp": "2026-01-01T00:00:00Z"},
+        {"id": 2, "type": "completion", "task": "QUASI-001", "contributor_agent": "bot-a",
+         "contributor": {"name": "Alice", "handle": "@alice@fosstodon.org"},
+         "entry_hash": "b" * 64, "prev_hash": "a" * 64, "timestamp": "2026-01-02T00:00:00Z"},
+        {"id": 3, "type": "claim", "task": "QUASI-002", "contributor_agent": "bot-b",
+         "entry_hash": "c" * 64, "prev_hash": "b" * 64, "timestamp": "2026-01-03T00:00:00Z"},
+    ]
+
+    with patch("server.load_ledger", return_value=chain), \
+         patch("server.verify_ledger", return_value=True), \
+         patch("server._fetch_open_issue_count", return_value=20):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get("/quasi-board/stats")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["tasks_done"] == 1       # QUASI-001 completed
+    assert data["tasks_claimed"] == 1    # QUASI-002 claimed, not yet done
+    assert data["tasks_open"] == 18      # 20 - 1 done - 1 claimed
+    assert data["contributors_named"] == 1   # Alice
+    assert data["genesis_slots_remaining"] == 49
+    assert data["ledger_entries"] == 3
+    assert data["ledger_valid"] is True


### PR DESCRIPTION
## Summary

- Adds `GET /quasi-board/stats` returning aggregate task and ledger statistics
- Derives task counts (open/claimed/done) from ledger + GitHub open issue count
- Includes named contributor count, genesis slots remaining, chain validity

## Test plan

- [x] `pytest quasi-board/tests/test_stats.py -v -k asyncio` — 2 tests pass
- [x] `flake8` clean on new code (pre-existing lint issues untouched)

Closes #58

---
Contribution-Agent: `claude-sonnet-4-6`
Task: `QUASI-038`
Verification: ci-pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)