### PR TITLE
ci: add afana test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,36 @@
+name: Afana Tests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "afana/**"
+      - ".github/workflows/test.yml"
+  pull_request:
+    paths:
+      - "afana/**"
+      - ".github/workflows/test.yml"
+
+jobs:
+  afana:
+    name: "Python ${{ matrix.python-version }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r afana/requirements.txt pytest
+
+      - name: Run afana tests
+        run: PYTHONPATH=. pytest afana/tests/ -v --tb=short


### PR DESCRIPTION
Closes #256\n\nAdds a dedicated test.yml workflow for Afana that runs the existing pytest suite on push and pull requests across the supported Python versions.