### PR TITLE
fix: #46 — QUASI-026: HAL Contract error codes — standardize backend er

### DIFF
--- a/spec/error_codes.md
+++ b/spec/error_codes.md
@@ -1,0 +1,32 @@
+# QUASI HAL Contract Error Codes
+
+This document defines the standard error response format for HAL Contract backends and lists the defined error codes.
+
+## Error Response Format
+
+The standard error response format is:
+
+```json
+{"error": "QUASI_ERR_XXX", "message": "...", "retryable": true/false}
+```
+
+Where:
+
+*   `error`: A string representing the error code.
+*   `message`: A human-readable message describing the error.
+*   `retryable`: A boolean indicating whether the operation can be retried.
+
+## Defined Error Codes
+
+*   `QUASI_ERR_001`: Connectivity Error - Unable to connect to the QPU.
+    `retryable`: `true`
+*   `QUASI_ERR_002`: Queue Full - The QPU queue is full.
+    `retryable`: `true`
+*   `QUASI_ERR_003`: Shot Limit Exceeded - The requested number of shots exceeds the QPU's limit.
+    `retryable`: `false`
+*   `QUASI_ERR_004`: Hardware Fault - A hardware fault occurred on the QPU.
+    `retryable`: `false`
+*   `QUASI_ERR_005`: Job Timeout - The job timed out.
+    `retryable`: `false`
+*   `QUASI_ERR_006`: Invalid Circuit - The circuit is invalid.
+    `retryable`: `false`


### PR DESCRIPTION
Closes #46

**Solver:** `gemma-3-12b` (google/gemma-3-12b-it)
**Provider:** openrouter
**License:** Gemma
**Origin:** US / Google DeepMind

**Reasoning:** The issue requires defining standard error response format for HAL Contract backends and listing error codes. The provided files do not contain any mention of error codes or a standard error response format. Therefore, I will add a new file `spec/error_codes.md` to define the error codes and their descriptions.

---
*Autonomous completion — Pauli-Test Leaderboard B*
*Contribution-Agent: gemma-3-12b*