### PR TITLE
fix(generate_issue): focus on MVP, add dedup, remove CI/docs noise

### DIFF
--- a/quasi-agent/generate_issue.py
+++ b/quasi-agent/generate_issue.py
@@ -261,7 +261,8 @@ def find_rotation_entry(model_arg: str) -> dict:
 
 
 LEVEL_NAMES = {
-    0: "L0 — Interfaces & Contracts (HAL Contract bindings, ActivityPub API endpoints, CLI UX, quasi-board task lifecycle)",
+    0: "L0 — Interfaces & Contracts (HAL Contract bindings, ActivityPub API endpoints,"
+       " CLI UX, quasi-board task lifecycle)",
     1: "L1 — Language Foundations (Ehrenfest syntax, parser, AST, type system, CBOR schema)",
     2: "L2 — Compiler / Afana (ZX-IR generation, rewriting rules, QASM3 output, optimisation passes)",
     3: "L3 — Hardware Backends (IBM/IQM adapters, HAL Contract execution, error mitigation, shot noise)",
@@ -350,7 +351,8 @@ def open_github_issue_titles(n: int = 40) -> str:
     }
     if token:
         headers["Authorization"] = f"Bearer {token}"
-    url = f"https://api.github.com/repos/ehrenfest-quantum/quasi/issues?state=open&per_page={n}&sort=created&direction=desc"
+    url = (f"https://api.github.com/repos/ehrenfest-quantum/quasi/issues"
+           f"?state=open&per_page={n}&sort=created&direction=desc")
     try:
         req = urllib.request.Request(url, headers=headers)
         with urllib.request.urlopen(req, timeout=10) as resp:


### PR DESCRIPTION
## Summary

The rotation had been generating ~90% CI workflow and CONTRIBUTING.md issues —
noise that doesn't advance the MVP goal of a working quantum OS.

### Root causes fixed

1. **L0 was "Scaffolding/CI/docs"** — models correctly identified missing CI workflows and kept proposing them even after CI was complete. L0 now means "Interfaces & Contracts" (HAL Contract, ActivityPub endpoints, CLI UX).

2. **No deduplication** — `open_issues_summary()` only showed 10 quasi-board items. Models had no visibility into 80+ already-open GitHub issues, so they kept proposing the same things. Now injects last 40 GitHub issue titles via `open_github_issue_titles()`.

3. **No MVP anchor** — prompt said "identify what's needed" with no end-goal. Added explicit MVP statement: Ehrenfest → Afana → hardware execution.

4. **`infrastructure` and `docs` in label taxonomy** — removed both. Added `core`. A model that can only pick from `compiler · specification · core · agent-ux · good-first-issue` is forced toward substantive work.

5. **No negative examples** — added explicit "DO NOT propose" block: CI workflows, GitHub Actions, README/CONTRIBUTING, docstrings, badges.

## Test plan
- [ ] Dry-run with `--dry-run --level 0` produces an interfaces/contracts issue, not a CI issue
- [ ] Dry-run with `--dry-run --level 1` produces a language/compiler issue
- [ ] No label validation warnings for `infrastructure` or `docs`
- [ ] Context size reasonable (was ~4k, now ~8k with GitHub titles injected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)