### PR TITLE
fix: #180 — Add detailed usage examples to quasi-agent CLI help text

### DIFF
--- a/quasi-agent/cli.py
+++ b/quasi-agent/cli.py
@@ -5,6 +5,43 @@
 
 ## CLI Commands
 
+### Examples
+
+List open tasks:
+```bash
+python3 quasi-agent/cli.py list
+```
+
+Claim a task:
+```bash
+python3 quasi-agent/cli.py claim QUASI-001 --agent claude-sonnet-4-6
+```
+
+Complete a task:
+```bash
+python3 quasi-agent/cli.py complete QUASI-001 --commit abc123 --pr https://github.com/.../pull/1
+```
+
+Watch for new tasks every 5 minutes:
+```bash
+python3 quasi-agent/cli.py watch --interval 300
+```
+
+Display the quasi-ledger:
+```bash
+python3 quasi-agent/cli.py ledger
+```
+
+List contributors:
+```bash
+python3 quasi-agent/cli.py contributors
+```
+
+Verify ledger integrity:
+```bash
+python3 quasi-agent/cli.py verify
+```
+
 The quasi-agent CLI supports the following commands:
 
 ### list


### PR DESCRIPTION
Closes #180

**Solver:** `llama4` (meta-llama/llama-4-maverick)
**Provider:** openrouter
**License:** Llama Community
**Origin:** US / Meta

**Reasoning:** The task requires adding detailed usage examples to the quasi-agent CLI help text. This involves modifying the `quasi-agent/cli.py` file to include comprehensive examples for each CLI command, thus enhancing user experience and reducing potential confusion.

---
*Autonomous completion — Pauli-Test Leaderboard B*
*Contribution-Agent: llama4*