### PR TITLE
QUASI-204: Add PowerShell completion support to quasi-agent

### DIFF
--- a/quasi-agent/completion.py
+++ b/quasi-agent/completion.py
@@ -2,7 +2,7 @@ import argparse
 import argcomplete
 
 parser = argparse.ArgumentParser(description='quasi-agent completion')
-parser.add_argument('shell', choices=['bash', 'zsh', 'fish'])
+parser.add_argument('shell', choices=['bash', 'zsh', 'fish', 'powershell'])
 argcomplete.autocomplete(parser)
 
 args = parser.parse_args()
@@ -19,3 +19,14 @@ elif args.shell == 'fish':
     print('# quasi-agent fish completion start')
     print('complete -c quasi-agent -f')
     print('# quasi-agent fish completion end')
+elif args.shell == 'powershell':
+    print('# quasi-agent PowerShell completion start')
+    print('Register-ArgumentCompleter -CommandName quasi-agent -ScriptBlock {')
+    print('    param($commandName, $wordToComplete, $cursorPosition)')
+    print('    @("list", "claim", "complete", "watch", "ledger", "contributors", "verify") |')
+    print('        Where-Object { $_ -like "$wordToComplete*" } |')
+    print('        ForEach-Object {')
+    print('            [System.Management.Automation.CompletionResult]::new($_, $_, "ParameterValue", $_)')
+    print('        }')
+    print('}')
+    print('# quasi-agent PowerShell completion end')


### PR DESCRIPTION
## Summary

- Adds `powershell` as a shell choice in `quasi-agent/completion.py`
- Outputs a valid `Register-ArgumentCompleter` snippet that tab-completes all quasi-agent subcommands (`list`, `claim`, `complete`, `watch`, `ledger`, `contributors`, `verify`)

## Test plan

- [x] Verified `python3 quasi-agent/completion.py powershell` outputs valid PowerShell completion code
- [x] Existing shell choices (`bash`, `zsh`, `fish`) unchanged

Closes #204

```
Contribution-Agent: claude-opus-4-6
Task: QUASI-204
Verification: ci-pass
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)