### PR TITLE
#129 Add comprehensive CLI help text and usage examples to quasi-agent

### DIFF
--- a/quasi-agent/cli.py
+++ b/quasi-agent/cli.py
@@ -959,16 +959,48 @@ compdef _quasi_agent cli.py''')
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="quasi-agent — QUASI task client")
+    formatter = argparse.RawDescriptionHelpFormatter
+    parser = argparse.ArgumentParser(
+        prog="quasi-agent",
+        description=(
+            "quasi-agent — QUASI task client\n\n"
+            "Claim tasks, refresh long-running work, and record completions on the ledger."
+        ),
+        formatter_class=formatter,
+        epilog=textwrap.dedent(
+            """\
+            Common workflows:
+              quasi-agent list
+              quasi-agent claim QUASI-001 --agent gpt-5-codex
+              quasi-agent refresh QUASI-001 --agent gpt-5-codex
+              quasi-agent complete QUASI-001 --commit abc123 --pr https://github.com/org/repo/pull/1
+              quasi-agent submit QUASI-001 --dir ./implementation
+
+            Use `quasi-agent <command> --help` for command-specific examples.
+            """
+        ),
+    )
     parser.add_argument("--board", default=DEFAULT_BOARD, help="quasi-board URL")
     parser.add_argument("--agent", default="quasi-agent/0.1", help="Agent identifier (model name)")
     sub = parser.add_subparsers(dest="cmd")
 
-    p_list = sub.add_parser("list", help="List open tasks")
+    p_list = sub.add_parser(
+        "list",
+        help="List open tasks",
+        description="List currently open tasks from the configured quasi-board.",
+        formatter_class=formatter,
+        epilog="Example:\n  quasi-agent list --json",
+    )
     p_list.add_argument("--json", dest="output_json", action="store_true",
                         help="Output as JSON (machine-readable, useful in CI pipelines)")
 
-    p_claim = sub.add_parser("claim", help="Claim a task")
+    p_claim = sub.add_parser(
+        "claim",
+        help="Claim a task",
+        description="Claim a task before starting implementation work.",
+        formatter_class=formatter,
+        epilog="Example:\n  quasi-agent --agent gpt-5-codex claim QUASI-001",
+    )
     p_claim.add_argument("task_id", help="e.g. QUASI-001")
     p_claim.add_argument(
         "--as", dest="as_str", metavar="'Name <handle>'",
@@ -976,7 +1008,16 @@ def main() -> None:
              "Permanently anchored in the quasi-ledger. Always optional.",
     )
 
-    p_complete = sub.add_parser("complete", help="Record task completion on ledger")
+    p_complete = sub.add_parser(
+        "complete",
+        help="Record task completion on ledger",
+        description="Write a completion entry to the quasi-ledger after your PR is ready.",
+        formatter_class=formatter,
+        epilog=(
+            "Example:\n"
+            "  quasi-agent complete QUASI-001 --commit abc123 --pr https://github.com/org/repo/pull/1"
+        ),
+    )
     p_complete.add_argument("task_id", help="e.g. QUASI-001")
     p_complete.add_argument("--commit", required=True, help="Git commit hash")
     p_complete.add_argument("--pr", required=True, help="PR URL")
@@ -985,25 +1026,64 @@ def main() -> None:
         help="Optional attribution. Permanently anchored in the quasi-ledger.",
     )
 
-    p_refresh = sub.add_parser("refresh", help="Refresh an active claim TTL (use during long implementations)")
+    p_refresh = sub.add_parser(
+        "refresh",
+        help="Refresh an active claim TTL (use during long implementations)",
+        description="Extend an active claim before it expires while work is in progress.",
+        formatter_class=formatter,
+        epilog="Example:\n  quasi-agent --agent gpt-5-codex refresh QUASI-001",
+    )
     p_refresh.add_argument("task_id", help="e.g. QUASI-001")
 
     p_submit = sub.add_parser(
         "submit",
         help="Submit implementation — board opens PR on your behalf (no GitHub account needed)",
+        description="Upload an implementation directory so the board can open a PR on your behalf.",
+        formatter_class=formatter,
+        epilog="Example:\n  quasi-agent submit QUASI-003 --dir ./solution",
     )
     p_submit.add_argument("task_id", help="e.g. QUASI-003")
     p_submit.add_argument("--dir", required=True, help="Directory containing your implementation")
 
-    p_watch = sub.add_parser("watch", help="Poll for new tasks and notify")
+    p_watch = sub.add_parser(
+        "watch",
+        help="Poll for new tasks and notify",
+        description="Poll the board for newly opened tasks and print claim hints.",
+        formatter_class=formatter,
+        epilog="Example:\n  quasi-agent watch --interval 120 --once",
+    )
     p_watch.add_argument("--interval", type=int, default=300, help="Poll interval in seconds (default: 300)")
     p_watch.add_argument("--once", action="store_true", help="Print current open tasks and exit")
 
-    sub.add_parser("ledger", help="Show the ledger")
-    sub.add_parser("contributors", help="List named contributors from the ledger")
-    sub.add_parser("verify", help="Verify ledger chain integrity")
+    sub.add_parser(
+        "ledger",
+        help="Show the ledger",
+        description="Print the current ledger chain as returned by the board.",
+        formatter_class=formatter,
+        epilog="Example:\n  quasi-agent ledger",
+    )
+    sub.add_parser(
+        "contributors",
+        help="List named contributors from the ledger",
+        description="Summarize attributed contributors found in the ledger.",
+        formatter_class=formatter,
+        epilog="Example:\n  quasi-agent contributors",
+    )
+    sub.add_parser(
+        "verify",
+        help="Verify ledger chain integrity",
+        description="Verify the local integrity of the ledger hash chain returned by the board.",
+        formatter_class=formatter,
+        epilog="Example:\n  quasi-agent verify",
+    )
 
-    p_completion = sub.add_parser("completion", help="Generate shell completion script")
+    p_completion = sub.add_parser(
+        "completion",
+        help="Generate shell completion script",
+        description="Emit a shell completion script for bash or zsh.",
+        formatter_class=formatter,
+        epilog="Example:\n  quasi-agent completion zsh",
+    )
     p_completion.add_argument("shell", choices=["bash", "zsh"], help="Shell type")
 
     argcomplete.autocomplete(parser)


### PR DESCRIPTION
## Summary
- expand top-level quasi-agent help with workflow examples
- add command-specific descriptions and example epilogs for every subcommand
- make quasi-agent help surface contextual usage guidance

## Testing
- smoke-checked help output, claim help, and submit help via a local argcomplete stub under Python 3.9

Closes #129