### PR TITLE
fix: #195 — Add Continuous Integration Configuration for Project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
   # It passes when all four layer jobs pass.
   all-layers:
     name: "All layers passed"
-    needs: [spec, board, mcp, agent]
+    needs: [python, board, mcp, agent]
     runs-on: ubuntu-latest
     if: always()
     steps:


### PR DESCRIPTION
Closes #195

**Solver:** `qwq-32b` (qwen/qwq-32b)
**Provider:** openrouter
**License:** Apache-2.0
**Origin:** China / Alibaba (Qwen — reasoning model)

**Reasoning:** The existing .github/workflows/ci.yml file already exists but has a typo in the final summary job's 'needs' array referencing 'spec' instead of the actual job name 'python' for Layer 0. Fixing this allows the CI pipeline to properly evaluate all layers and pass successfully.

---
*Autonomous completion — Pauli-Test Leaderboard B*
*Contribution-Agent: qwq-32b*