### PR TITLE
ci: add python package test suite workflow

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -1,0 +1,65 @@
+name: Python Package Test Suite
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "afana/**"
+      - "quasi-agent/**"
+      - ".github/workflows/python-test.yml"
+  pull_request:
+    paths:
+      - "afana/**"
+      - "quasi-agent/**"
+      - ".github/workflows/python-test.yml"
+
+jobs:
+  tests:
+    name: "Python ${{ matrix.python-version }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            afana/requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r afana/requirements.txt pytest argcomplete requests
+
+      - name: Run afana tests
+        run: pytest afana/tests/ -v --tb=short
+
+      - name: Run quasi-agent smoke tests via pytest
+        run: |
+          cat <<'PYTEST' > /tmp/test_quasi_agent_cli.py
+          import subprocess
+          import sys
+
+
+          def test_cli_help():
+              subprocess.run(
+                  [sys.executable, "quasi-agent/cli.py", "--help"],
+                  check=True,
+                  stdout=subprocess.DEVNULL,
+              )
+
+
+          def test_generate_issue_help():
+              subprocess.run(
+                  [sys.executable, "quasi-agent/generate_issue.py", "--help"],
+                  check=True,
+                  stdout=subprocess.DEVNULL,
+              )
+          PYTEST
+          pytest -q /tmp/test_quasi_agent_cli.py


### PR DESCRIPTION
Closes #258\n\nAdds a dedicated python-test.yml workflow that runs afana tests and pytest-based quasi-agent CLI smoke coverage on push and pull requests.