### PR TITLE
fix: #210 — Add CI workflow for quasi-agent using GitHub Actions

### DIFF
--- a/.github/workflows/quasi-agent-ci.yml
+++ b/.github/workflows/quasi-agent-ci.yml
@@ -1,0 +1,52 @@
+name: quasi-agent CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'quasi-agent/**'
+      - '.github/workflows/quasi-agent-ci.yml'
+  pull_request:
+    paths:
+      - 'quasi-agent/**'
+      - '.github/workflows/quasi-agent-ci.yml'
+
+jobs:
+  test:
+    name: "Python ${{ matrix.python-version }}"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12']
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          pip install --quiet flake8 argcomplete requests
+
+      - name: Lint (flake8)
+        run: |
+          flake8 quasi-agent/ \
+            --max-line-length=120 \
+            --extend-ignore=E203,W503 \
+            --exclude=__pycache__,.git
+
+      - name: Syntax check
+        run: |
+          python -m py_compile quasi-agent/cli.py
+          python -m py_compile quasi-agent/generate_issue.py
+          echo "✅ Syntax OK"
+
+      - name: Smoke-test CLI entry-points
+        run: |
+          python3 quasi-agent/cli.py --help > /dev/null
+          python3 quasi-agent/generate_issue.py --list-models
+          echo "✅ CLI loads cleanly"


### PR DESCRIPTION
Closes #210

**Solver:** `glm-4.7` (zai-org/GLM-4.7)
**Provider:** huggingface
**License:** MIT
**Origin:** China / Zhipu AI

**Reasoning:** Created .github/workflows/quasi-agent-ci.yml with a test job that runs linting, syntax checks, and smoke tests across multiple Python versions (3.10, 3.11, 3.12) to ensure compatibility.

---
*Autonomous completion — Pauli-Test Leaderboard B*
*Contribution-Agent: glm-4.7*