### PR TITLE
feat(afana): Ehrenfest .ef text parser — stdlib-only, typed AST (#321)

### DIFF
--- a/afana/__init__.py
+++ b/afana/__init__.py
@@ -4,6 +4,7 @@ from .backend_selector import BackendCapabilities, NoiseRequirements, select_bac
 from .circuit import Circuit, Operation
 from .compile import compile_for_backend, compile_qasm
 from .optimize import optimize_qasm, optimize_qasm_with_stats
+from .parser import ConditionalGate, EhrenfestAST, Gate, Measure, Expect, ParseError, parse, parse_file
 from .phase_kickback import phase_kickback
 
 __all__ = [
@@ -17,5 +18,13 @@ __all__ = [
     "compile_for_backend",
     "optimize_qasm",
     "optimize_qasm_with_stats",
+    "ConditionalGate",
+    "EhrenfestAST",
+    "Gate",
+    "Measure",
+    "Expect",
+    "ParseError",
+    "parse",
+    "parse_file",
     "phase_kickback",
 ]

--- a/afana/parser.py
+++ b/afana/parser.py
@@ -1,0 +1,301 @@
+"""Ehrenfest (.ef) text parser — converts .ef source to an AST.
+
+Grammar summary (v0.1):
+  program  ::= header stmt*
+  header   ::= 'program' STRING 'qubits' INT ('prepare' 'basis' STATE)?
+  stmt     ::= gate_stmt | measure_stmt | expect_stmt | comment
+  gate_stmt    ::= GATE qubit_list
+  measure_stmt ::= 'measure' QUBIT '->' CBIT
+  expect_stmt  ::= 'expect' ('state' | 'counts') STRING
+  comment  ::= '//' REST_OF_LINE
+
+Supported gates (case-insensitive): h, x, y, z, s, t, sdg, tdg,
+  cx / cnot, cz, swap, ccx / toffoli, rx, ry, rz.
+
+No external dependencies — stdlib only.
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+
+# ── AST nodes ─────────────────────────────────────────────────────────────────
+
+@dataclass
+class Gate:
+    """A single gate application, e.g. ``h q0`` or ``cnot q0 q1``."""
+    name: str          # lower-cased gate name, e.g. "h", "cnot", "rx"
+    qubits: List[int]  # qubit indices, e.g. [0] or [0, 1]
+    params: List[float] = field(default_factory=list)  # rotation angles
+
+
+@dataclass
+class Measure:
+    """A measurement directive: ``measure qN -> cN``."""
+    qubit: int
+    cbit: int
+
+
+@dataclass
+class ConditionalGate:
+    """A classically-conditioned gate: ``if cN == M: gate qN``."""
+    cbit: int
+    cbit_value: int
+    gate: "Gate"
+
+
+@dataclass
+class Expect:
+    """An assertion hint (non-executable): ``expect state "..."``."""
+    kind: str   # "state", "counts", or "relation"
+    value: str  # raw string, e.g. "(|00> + |11>) / sqrt(2)"
+
+
+@dataclass
+class EhrenfestAST:
+    """Root AST node for a parsed .ef program."""
+    name: str
+    n_qubits: int
+    prepare: Optional[str]        # basis state string, e.g. "|00>"
+    gates: List[Gate]
+    measures: List[Measure]
+    conditionals: List[ConditionalGate]
+    expects: List[Expect]
+
+
+# ── Tokenisation helpers ───────────────────────────────────────────────────────
+
+_GATE_RE = re.compile(
+    r"^(h|x|y|z|s|t|sdg|tdg|cx|cnot|cz|swap|ccx|toffoli|rx|ry|rz)$",
+    re.IGNORECASE,
+)
+_QUBIT_RE = re.compile(r"^q(\d+)$", re.IGNORECASE)
+_CBIT_RE = re.compile(r"^c(\d+)$", re.IGNORECASE)
+_FLOAT_RE = re.compile(r"^-?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?(pi)?$", re.IGNORECASE)
+
+
+def _parse_qubit(token: str, lineno: int) -> int:
+    m = _QUBIT_RE.match(token)
+    if not m:
+        raise ParseError(f"line {lineno}: expected qubit (e.g. q0), got {token!r}")
+    return int(m.group(1))
+
+
+def _parse_cbit(token: str, lineno: int) -> int:
+    m = _CBIT_RE.match(token)
+    if not m:
+        raise ParseError(f"line {lineno}: expected cbit (e.g. c0), got {token!r}")
+    return int(m.group(1))
+
+
+def _parse_float_param(token: str, lineno: int) -> float:
+    import math
+    t = token.lower()
+    if t.endswith("pi"):
+        prefix = t[:-2]
+        factor = float(prefix) if prefix and prefix not in ("", "-", "+") else (
+            -math.pi if prefix == "-" else math.pi
+        )
+        return factor * math.pi if prefix not in ("", "-", "+") else factor
+    try:
+        return float(token)
+    except ValueError:
+        raise ParseError(f"line {lineno}: invalid float parameter {token!r}")
+
+
+def _strip_comment(line: str) -> str:
+    """Remove inline // comment and return stripped content."""
+    idx = line.find("//")
+    return line[:idx].strip() if idx != -1 else line.strip()
+
+
+# ── Parser ─────────────────────────────────────────────────────────────────────
+
+class ParseError(ValueError):
+    """Raised when .ef source cannot be parsed."""
+
+
+def parse(source: str) -> EhrenfestAST:
+    """Parse *source* (contents of a .ef file) into an :class:`EhrenfestAST`.
+
+    Raises :class:`ParseError` on any syntax error.
+    """
+    lines = source.splitlines()
+    tokens_by_line: List[Tuple[int, List[str]]] = []
+    for lineno, raw in enumerate(lines, start=1):
+        clean = _strip_comment(raw)
+        if not clean:
+            continue
+        # Use shlex to handle quoted strings correctly
+        try:
+            toks = shlex.split(clean)
+        except ValueError as exc:
+            raise ParseError(f"line {lineno}: {exc}") from exc
+        if toks:
+            tokens_by_line.append((lineno, toks))
+
+    it = iter(tokens_by_line)
+
+    def _next_line(expect_what: str) -> Tuple[int, List[str]]:
+        try:
+            return next(it)
+        except StopIteration:
+            raise ParseError(f"unexpected end of file while expecting {expect_what}")
+
+    # ── Header ────────────────────────────────────────────────────────────────
+
+    lineno, toks = _next_line("'program' declaration")
+    if toks[0].lower() != "program":
+        raise ParseError(f"line {lineno}: expected 'program', got {toks[0]!r}")
+    if len(toks) < 2:
+        raise ParseError(f"line {lineno}: 'program' requires a name")
+    program_name = toks[1]
+
+    lineno, toks = _next_line("'qubits' declaration")
+    if toks[0].lower() != "qubits":
+        raise ParseError(f"line {lineno}: expected 'qubits', got {toks[0]!r}")
+    if len(toks) < 2 or not toks[1].isdigit():
+        raise ParseError(f"line {lineno}: 'qubits' requires a positive integer")
+    n_qubits = int(toks[1])
+    if n_qubits < 1:
+        raise ParseError(f"line {lineno}: qubit count must be ≥ 1, got {n_qubits}")
+
+    # ── Body ──────────────────────────────────────────────────────────────────
+
+    prepare: Optional[str] = None
+    gates: List[Gate] = []
+    measures: List[Measure] = []
+    conditionals: List[ConditionalGate] = []
+    expects: List[Expect] = []
+
+    for lineno, toks in it:
+        kw = toks[0].lower()
+
+        if kw == "prepare":
+            # prepare basis |00>
+            if len(toks) < 3 or toks[1].lower() != "basis":
+                raise ParseError(f"line {lineno}: 'prepare' syntax: prepare basis |STATE>")
+            prepare = toks[2]
+
+        elif kw == "measure":
+            # measure q0 -> c0
+            if len(toks) < 4 or toks[2] != "->":
+                raise ParseError(f"line {lineno}: 'measure' syntax: measure qN -> cN")
+            qubit = _parse_qubit(toks[1], lineno)
+            cbit = _parse_cbit(toks[3], lineno)
+            if qubit >= n_qubits:
+                raise ParseError(
+                    f"line {lineno}: qubit q{qubit} out of range (n_qubits={n_qubits})"
+                )
+            measures.append(Measure(qubit=qubit, cbit=cbit))
+
+        elif kw == "expect":
+            # expect state|counts|relation "..."
+            if len(toks) < 3:
+                raise ParseError(
+                    f"line {lineno}: 'expect' syntax: expect state|counts|relation \"...\""
+                )
+            kind = toks[1].lower()
+            if kind not in ("state", "counts", "relation"):
+                raise ParseError(
+                    f"line {lineno}: 'expect' kind must be 'state', 'counts', or 'relation',"
+                    f" got {toks[1]!r}"
+                )
+            expects.append(Expect(kind=kind, value=toks[2]))
+
+        elif kw == "if":
+            # if cN == M: gate qN ...
+            # Tokens after stripping inline comment and shlex split:
+            #   ["if", "c1", "==", "1:", "x", "q2"]   (colon attached to value)
+            #   or ["if", "c1", "==", "1", "x", "q2"] (colon stripped by comment remover)
+            if len(toks) < 5:
+                raise ParseError(
+                    f"line {lineno}: 'if' syntax: if cN == M: gate qN"
+                )
+            cbit = _parse_cbit(toks[1], lineno)
+            if toks[2] != "==":
+                raise ParseError(
+                    f"line {lineno}: 'if' expects '==', got {toks[2]!r}"
+                )
+            # Strip trailing colon from the value token if present
+            val_tok = toks[3].rstrip(":")
+            if not val_tok.isdigit():
+                raise ParseError(
+                    f"line {lineno}: 'if' condition value must be an integer, got {toks[3]!r}"
+                )
+            cbit_value = int(val_tok)
+            # The rest is the gate
+            gate_toks = toks[4:]
+            if not gate_toks or not _GATE_RE.match(gate_toks[0]):
+                raise ParseError(
+                    f"line {lineno}: 'if' body must be a gate, got {gate_toks}"
+                )
+            g_name = gate_toks[0].lower()
+            if g_name == "cnot":
+                g_name = "cx"
+            if g_name == "toffoli":
+                g_name = "ccx"
+            g_qubits = [_parse_qubit(qt, lineno) for qt in gate_toks[1:]]
+            if not g_qubits:
+                raise ParseError(
+                    f"line {lineno}: gate in 'if' body requires at least one qubit"
+                )
+            cond_gate = Gate(name=g_name, qubits=g_qubits)
+            conditionals.append(ConditionalGate(cbit=cbit, cbit_value=cbit_value, gate=cond_gate))
+
+        elif _GATE_RE.match(kw):
+            gate_name = kw
+            # Normalise aliases
+            if gate_name == "cnot":
+                gate_name = "cx"
+            if gate_name == "toffoli":
+                gate_name = "ccx"
+
+            # Collect optional float params (for rx/ry/rz), then qubits
+            params: List[float] = []
+            qubit_tokens: List[str] = toks[1:]
+
+            # Rotation gates carry one float param before qubits
+            if gate_name in ("rx", "ry", "rz"):
+                if not qubit_tokens:
+                    raise ParseError(f"line {lineno}: {gate_name} requires an angle parameter")
+                params.append(_parse_float_param(qubit_tokens[0], lineno))
+                qubit_tokens = qubit_tokens[1:]
+
+            qubit_indices: List[int] = []
+            for qt in qubit_tokens:
+                idx = _parse_qubit(qt, lineno)
+                if idx >= n_qubits:
+                    raise ParseError(
+                        f"line {lineno}: qubit q{idx} out of range (n_qubits={n_qubits})"
+                    )
+                qubit_indices.append(idx)
+
+            if not qubit_indices:
+                raise ParseError(f"line {lineno}: gate {toks[0]!r} requires at least one qubit")
+
+            gates.append(Gate(name=gate_name, qubits=qubit_indices, params=params))
+
+        else:
+            raise ParseError(f"line {lineno}: unknown directive {toks[0]!r}")
+
+    return EhrenfestAST(
+        name=program_name,
+        n_qubits=n_qubits,
+        prepare=prepare,
+        gates=gates,
+        measures=measures,
+        conditionals=conditionals,
+        expects=expects,
+    )
+
+
+def parse_file(path: str | Path) -> EhrenfestAST:
+    """Read *path* and parse its contents."""
+    source = Path(path).read_text(encoding="utf-8")
+    return parse(source)

--- a/afana/tests/test_parser.py
+++ b/afana/tests/test_parser.py
@@ -1,0 +1,243 @@
+"""Tests for afana.parser — Ehrenfest .ef text parser."""
+
+import pytest
+from afana.parser import (
+    EhrenfestAST, Gate, Measure, Expect,
+    ParseError, parse, parse_file,
+)
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _src(*lines: str) -> str:
+    return "\n".join(lines)
+
+
+# ── Basic structure ───────────────────────────────────────────────────────────
+
+def test_parse_minimal():
+    src = _src('program "minimal"', "qubits 1")
+    ast = parse(src)
+    assert ast.name == "minimal"
+    assert ast.n_qubits == 1
+    assert ast.prepare is None
+    assert ast.gates == []
+    assert ast.measures == []
+    assert ast.expects == []
+
+
+def test_parse_bell():
+    """Acceptance criterion: parse examples/bell.ef into a valid AST."""
+    src = _src(
+        '// Bell state',
+        'program "bell"',
+        "qubits 2",
+        "prepare basis |00>",
+        "h q0",
+        "cnot q0 q1",
+        "measure q0 -> c0",
+        "measure q1 -> c1",
+        'expect state "(|00> + |11>) / sqrt(2)"',
+        'expect counts "00,11"',
+    )
+    ast = parse(src)
+    assert isinstance(ast, EhrenfestAST)
+    assert ast.name == "bell"
+    assert ast.n_qubits == 2
+    assert ast.prepare == "|00>"
+    assert ast.gates == [
+        Gate(name="h", qubits=[0]),
+        Gate(name="cx", qubits=[0, 1]),  # cnot normalised to cx
+    ]
+    assert ast.measures == [Measure(qubit=0, cbit=0), Measure(qubit=1, cbit=1)]
+    assert ast.expects == [
+        Expect(kind="state", value="(|00> + |11>) / sqrt(2)"),
+        Expect(kind="counts", value="00,11"),
+    ]
+
+
+def test_parse_ghz():
+    src = _src(
+        'program "ghz"',
+        "qubits 3",
+        "prepare basis |000>",
+        "h q0",
+        "cnot q0 q1",
+        "cnot q0 q2",
+        "measure q0 -> c0",
+        "measure q1 -> c1",
+        "measure q2 -> c2",
+    )
+    ast = parse(src)
+    assert ast.n_qubits == 3
+    assert len(ast.gates) == 3
+    assert ast.gates[0] == Gate(name="h", qubits=[0])
+    assert ast.gates[1] == Gate(name="cx", qubits=[0, 1])
+    assert ast.gates[2] == Gate(name="cx", qubits=[0, 2])
+    assert len(ast.measures) == 3
+
+
+# ── Gate coverage ─────────────────────────────────────────────────────────────
+
+def test_single_qubit_gates():
+    src = _src('program "p"', "qubits 2", "x q0", "y q1", "z q0", "s q1", "t q0")
+    ast = parse(src)
+    names = [g.name for g in ast.gates]
+    assert names == ["x", "y", "z", "s", "t"]
+
+
+def test_two_qubit_gates():
+    src = _src('program "p"', "qubits 2", "cx q0 q1", "cz q0 q1", "swap q0 q1")
+    ast = parse(src)
+    assert [g.name for g in ast.gates] == ["cx", "cz", "swap"]
+
+
+def test_toffoli_alias():
+    src = _src('program "p"', "qubits 3", "ccx q0 q1 q2", "toffoli q2 q1 q0")
+    ast = parse(src)
+    assert all(g.name == "ccx" for g in ast.gates)
+    assert ast.gates[0].qubits == [0, 1, 2]
+    assert ast.gates[1].qubits == [2, 1, 0]
+
+
+def test_rotation_gate_parses_angle():
+    src = _src('program "p"', "qubits 1", "rx 1.5708 q0")
+    ast = parse(src)
+    assert ast.gates[0].name == "rx"
+    assert abs(ast.gates[0].params[0] - 1.5708) < 1e-9
+    assert ast.gates[0].qubits == [0]
+
+
+def test_sdg_tdg_gates():
+    src = _src('program "p"', "qubits 1", "sdg q0", "tdg q0")
+    ast = parse(src)
+    assert [g.name for g in ast.gates] == ["sdg", "tdg"]
+
+
+# ── Comments ──────────────────────────────────────────────────────────────────
+
+def test_inline_comments_stripped():
+    src = _src(
+        'program "p"  // the name',
+        "qubits 2     // two qubits",
+        "h q0         // Hadamard",
+    )
+    ast = parse(src)
+    assert ast.name == "p"
+    assert ast.n_qubits == 2
+    assert ast.gates == [Gate(name="h", qubits=[0])]
+
+
+def test_full_line_comment_ignored():
+    src = _src(
+        "// This is a comment",
+        'program "p"',
+        "// Another comment",
+        "qubits 1",
+    )
+    ast = parse(src)
+    assert ast.name == "p"
+
+
+# ── Error cases ───────────────────────────────────────────────────────────────
+
+def test_missing_program_header():
+    with pytest.raises(ParseError, match="expected 'program'"):
+        parse("qubits 2")
+
+
+def test_missing_qubits():
+    with pytest.raises(ParseError, match="qubits"):
+        parse('program "p"')
+
+
+def test_zero_qubits_rejected():
+    with pytest.raises(ParseError, match="qubit count must be"):
+        parse(_src('program "p"', "qubits 0"))
+
+
+def test_qubit_out_of_range():
+    with pytest.raises(ParseError, match="out of range"):
+        parse(_src('program "p"', "qubits 2", "h q5"))
+
+
+def test_measure_out_of_range():
+    with pytest.raises(ParseError, match="out of range"):
+        parse(_src('program "p"', "qubits 2", "measure q9 -> c0"))
+
+
+def test_invalid_directive():
+    with pytest.raises(ParseError, match="unknown directive"):
+        parse(_src('program "p"', "qubits 1", "foo q0"))
+
+
+def test_measure_missing_arrow():
+    with pytest.raises(ParseError, match="measure.*syntax"):
+        parse(_src('program "p"', "qubits 1", "measure q0 c0"))
+
+
+def test_gate_missing_qubit():
+    with pytest.raises(ParseError, match="requires at least one qubit"):
+        parse(_src('program "p"', "qubits 1", "h"))
+
+
+def test_expect_invalid_kind():
+    with pytest.raises(ParseError, match="kind must be"):
+        parse(_src('program "p"', "qubits 1", 'expect probability "0.5"'))
+
+
+def test_expect_relation():
+    src = _src(
+        'program "teleport"',
+        "qubits 3",
+        'expect relation "state(q2) == initial_state(q0)"',
+    )
+    ast = parse(src)
+    assert ast.expects[0].kind == "relation"
+
+
+def test_conditional_gate():
+    src = _src(
+        'program "teleport"',
+        "qubits 3",
+        "measure q0 -> c0",
+        "if c0 == 1: x q2",
+    )
+    ast = parse(src)
+    assert len(ast.conditionals) == 1
+    cg = ast.conditionals[0]
+    assert cg.cbit == 0
+    assert cg.cbit_value == 1
+    assert cg.gate.name == "x"
+    assert cg.gate.qubits == [2]
+
+
+def test_empty_source():
+    with pytest.raises(ParseError, match="unexpected end of file"):
+        parse("")
+
+
+# ── File loading ──────────────────────────────────────────────────────────────
+
+def test_parse_file_bell(tmp_path):
+    p = tmp_path / "bell.ef"
+    p.write_text(
+        'program "bell"\nqubits 2\nh q0\ncnot q0 q1\n',
+        encoding="utf-8",
+    )
+    ast = parse_file(p)
+    assert ast.name == "bell"
+    assert ast.n_qubits == 2
+    assert len(ast.gates) == 2
+
+
+def test_parse_file_examples(tmp_path):
+    """Parse all bundled .ef examples without error."""
+    import pathlib
+    examples_dir = pathlib.Path(__file__).parent.parent.parent / "examples"
+    ef_files = list(examples_dir.glob("*.ef"))
+    assert ef_files, "No .ef example files found"
+    for ef in ef_files:
+        ast = parse_file(ef)
+        assert ast.n_qubits >= 1
+        assert ast.name  # non-empty


### PR DESCRIPTION
Closes #321

## Summary
- New `afana/parser.py`: recursive-descent parser for Ehrenfest `.ef` source files, zero external dependencies (stdlib `shlex` only)
- Produces a typed AST: `EhrenfestAST`, `Gate`, `Measure`, `ConditionalGate`, `Expect`
- Handles the full grammar present in all four bundled examples (`bell`, `ghz`, `grover`, `teleport`): header, gates (including Rx/Ry/Rz with angles), measure, classical feed-forward (`if cN == M: gate qN`), `expect` assertions, `//` comments
- Qubit range validation; descriptive `ParseError` messages for all error cases
- Exported from `afana/__init__.py`

## Acceptance criteria (from issue)
- [x] Parser converts `examples/bell.ef` into a valid AST (`test_parse_bell`)
- [x] Parser rejects invalid syntax with appropriate error messages (7 error-path tests)

## Test plan
- [x] 24 unit tests in `afana/tests/test_parser.py` — all pass
- [x] `test_parse_file_examples` verifies all 4 bundled `.ef` files parse without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)