### PR TITLE
ci: add python test matrix workflow

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -1,0 +1,81 @@
+name: Python Test Matrix
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "afana/**"
+      - "quasi-agent/**"
+      - ".github/workflows/python-test.yml"
+  pull_request:
+    paths:
+      - "afana/**"
+      - "quasi-agent/**"
+      - ".github/workflows/python-test.yml"
+
+jobs:
+  afana:
+    name: "afana (Python ${{ matrix.python-version }})"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install afana dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r afana/requirements.txt pytest
+
+      - name: Run afana tests
+        run: pytest afana/tests/ -v --tb=short
+
+  quasi-agent:
+    name: "quasi-agent (Python ${{ matrix.python-version }})"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install quasi-agent dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install argcomplete requests pytest
+
+      - name: Run quasi-agent smoke tests
+        run: |
+          cat <<'PYTEST' > /tmp/test_quasi_agent_smoke.py
+          import subprocess
+          import sys
+
+
+          def test_cli_help():
+              subprocess.run(
+                  [sys.executable, "quasi-agent/cli.py", "--help"],
+                  check=True,
+                  stdout=subprocess.DEVNULL,
+              )
+
+
+          def test_generate_issue_list_models():
+              subprocess.run(
+                  [sys.executable, "quasi-agent/generate_issue.py", "--list-models"],
+                  check=True,
+              )
+          PYTEST
+          pytest -q /tmp/test_quasi_agent_smoke.py


### PR DESCRIPTION
Closes #263\n\nAdds a dedicated python-test.yml workflow for afana and quasi-agent, including a Python version matrix and pytest-based smoke coverage for the CLI entry points.