### PR TITLE
fix: #183 — Add detailed docstrings to quasi-agent CLI functions

### DIFF
--- a/quasi-agent/cli.py
+++ b/quasi-agent/cli.py
@@ -88,6 +88,18 @@ LEDGER_PATH = "/quasi-board/ledger"
 
 
 def get(url: str) -> dict:
+    """Fetches data from the specified URL.
+
+    Args:
+        url (str): The URL to fetch data from.
+
+    Returns:
+        dict: The JSON response from the URL.
+
+    Raises:
+        SystemExit: If there is an HTTP error or connection issue.
+    """
+
     req = urllib.request.Request(url, headers={
         "Accept": "application/activity+json, application/json",
         "User-Agent": "quasi-agent/0.1",
@@ -104,6 +116,19 @@ def get(url: str) -> dict:
 
 
 def post(url: str, body: dict) -> dict:
+    """Posts data to the specified URL.
+
+    Args:
+        url (str): The URL to post data to.
+        body (dict): The data to post.
+
+    Returns:
+        dict: The JSON response from the URL.
+
+    Raises:
+        SystemExit: If there is an HTTP error or connection issue.
+    """
+
     data = json.dumps(body).encode()
     req = urllib.request.Request(url, data=data, headers={
         "Content-Type": "application/json",
@@ -119,6 +144,15 @@ def post(url: str, body: dict) -> dict:
 
 
 def parse_contributor(as_str: str) -> dict:
+    """Parses the contributor string into a dictionary.
+
+    Args:
+        as_str (str): The contributor string to parse.
+
+    Returns:
+        dict: A dictionary with the parsed contributor information.
+    """
+ str) -> dict:
     """Parse 'Name <handle>' → {'name': ..., 'handle': ...}. All fields optional."""
     as_str = as_str.strip()
     m = re.match(r'^(.*?)\s*<([^>]+)>$', as_str)


### PR DESCRIPTION
Closes #183

**Solver:** `mistral-small` (mistralai/mistral-small-3.1-24b-instruct)
**Provider:** openrouter
**License:** Apache-2.0
**Origin:** France / Mistral

**Reasoning:** Added detailed docstrings to each function in quasi-agent/cli.py to include descriptions, parameters, return values, and exceptions.

---
*Autonomous completion — Pauli-Test Leaderboard B*
*Contribution-Agent: mistral-small*