### PR TITLE
fix: return JSON 404 for missing tasks

### DIFF
--- a/quasi-board/server.py
+++ b/quasi-board/server.py
@@ -54,6 +54,10 @@ app = FastAPI(title="quasi-board", version="0.1.0")
 app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["GET"], allow_headers=["*"])
 
 
+class TaskNotFoundError(Exception):
+    """Raised when GitHub confirms that a task issue does not exist."""
+
+
 # Prometheus-compatible metrics for quasi-board
 @app.get("/quasi-board/metrics", response_class=PlainTextResponse)
 def metrics() -> PlainTextResponse:
@@ -333,7 +337,11 @@ def _save_pending_merges(merges: list) -> None:
 
 
 async def _fetch_github_issue(issue_number: int) -> dict | None:
-    """Fetch a single GitHub issue by number. Returns None on failure."""
+    """Fetch a single GitHub issue by number.
+
+    Returns None on transient failure. Raises TaskNotFoundError when GitHub
+    explicitly returns 404 for the issue lookup.
+    """
     token = _github_token()
     headers: dict[str, str] = {"Accept": "application/vnd.github+json"}
     if token:
@@ -346,6 +354,10 @@ async def _fetch_github_issue(issue_number: int) -> dict | None:
             )
             if resp.status_code == 200:
                 return resp.json()
+            if resp.status_code == 404:
+                raise TaskNotFoundError(issue_number)
+    except TaskNotFoundError:
+        raise
     except Exception:
         pass
     return None
@@ -1127,7 +1139,13 @@ async def task_status(task_id: str):
 
     # Fetch GitHub issue data (graceful degradation on failure)
     if issue_number is not None:
-        github_issue = await _fetch_github_issue(issue_number)
+        try:
+            github_issue = await _fetch_github_issue(issue_number)
+        except TaskNotFoundError:
+            return JSONResponse(
+                {"error": "task_not_found", "quasi:taskId": task_id},
+                status_code=404,
+            )
         if github_issue is not None:
             result["task"] = github_issue
 

--- a/quasi-board/tests/test_task_detail.py
+++ b/quasi-board/tests/test_task_detail.py
@@ -102,6 +102,21 @@ async def test_task_detail_github_unavailable():
 
 
 @pytest.mark.anyio
+async def test_task_detail_not_found_returns_json_404():
+    from httpx import ASGITransport, AsyncClient
+    from server import TaskNotFoundError, app
+
+    with patch("server.load_ledger", return_value=[]), \
+         patch("server._fetch_github_issue", side_effect=TaskNotFoundError(54)):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get("/quasi-board/tasks/QUASI-054")
+
+    assert resp.status_code == 404
+    assert resp.json() == {"error": "task_not_found", "quasi:taskId": "QUASI-054"}
+
+
+@pytest.mark.anyio
 async def test_task_detail_invalid_id():
     from httpx import ASGITransport, AsyncClient
     from server import app


### PR DESCRIPTION
Closes #196\n\nDistinguishes a real GitHub 404 from transient fetch failures in the task detail handler and returns a structured JSON 404 response for missing tasks. Includes a focused regression test for the new behavior.