### PR TITLE
ci: add quasi-board workflow

### DIFF
--- a/.github/workflows/quasi-board-ci.yml
+++ b/.github/workflows/quasi-board-ci.yml
@@ -1,0 +1,43 @@
+name: quasi-board CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "quasi-board/**"
+      - ".github/workflows/quasi-board-ci.yml"
+  pull_request:
+    paths:
+      - "quasi-board/**"
+      - ".github/workflows/quasi-board-ci.yml"
+
+jobs:
+  test:
+    name: "Python ${{ matrix.python-version }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r quasi-board/requirements.txt pytest pytest-anyio anyio[asyncio] flake8
+
+      - name: Lint quasi-board
+        run: |
+          flake8 quasi-board/ \
+            --max-line-length=120 \
+            --extend-ignore=E203,W503 \
+            --exclude=__pycache__,.git
+
+      - name: Run quasi-board tests
+        run: pytest quasi-board/tests/ -v --tb=short


### PR DESCRIPTION
Closes #165\n\nAdds a dedicated GitHub Actions workflow for quasi-board with linting and the existing pytest suite on push and pull requests.