### PR TITLE
fix(rotate): normalise footer model string to short ID; remove Codestral

### DIFF
--- a/quasi-agent/generate_issue.py
+++ b/quasi-agent/generate_issue.py
@@ -128,8 +128,6 @@ ROTATION: list[dict] = [
      "provider": "openrouter", "license": "Llama Community", "origin": "US / Meta"},
     {"id": "llama3.3", "model": "meta-llama/llama-3.3-70b-instruct",
      "provider": "openrouter", "license": "Llama Community", "origin": "US / Meta"},
-    {"id": "codestral", "model": "mistralai/codestral-2508",
-     "provider": "openrouter", "license": "MNPL", "origin": "France / Mistral (code specialist)"},
     # ── Tier 2 — EU / competitive coding ─────────────────────────────────
     {"id": "mistral-small", "model": "mistralai/mistral-small-3.1-24b-instruct",
      "provider": "openrouter", "license": "Apache-2.0", "origin": "France / Mistral"},

--- a/quasi-agent/rotate.py
+++ b/quasi-agent/rotate.py
@@ -110,12 +110,17 @@ def github_get(path: str, token: str) -> list | dict:
     return results
 
 
+def _model_string_to_id() -> dict[str, str]:
+    """Build a reverse map: full API model string -> short rotation ID."""
+    return {e["model"]: e["id"] for e in ROTATION}
+
+
 def count_issues_per_model_level(token: str) -> dict[str, dict[int, int]]:
     """
     Parse all open+closed QUASI issues and count how many each model has
     generated at each level.
 
-    Returns: {model_id: {level: count}}
+    Returns: {short_id: {level: count}}
     """
     # Fetch open issues
     all_issues: list[dict] = []
@@ -156,13 +161,20 @@ def count_issues_per_model_level(token: str) -> dict[str, dict[int, int]]:
                 break
             pages += 1
 
+    # Build reverse map so we can normalise the full model string in the issue
+    # footer back to the short rotation ID used as the count key.
+    model_str_to_id = _model_string_to_id()
+
     counts: dict[str, dict[int, int]] = defaultdict(lambda: defaultdict(int))
     matched = 0
     for issue in all_issues:
         body = issue.get("body") or ""
         m = GENERATOR_PATTERN.search(body)
         if m:
-            model_id = m.group(1)
+            raw_model = m.group(1)
+            # Normalise: footer stores the full API model string; map to short id.
+            # Falls back to the raw string so old issues with unknown models still count.
+            model_id = model_str_to_id.get(raw_model, raw_model)
             level = int(m.group(2))
             counts[model_id][level] += 1
             matched += 1


### PR DESCRIPTION
## Summary

- **Bug fix**: `count_issues_per_model_level()` was recording issue counts keyed by the full API model string (`deepseek/deepseek-chat-v3-0324`) from the issue footer, but `pick_next()` queried the same dict by the short rotation ID (`deepseek-v3`). Keys never matched → every model always showed 0 issues → scheduler kept re-selecting `deepseek-v3` at L0 every single fire. All 110 generated issues were from one model at one level.
- **Fix**: adds `_model_string_to_id()` reverse-lookup and normalises captured model strings to short IDs before counting.
- **Codestral removed**: `codestral-2508` has no publicly downloadable weights (API-only on La Plateforme); older 22B uses MNPL (non-commercial). Both disqualify under the open-weights eligibility rule in `docs/ELIGIBLE-MODELS.md`. Confirmed via web search before removing.

## Impact

After this fix the rotation will correctly see `deepseek-v3` at L0 as saturated (110 issues >> quota of 6) and advance to the next model in the list on the next timer fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)