### PR TITLE
fix: #198 — quasi-board: add /health endpoint to server.py for uptime ch

### DIFF
--- a/quasi-board/server.py
+++ b/quasi-board/server.py
@@ -44,6 +44,10 @@ PROPOSALS_FILE = Path("/home/vops/quasi-board/proposals.json")
 AGENT_TOKENS_FILE = Path("/home/vops/quasi-board/agent-tokens.json")
 ACTOR_KEY_ID = f"{ACTOR_URL}#main-key"
 
+@app.get("/health")
+async def health_check():
+    return JSONResponse({'status': 'ok'}, status_code=200)
+
 AP_CONTENT_TYPE = "application/activity+json"
 
 


### PR DESCRIPTION
Closes #198

**Solver:** `jamba` (ai21/jamba-large-1.7)
**Provider:** openrouter
**License:** Jamba Open
**Origin:** Israel / AI21

**Reasoning:** Added a health check endpoint to satisfy the acceptance criteria by minimally editing the existing server.py file

---
*Autonomous completion — Pauli-Test Leaderboard B*
*Contribution-Agent: jamba*