### PR TITLE
ci: add python CI workflow

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,0 +1,72 @@
+name: Python CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "afana/**"
+      - "quasi-agent/**"
+      - "quasi-board/**"
+      - ".github/workflows/python-ci.yml"
+  pull_request:
+    paths:
+      - "afana/**"
+      - "quasi-agent/**"
+      - "quasi-board/**"
+      - ".github/workflows/python-ci.yml"
+
+jobs:
+  test:
+    name: "Python ${{ matrix.python-version }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install shared tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest pytest-anyio anyio[asyncio] argcomplete requests
+
+      - name: Install afana dependencies
+        run: pip install -r afana/requirements.txt
+
+      - name: Install quasi-board dependencies
+        run: pip install -r quasi-board/requirements.txt
+
+      - name: Run afana tests
+        run: pytest afana/tests/ -v --tb=short
+
+      - name: Run quasi-board tests
+        run: pytest quasi-board/tests/ -v --tb=short
+
+      - name: Run quasi-agent smoke tests
+        run: |
+          cat <<'PYTEST' > /tmp/test_quasi_agent_smoke.py
+          import subprocess
+          import sys
+
+
+          def test_cli_help():
+              subprocess.run(
+                  [sys.executable, "quasi-agent/cli.py", "--help"],
+                  check=True,
+                  stdout=subprocess.DEVNULL,
+              )
+
+
+          def test_generate_issue_list_models():
+              subprocess.run(
+                  [sys.executable, "quasi-agent/generate_issue.py", "--list-models"],
+                  check=True,
+              )
+          PYTEST
+          pytest -q /tmp/test_quasi_agent_smoke.py


### PR DESCRIPTION
Closes #259\n\nAdds a dedicated python-ci.yml workflow that runs afana and quasi-board pytest suites plus quasi-agent smoke coverage across Python 3.10 through 3.12.