### PR TITLE
feat(rotation): Fireworks, solve rotation, provider alternation

### DIFF
--- a/quasi-agent/generate_issue.py
+++ b/quasi-agent/generate_issue.py
@@ -94,6 +94,14 @@ PROVIDERS: dict[str, dict] = {
         "headers": {},
         "verify_header": None,
     },
+    # Fireworks AI — fast inference, pay-per-token, OpenAI-compatible
+    # https://fireworks.ai — model IDs use accounts/{org}/models/{name} format
+    "fireworks": {
+        "url": "https://api.fireworks.ai/inference/v1/chat/completions",
+        "env": "FIREWORKS_API_KEY",
+        "headers": {},
+        "verify_header": None,
+    },
     # Swiss National Supercomputing Centre (CSCS) — hosts Apertus-70B
     # Register at https://serving.swissai.cscs.ch to obtain a token.
     # Env var name matches their official docs and CLI repo.
@@ -222,6 +230,17 @@ ROTATION: list[dict] = [
     {"id": "allam-2", "model": "allam-2-7b",
      "provider": "groq", "license": "Apache-2.0",
      "origin": "Saudi Arabia / SDAIA"},
+    # ── Fireworks additions — Tier 1 ──────────────────────────────────────
+    # Cogito-671B: Deep Cogito (US). MIT. Fine-tuned on DeepSeek-V3-Base.
+    # 671B MoE, 128k context. Strong coding and reasoning.
+    {"id": "cogito-671b", "model": "accounts/cogito/models/cogito-671b-v2-p1",
+     "provider": "fireworks", "license": "MIT",
+     "origin": "US / Deep Cogito"},
+    # MiniMax-M2.1: MiniMax (Shanghai, China). Modified MIT. Open weights.
+    # 230B total / 10B active MoE. Strong on coding and agent tasks.
+    {"id": "minimax-m2", "model": "accounts/fireworks/models/minimax-m2p1",
+     "provider": "fireworks", "license": "Modified MIT",
+     "origin": "China / MiniMax (Shanghai)"},
 ]
 
 DEFAULT_MODEL_ID = "deepseek-v3"

--- a/quasi-agent/rotate.py
+++ b/quasi-agent/rotate.py
@@ -2,24 +2,33 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright 2026 QUASI Contributors
 """
-rotate.py — Rotation scheduler for the QUASI Pauli-Test issue generator.
+rotate.py — Rotation scheduler for the QUASI Pauli-Test (generate + solve).
 
-Picks the next model in round-robin order (model with fewest existing issues
-per capability level) and calls generate_issue.py as a subprocess.
+Modes:
+  --generate  (default) Pick the model with fewest generated issues and call
+              generate_issue.py to create the next GitHub issue.
+  --solve     Pick an open unclaimed GitHub issue and a model, then call
+              solve.py to attempt a resolution.
 
 Usage:
-    python3 quasi-agent/rotate.py              # auto-select model and level
-    python3 quasi-agent/rotate.py --dry-run    # show selection, do not generate
-    python3 quasi-agent/rotate.py --level 0    # fix the level, rotate model only
+    python3 quasi-agent/rotate.py              # generate next issue
+    python3 quasi-agent/rotate.py --solve      # solve next open issue
+    python3 quasi-agent/rotate.py --dry-run    # show selection, do nothing
+    python3 quasi-agent/rotate.py --level 0    # fix level (generate only)
+
+Provider alternation: a state file records the last provider used per mode.
+The scheduler de-prioritises that provider on the next fire to spread load
+across OpenRouter, HuggingFace, Groq, Fireworks, etc.
 
 This script is designed to run as a systemd timer on Camelot.
-Environment variables needed (same as generate_issue.py):
-    GITHUB_TOKEN         Read issues + create issues
+Environment variables (same as generate_issue.py):
+    GITHUB_TOKEN         Read issues + create PRs
     OPENROUTER_API_KEY   OpenRouter models
     HF_TOKEN             HuggingFace Inference Router models
-    SARVAM_API_KEY       Sarvam-30B/105B (India)
-    MISTRAL_API_KEY      Mistral direct endpoint (optional)
-    CSCS_SERVING_API     Swiss AI / Apertus (optional, needs account)
+    GROQ_API_KEY         Groq models (free tier)
+    FIREWORKS_API_KEY    Fireworks AI models
+    SARVAM_API_KEY       Sarvam-M (India)
+    CSCS_SERVING_API     Swiss AI / Apertus (optional)
 """
 
 from __future__ import annotations
@@ -63,6 +72,23 @@ GENERATOR_PATTERN = re.compile(
 )
 
 LOG_FILE = Path("/home/vops/quasi-rotate.log")
+STATE_FILE = Path("/home/vops/quasi-rotate-state.json")
+
+
+def load_state() -> dict:
+    """Load rotation state (last provider used per mode)."""
+    try:
+        return json.loads(STATE_FILE.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def save_state(state: dict) -> None:
+    """Persist rotation state."""
+    try:
+        STATE_FILE.write_text(json.dumps(state, indent=2))
+    except OSError as exc:
+        log(f"Warning: could not write state file: {exc}")
 
 
 def log(msg: str) -> None:
@@ -217,6 +243,7 @@ def planck_quota_met(
 def pick_next(
     counts: dict[str, dict[int, int]],
     fixed_level: int | None = None,
+    last_provider: str | None = None,
 ) -> tuple[str, int]:
     """
     Pick (model_id, level) with the fewest generated issues.
@@ -224,10 +251,12 @@ def pick_next(
     Strategy:
     1. For each (model_id, level) pair in eligible ROTATION × LEVEL_NAMES,
        compute issue count (0 if not in counts).
-    2. Sort by count ascending, then by ROTATION index (stable ordering).
+    2. Sort by: (count, same_provider_as_last, rotation_idx) ascending.
+       The same_provider penalty ensures consecutive runs alternate providers.
     3. Return the first pair below PLANCK_QUOTA.
 
     If fixed_level is given, only consider that level.
+    last_provider de-prioritises models on the same provider as the previous run.
     """
     eligible = eligible_rotation()
     if not eligible:
@@ -236,97 +265,211 @@ def pick_next(
 
     levels = [fixed_level] if fixed_level is not None else list(LEVEL_NAMES.keys())
 
-    candidates: list[tuple[int, int, str, int]] = []  # (count, rotation_idx, model_id, level)
+    # (count, same_provider_penalty, rotation_idx, model_id, level)
+    candidates: list[tuple[int, int, int, str, int]] = []
     for rot_idx, entry in enumerate(eligible):
         mid = entry["id"]
+        same_provider = 1 if (last_provider and entry["provider"] == last_provider) else 0
         for level in levels:
             c = counts.get(mid, {}).get(level, 0)
             if c < PLANCK_QUOTA:
-                candidates.append((c, rot_idx, mid, level))
+                candidates.append((c, same_provider, rot_idx, mid, level))
 
     candidates.sort()
-    _, _, model_id, level = candidates[0]
+    _, _, _, model_id, level = candidates[0]
     return model_id, level
 
 
 def run_generator(model_id: str, level: int, dry_run: bool = False) -> int:
-    """
-    Call generate_issue.py as a subprocess.
-    Returns the exit code.
-    """
+    """Call generate_issue.py as a subprocess. Returns exit code."""
     script = _here / "generate_issue.py"
-    cmd = [
-        sys.executable,
-        str(script),
-        "--model", model_id,
-        "--level", str(level),
-    ]
+    cmd = [sys.executable, str(script), "--model", model_id, "--level", str(level)]
     if dry_run:
         cmd.append("--dry-run")
-
     log(f"Invoking: {' '.join(cmd)}")
     result = subprocess.run(cmd, env=os.environ.copy())
     return result.returncode
 
 
+# ── Solve-side rotation ───────────────────────────────────────────────────────
+
+
+def fetch_open_issues(token: str) -> list[dict]:
+    """Return open GitHub issues that are Pauli-Test tasks (have a generator footer)."""
+    all_issues: list[dict] = []
+    url: str | None = (
+        f"{GITHUB_API_BASE}/issues?per_page={ISSUES_PER_PAGE}&state=open"
+    )
+    pages = 0
+    while url and pages < MAX_PAGES:
+        req = urllib.request.Request(
+            url,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=20) as resp:
+                data = json.loads(resp.read().decode())
+                if not isinstance(data, list):
+                    break
+                all_issues.extend(data)
+                link = resp.headers.get("Link", "")
+                next_url = None
+                for part in link.split(","):
+                    part = part.strip()
+                    if 'rel="next"' in part:
+                        m = re.search(r"<([^>]+)>", part)
+                        if m:
+                            next_url = m.group(1)
+                url = next_url
+        except urllib.error.HTTPError as exc:
+            log(f"GitHub error {exc.code} fetching open issues")
+            break
+        pages += 1
+    return [i for i in all_issues if GENERATOR_PATTERN.search(i.get("body") or "")]
+
+
+def pick_solve_issue(issues: list[dict], last_issue: int | None) -> dict | None:
+    """Pick oldest open Pauli-Test issue, skipping the last attempted."""
+    if not issues:
+        return None
+    candidates = sorted(issues, key=lambda i: i["number"])
+    for issue in candidates:
+        if issue["number"] != last_issue:
+            return issue
+    return candidates[0]
+
+
+def run_solver(model_id: str, issue_num: int, dry_run: bool = False) -> int:
+    """Call solve.py as a subprocess. Returns exit code."""
+    script = _here / "solve.py"
+    cmd = [sys.executable, str(script), "--model", model_id, "--issue", str(issue_num)]
+    if dry_run:
+        cmd.append("--dry-run")
+    log(f"Invoking: {' '.join(cmd)}")
+    result = subprocess.run(cmd, env=os.environ.copy())
+    return result.returncode
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         prog="quasi-agent/rotate.py",
-        description="Select the next eligible model/level pair and run the issue generator.",
+        description="Rotate through QUASI eligible models for issue generation and solving.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""Examples:
-  python3 quasi-agent/rotate.py
-  python3 quasi-agent/rotate.py --dry-run
-  python3 quasi-agent/rotate.py --level 2
+  python3 quasi-agent/rotate.py              # generate next issue
+  python3 quasi-agent/rotate.py --solve      # solve next open issue
+  python3 quasi-agent/rotate.py --dry-run    # show selection, do nothing
+  python3 quasi-agent/rotate.py --level 2    # fix capability level
 """,
     )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--generate", action="store_true", default=True,
+                      help="Generate the next Pauli-Test issue (default).")
+    mode.add_argument("--solve", action="store_true",
+                      help="Solve the next open Pauli-Test issue.")
     parser.add_argument("--dry-run", action="store_true",
-                        help="Show the chosen model/level and generator output without creating a real issue")
+                        help="Show selection, do not create issues or PRs.")
     parser.add_argument("--level", type=int, choices=list(LEVEL_NAMES.keys()),
-                        help="Fix the capability level (0-4). Default: auto-select across all levels.")
+                        help="Fix capability level for --generate (0-4).")
     args = parser.parse_args()
 
     token = os.environ.get("GITHUB_TOKEN")
     if not token:
-        log("ERROR: GITHUB_TOKEN not set — cannot read issue counts from GitHub.")
+        log("ERROR: GITHUB_TOKEN not set.")
         sys.exit(1)
 
-    log("rotate.py starting — counting existing issues per model/level")
-    try:
-        counts = count_issues_per_model_level(token)
-    except Exception as exc:
-        log(f"ERROR counting issues: {exc}")
-        sys.exit(1)
+    state = load_state()
 
-    # Print summary of current counts
-    eligible = eligible_rotation()
-    log(f"Eligible models in rotation: {len(eligible)}/{len(ROTATION)}")
-    for entry in eligible:
-        mid = entry["id"]
-        level_counts = counts.get(mid, {})
-        totals = " ".join(f"L{lv}:{level_counts.get(lv, 0)}" for lv in LEVEL_NAMES)
-        log(f"  {mid:20s} {totals}")
+    if args.solve:
+        # ── Solve mode ──────────────────────────────────────────────────────
+        log("rotate.py --solve: fetching open Pauli-Test issues")
+        try:
+            open_issues = fetch_open_issues(token)
+        except Exception as exc:
+            log(f"ERROR fetching open issues: {exc}")
+            sys.exit(1)
 
-    # Planck quota check — h ≈ 6.626: stop when all models reach 6 issues/level
-    if planck_quota_met(counts, fixed_level=args.level):
-        eligible = eligible_rotation()
-        total = len(eligible) * len(LEVEL_NAMES) * PLANCK_QUOTA
-        log(
-            f"Planck quota met — all {len(eligible)} models have ≥{PLANCK_QUOTA} issues "
-            f"at every level ({total} total). Rotation complete. Timer will keep firing "
-            f"but do nothing until quota is raised or models are added."
-        )
-        return
+        log(f"Found {len(open_issues)} open Pauli-Test issues")
+        if not open_issues:
+            log("No open issues to solve — nothing to do.")
+            return
 
-    model_id, level = pick_next(counts, fixed_level=args.level)
-    log(f"Selected: model={model_id} level=L{level} (quota={PLANCK_QUOTA}, h≈6.626)")
+        last_issue = state.get("last_solve_issue")
+        issue = pick_solve_issue(open_issues, last_issue)
+        if issue is None:
+            log("No suitable issue found.")
+            return
 
-    rc = run_generator(model_id, level, dry_run=args.dry_run)
-    if rc == 0:
-        log(f"generate_issue.py exited OK for {model_id} L{level}")
+        last_provider = state.get("last_solve_provider")
+        try:
+            counts = count_issues_per_model_level(token)
+        except Exception as exc:
+            log(f"ERROR counting issues: {exc}")
+            counts = {}
+
+        model_id, _ = pick_next(counts, last_provider=last_provider)
+        provider = next(e["provider"] for e in ROTATION if e["id"] == model_id)
+        log(f"Selected solver: model={model_id} ({provider}) for issue #{issue['number']}: {issue['title'][:60]}")
+
+        if not args.dry_run:
+            rc = run_solver(model_id, issue["number"])
+            if rc == 0:
+                log(f"solve.py exited OK — #{issue['number']} by {model_id}")
+                state["last_solve_provider"] = provider
+                state["last_solve_issue"] = issue["number"]
+                save_state(state)
+            else:
+                log(f"solve.py exited with code {rc}")
+                sys.exit(rc)
+        else:
+            log(f"Dry run — would solve #{issue['number']} with {model_id}")
+
     else:
-        log(f"generate_issue.py exited with code {rc} for {model_id} L{level}")
-        sys.exit(rc)
+        # ── Generate mode ────────────────────────────────────────────────────
+        log("rotate.py --generate: counting existing issues per model/level")
+        try:
+            counts = count_issues_per_model_level(token)
+        except Exception as exc:
+            log(f"ERROR counting issues: {exc}")
+            sys.exit(1)
+
+        eligible = eligible_rotation()
+        log(f"Eligible models in rotation: {len(eligible)}/{len(ROTATION)}")
+        for entry in eligible:
+            mid = entry["id"]
+            level_counts = counts.get(mid, {})
+            totals = " ".join(f"L{lv}:{level_counts.get(lv, 0)}" for lv in LEVEL_NAMES)
+            log(f"  {mid:20s} {totals}")
+
+        if planck_quota_met(counts, fixed_level=args.level):
+            total = len(eligible) * len(LEVEL_NAMES) * PLANCK_QUOTA
+            log(
+                f"Planck quota met — all {len(eligible)} models have ≥{PLANCK_QUOTA} issues "
+                f"at every level ({total} total). Rotation complete."
+            )
+            return
+
+        last_provider = state.get("last_generate_provider")
+        model_id, level = pick_next(counts, fixed_level=args.level, last_provider=last_provider)
+        provider = next(e["provider"] for e in ROTATION if e["id"] == model_id)
+        log(f"Selected: model={model_id} ({provider}) level=L{level} (quota={PLANCK_QUOTA})")
+
+        rc = run_generator(model_id, level, dry_run=args.dry_run)
+        if rc == 0:
+            log(f"generate_issue.py exited OK for {model_id} L{level}")
+            if not args.dry_run:
+                state["last_generate_provider"] = provider
+                save_state(state)
+        else:
+            log(f"generate_issue.py exited with code {rc} for {model_id} L{level}")
+            sys.exit(rc)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

**Replaces #319** (had rebase conflicts — clean branch from main).

### Fireworks AI provider
- `api.fireworks.ai/inference/v1` — pay-per-token, fast, OpenAI-compatible
- Env var: `FIREWORKS_API_KEY`
- New models: **cogito-671b** (Deep Cogito, MIT, 671B MoE, US) and **minimax-m2** (MiniMax M2.1, Modified MIT, 230B/10B active MoE, China/Shanghai)
- Roster is now **33 models** across 5 providers

### Solve rotation (`--solve` mode)
`rotate.py --solve` picks the oldest open Pauli-Test GitHub issue and calls `solve.py` with a rotation-selected model. The quasi-solve.timer (2h cadence) runs this on Camelot alongside the existing generate timer (1h).

### Provider alternation
`pick_next()` now records `last_provider` in a state file and applies a sort-key penalty to same-provider models on the next fire. Consecutive timer fires spread load across OpenRouter → HuggingFace → Groq → Fireworks instead of hammering one provider.

State persists in `/home/vops/quasi-rotate-state.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)