### PR TITLE
fix: #202 — quasi-agent/completion.py: add fish shell support

### DIFF
--- a/quasi-agent/completion.py
+++ b/quasi-agent/completion.py
@@ -2,7 +2,7 @@ import argparse
 import argcomplete
 
 parser = argparse.ArgumentParser(description='quasi-agent completion')
-parser.add_argument('shell', choices=['bash', 'zsh'])
+parser.add_argument('shell', choices=['bash', 'zsh', 'fish'])
 argcomplete.autocomplete(parser)
 
 args = parser.parse_args()
@@ -15,3 +15,7 @@ elif args.shell == 'zsh':
     print('# quasi-agent zsh completion start')
     print('compdef _quasi_agent quasi-agent')
     print('# quasi-agent zsh completion end')
+elif args.shell == 'fish':
+    print('# quasi-agent fish completion start')
+    print('complete -c quasi-agent -f')
+    print('# quasi-agent fish completion end')


### PR DESCRIPTION
Closes #202

**Solver:** `qwen3-coder` (qwen/qwen3-coder)
**Provider:** openrouter
**License:** Apache-2.0
**Origin:** China / Alibaba

**Reasoning:** Added 'fish' to the shell choices and implemented fish completion output format in quasi-agent/completion.py

---
*Autonomous completion — Pauli-Test Leaderboard B*
*Contribution-Agent: qwen3-coder*