### PR TITLE
feat(quasi-board): QUASI-054 — /tasks/{id} endpoint with GitHub issue + ledger data

### DIFF
--- a/quasi-board/server.py
+++ b/quasi-board/server.py
@@ -912,19 +912,62 @@ async def inbox(request: Request):
 
 # ── Task status endpoint ──────────────────────────────────────────────────────
 
+def _fetch_github_issue(issue_number: int) -> dict | None:
+    """Fetch a single GitHub issue by number. Returns None on error."""
+    try:
+        resp = httpx.get(
+            f"https://api.github.com/repos/{GITHUB_REPO}/issues/{issue_number}",
+            headers={"Accept": "application/vnd.github+json"},
+            timeout=10,
+        )
+        if resp.status_code == 200:
+            return resp.json()
+    except Exception:
+        pass
+    return None
+
+
 @app.get("/quasi-board/tasks/{task_id}")
 async def task_status(task_id: str):
-    _validate_task_id(task_id)
-    effective = _effective_task_status(task_id)
+    # Accept both "QUASI-007" and plain numbers ("7", "007")
+    import re as _re
+    m = _re.fullmatch(r"(?:QUASI-)?(\d{1,6})", task_id)
+    if not m:
+        raise HTTPException(400, f"Invalid task id {task_id!r} — expected QUASI-NNN or a plain number")
+    issue_number = int(m.group(1))
+    canonical_id = f"QUASI-{issue_number:03d}"
+
+    effective = _effective_task_status(canonical_id)
+
+    # All ledger entries for this task
+    chain = load_ledger()
+    task_entries = [e for e in chain if e.get("task") == canonical_id]
+
     result: dict[str, Any] = {
-        "quasi:taskId": task_id,
+        "quasi:taskId": canonical_id,
         "quasi:status": effective["status"],
+        "quasi:ledgerEntries": task_entries,
     }
     if effective["status"] == "claimed":
         result["quasi:claimedBy"] = effective.get("agent")
         result["quasi:expiresAt"] = effective.get("expires_at")
     elif effective["status"] == "done":
         result["quasi:claimedBy"] = effective.get("agent")
+
+    # Enrich with GitHub issue data when available
+    issue = _fetch_github_issue(issue_number)
+    if issue:
+        result["task"] = {
+            "number": issue["number"],
+            "title": issue["title"],
+            "body": issue.get("body", ""),
+            "html_url": issue["html_url"],
+            "state": issue["state"],
+            "labels": [lb["name"] for lb in issue.get("labels", [])],
+            "created_at": issue["created_at"],
+            "updated_at": issue["updated_at"],
+        }
+
     return JSONResponse(result)
 
 

--- a/quasi-board/tests/test_task_detail.py
+++ b/quasi-board/tests/test_task_detail.py
@@ -1,0 +1,113 @@
+from unittest.mock import patch
+
+import pytest
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+MOCK_ISSUE = {
+    "number": 54,
+    "title": "QUASI-054: /tasks/{id} endpoint",
+    "body": "Add a GET endpoint that returns a single task by its QUASI number.",
+    "html_url": "https://github.com/ehrenfest-quantum/quasi/issues/54",
+    "state": "open",
+    "labels": [{"name": "L1"}],
+    "created_at": "2026-02-20T00:00:00Z",
+    "updated_at": "2026-02-24T00:00:00Z",
+}
+
+MOCK_LEDGER = [
+    {
+        "id": 1, "type": "claim", "task": "QUASI-054",
+        "contributor_agent": "bot-a", "timestamp": "2026-02-24T10:00:00Z",
+        "entry_hash": "a" * 64, "prev_hash": "0" * 64,
+    },
+]
+
+
+@pytest.mark.anyio
+async def test_task_detail_open():
+    from httpx import ASGITransport, AsyncClient
+    from server import app
+
+    with patch("server.load_ledger", return_value=[]), \
+         patch("server._fetch_github_issue", return_value=MOCK_ISSUE):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get("/quasi-board/tasks/QUASI-054")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["quasi:taskId"] == "QUASI-054"
+    assert data["quasi:status"] == "open"
+    assert data["quasi:ledgerEntries"] == []
+    assert data["task"]["number"] == 54
+    assert data["task"]["title"] == "QUASI-054: /tasks/{id} endpoint"
+    assert data["task"]["state"] == "open"
+
+
+@pytest.mark.anyio
+async def test_task_detail_plain_number():
+    """Plain number route: /tasks/54 same as /tasks/QUASI-054"""
+    from httpx import ASGITransport, AsyncClient
+    from server import app
+
+    with patch("server.load_ledger", return_value=[]), \
+         patch("server._fetch_github_issue", return_value=MOCK_ISSUE):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get("/quasi-board/tasks/54")
+
+    assert resp.status_code == 200
+    assert resp.json()["quasi:taskId"] == "QUASI-054"
+
+
+@pytest.mark.anyio
+async def test_task_detail_with_ledger_entries():
+    from httpx import ASGITransport, AsyncClient
+    from server import app
+
+    with patch("server.load_ledger", return_value=MOCK_LEDGER), \
+         patch("server._fetch_github_issue", return_value=MOCK_ISSUE):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get("/quasi-board/tasks/QUASI-054")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["quasi:status"] == "claimed"
+    assert len(data["quasi:ledgerEntries"]) == 1
+    assert data["quasi:ledgerEntries"][0]["type"] == "claim"
+    assert data["quasi:claimedBy"] == "bot-a"
+
+
+@pytest.mark.anyio
+async def test_task_detail_github_unavailable():
+    """Falls back gracefully when GitHub is unreachable."""
+    from httpx import ASGITransport, AsyncClient
+    from server import app
+
+    with patch("server.load_ledger", return_value=[]), \
+         patch("server._fetch_github_issue", return_value=None):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get("/quasi-board/tasks/QUASI-054")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["quasi:taskId"] == "QUASI-054"
+    assert "task" not in data  # no GitHub data — graceful degradation
+
+
+@pytest.mark.anyio
+async def test_task_detail_invalid_id():
+    from httpx import ASGITransport, AsyncClient
+    from server import app
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/quasi-board/tasks/INVALID")
+
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary

Enhances `GET /quasi-board/tasks/{task_id}`:

- Accepts both `QUASI-NNN` and plain number formats (`/tasks/54` = `/tasks/QUASI-054`)
- Returns full GitHub issue data (title, body, labels, state, URLs)
- Returns all matching ledger entries for the task (claims, submissions, completions)
- Graceful degradation when GitHub is unreachable (`task` field omitted, status still works)

Adds `_fetch_github_issue()` helper.

## Tests

5 new tests in `quasi-board/tests/test_task_detail.py`:
- `test_task_detail_open` — open task with GitHub data
- `test_task_detail_plain_number` — `/tasks/54` routing
- `test_task_detail_with_ledger_entries` — claimed task with ledger
- `test_task_detail_github_unavailable` — graceful degradation
- `test_task_detail_invalid_id` — 400 on bad format

Closes #54

---
Contribution-Agent: `gawain-openclaw`
Task: `QUASI-054`
Verification: ci-pass