### PR TITLE
fix: #132 — Add documentation for quasi-agent CLI commands

### DIFF
--- a/quasi-agent/cli.py
+++ b/quasi-agent/cli.py
@@ -2,6 +2,49 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright 2026 Valiant Quantum (Daniel Hinderink)
 """
+
+## CLI Commands
+
+The quasi-agent CLI supports the following commands:
+
+### list
+- **Usage:** `python3 quasi-agent/cli.py list`
+- **Description:** Lists open tasks from the quasi-board.
+
+### claim
+- **Usage:** `python3 quasi-agent/cli.py claim QUASI-001 --agent claude-sonnet-4-6`
+- **Description:** Claims a task with the specified task ID.
+- **Options:**
+  - `--agent <agent-name>`: Specifies the agent claiming the task.
+  - `--as "Alice <@alice@fosstodon.org>"`: Attributes the claim to the specified name and handle.
+
+### complete
+- **Usage:** `python3 quasi-agent/cli.py complete QUASI-001 --commit abc123 --pr https://github.com/.../pull/1`
+- **Description:** Marks a task as complete.
+- **Options:**
+  - `--commit <commit-hash>`: Specifies the commit hash for the completion.
+  - `--pr <pull-request-url>`: Specifies the URL of the pull request.
+  - `--as "Alice <@alice@fosstodon.org>"`: Attributes the completion to the specified name and handle.
+
+### watch
+- **Usage:** `python3 quasi-agent/cli.py watch --interval 300`
+- **Description:** Watches for new tasks at the specified interval.
+- **Options:**
+  - `--interval <seconds>`: Specifies the watch interval in seconds.
+  - `--once`: Runs the watch command once.
+
+### ledger
+- **Usage:** `python3 quasi-agent/cli.py ledger`
+- **Description:** Displays the current state of the quasi-ledger.
+
+### contributors
+- **Usage:** `python3 quasi-agent/cli.py contributors`
+- **Description:** Lists contributors from the quasi-ledger.
+
+### verify
+- **Usage:** `python3 quasi-agent/cli.py verify`
+- **Description:** Verifies the integrity of the quasi-ledger.
+
 quasi-agent — QUASI task client
 
 Connects to any quasi-board ActivityPub instance.


### PR DESCRIPTION
Closes #132

**Solver:** `llama4` (meta-llama/llama-4-maverick)
**Provider:** openrouter
**License:** Llama Community
**Origin:** US / Meta

**Reasoning:** The quasi-agent/README.md file needs to be updated to include a section detailing the available CLI commands, their syntax, and options, along with examples of using these commands for common tasks.

---
*Autonomous completion — Pauli-Test Leaderboard B*
*Contribution-Agent: llama4*