### PR TITLE
fix(generate_issue): add User-Agent header for Groq provider

### DIFF
--- a/quasi-agent/generate_issue.py
+++ b/quasi-agent/generate_issue.py
@@ -91,7 +91,8 @@ PROVIDERS: dict[str, dict] = {
     "groq": {
         "url": "https://api.groq.com/openai/v1/chat/completions",
         "env": "GROQ_API_KEY",
-        "headers": {},
+        # User-Agent required — Groq's Cloudflare layer blocks Python's default urllib UA.
+        "headers": {"User-Agent": "quasi-agent/1.0 (https://quasi.arvak.io)"},
         "verify_header": None,
     },
     # Fireworks AI — fast inference, pay-per-token, OpenAI-compatible


### PR DESCRIPTION
## Summary

- Groq's Cloudflare layer returns `403 error code: 1010` when Python's default `urllib` User-Agent is used
- Direct `curl` from Camelot works fine; the block is UA-specific
- Adds `User-Agent: quasi-agent/1.0 (https://quasi.arvak.io)` to Groq's headers, identical to the fix already applied to the HuggingFace provider

## Test plan
- [ ] Trigger `quasi-rotate.service` on Camelot and confirm `llama4-scout` (Groq) generates an issue successfully
- [ ] Check `/home/vops/quasi-rotate.log` for no 403 errors on Groq calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)