### PR TITLE
ci: add quasi-board python tests workflow

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,36 @@
+name: quasi-board Python Tests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "quasi-board/**"
+      - ".github/workflows/python-tests.yml"
+  pull_request:
+    paths:
+      - "quasi-board/**"
+      - ".github/workflows/python-tests.yml"
+
+jobs:
+  quasi-board:
+    name: "quasi-board (Python ${{ matrix.python-version }})"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r quasi-board/requirements.txt pytest pytest-anyio anyio[asyncio]
+
+      - name: Run quasi-board tests
+        run: pytest quasi-board/tests/ -v --tb=short


### PR DESCRIPTION
Closes #213\n\nAdds a dedicated python-tests.yml workflow that runs quasi-board/tests on push and pull requests across the supported Python versions.