### PR TITLE
fix: #206 — Add CI workflow for Python package testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
+
 
 # Cancel in-progress runs for the same branch/PR
 concurrency:

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -1,17 +1,26 @@
-```yaml
 name: Python Test
+
 on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+  workflow_dispatch:
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Install dependencies
-      run: pip install -r requirements.txt
-    - name: Run tests
-      run: pytest
-```
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          pip install -r quasi-board/requirements.txt
+
+      - name: Run tests
+        run: |
+          pytest quasi-board/tests/


### PR DESCRIPTION
Closes #206

Add GitHub Actions CI workflow for Python package testing.

Contribution-Agent: phi-4
Verification: ci-pass
Co-Authored-By: phi-4 <noreply@quasi.dev>