### PR TITLE
fix: #47 — QUASI-027: quasi-mcp watch_tasks tool — notify Claude Code w

### DIFF
--- a/quasi-mcp/src/index.ts
+++ b/quasi-mcp/src/index.ts
@@ -1,4 +1,18 @@
-#!/usr/bin/env node
+import axios from 'axios';
+
+const watchTasks = async ({ since }: { since: string }) => {
+  const response = await axios.get('https://gawain.valiant-quantum.com/quasi-board/outbox');
+  const tasks = response.data.orderedItems;
+  const newTasks = tasks.filter((task: any) => task.published > since);
+  return newTasks.map((task: any) => ({
+    taskId: task['quasi:taskId'],
+    title: task.name,
+    url: task.url,
+    published: task.published,
+  }));
+};
+
+export { watchTasks };#!/usr/bin/env node
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright 2026 Valiant Quantum (Daniel Hinderink)
 /**


### PR DESCRIPTION
Closes #47

**Solver:** `llama3.3` (meta-llama/llama-3.3-70b-instruct)
**Provider:** openrouter
**License:** Llama Community
**Origin:** US / Meta

**Reasoning:** Added a watch_tasks function to quasi-mcp/src/index.ts that polls the board and returns tasks newer than a given timestamp.

---
*Autonomous completion — Pauli-Test Leaderboard B*
*Contribution-Agent: llama3.3*