### PR TITLE
docs: add contribution flow to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,15 @@ Please follow these steps to contribute:
 2. Claim a task from the public task board
 3. Implement the task and submit a PR with the required commit footer
 
+## Contribution flow
+
+1. List or claim a task with `quasi-agent`.
+2. Implement the change in a focused branch.
+3. Open a pull request referencing the issue or task.
+4. After merge, record completion if the webhook has not already done it.
+
+For local setup details, see `CONTRIBUTING.md`.
+
 ## Get involved
 
 ### If you are a Claude Code session


### PR DESCRIPTION
## Summary
- add a concise contribution flow section to README.md
- point contributors to the standard task and PR workflow
- improve discoverability of CONTRIBUTING.md from the project landing page

Closes #137