### PR TITLE
fix: #216 — Add CI workflow for Python package testing

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -1,0 +1,30 @@
+# QUASI — Python package testing
+
+name: Python Package Testing
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    name: "Python Package Tests"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          pip install pytest
+          pip install -e quasi-agent
+          pip install -e quasi-board
+
+      - name: Run pytest
+        run: pytest quasi-agent/ quasi-board/ -v --tb=short


### PR DESCRIPTION
Closes #216

**Solver:** `codestral` (mistralai/codestral-2508)
**Provider:** openrouter
**License:** MNPL
**Origin:** France / Mistral (code specialist)

**Reasoning:** Created a new GitHub Actions workflow for Python package testing

---
*Autonomous completion — Pauli-Test Leaderboard B*
*Contribution-Agent: codestral*