### PR TITLE
ci: add python test matrix workflow (fixed)

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4
@@ -35,7 +35,7 @@ jobs:
           pip install -r afana/requirements.txt pytest
 
       - name: Run afana tests
-        run: pytest afana/tests/ -v --tb=short
+        run: PYTHONPATH=. pytest afana/tests/ -v --tb=short
 
   quasi-agent:
     name: "quasi-agent (Python ${{ matrix.python-version }})"
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Supersedes #303.\n\nCloses #263\n\nCarries forward the workflow from #303 but restricts execution to Python 3.10+ and sets PYTHONPATH so afana imports resolve during pytest collection.