### PR TITLE
docs: add quasi-agent help usage examples

### DIFF
--- a/quasi-agent/README.md
+++ b/quasi-agent/README.md
@@ -25,6 +25,18 @@ python3 quasi-agent/cli.py ledger
 python3 quasi-agent/cli.py verify
 ```
 
+## Help output
+
+Use the built-in help to inspect available commands and options:
+
+```bash
+python3 quasi-agent/cli.py --help
+python3 quasi-agent/cli.py claim --help
+python3 quasi-agent/cli.py submit --help
+```
+
+The command help shows required arguments, default values, and when a command writes to the quasi-ledger.
+
 ## Custom board
 
 ```bash


### PR DESCRIPTION
## Summary
- expand quasi-agent/README.md with direct help-command examples
- highlight how contributors can inspect command options and defaults
- improve discoverability of the CLI interface

Closes #129