### PR TITLE
ci: add python package test suite workflow (fixed)

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4
@@ -38,7 +38,7 @@ jobs:
           pip install -r afana/requirements.txt pytest argcomplete requests
 
       - name: Run afana tests
-        run: pytest afana/tests/ -v --tb=short
+        run: PYTHONPATH=. pytest afana/tests/ -v --tb=short
 
       - name: Run quasi-agent smoke tests via pytest
         run: |


### PR DESCRIPTION
Supersedes #305.\n\nCloses #258\n\nReopens the workflow from #305 with Python 3.10+ only and a fixed PYTHONPATH for afana test imports.