### PR TITLE
#85 Add minimum complexity gate for task proposals

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,21 @@
    - Browse open issues labeled 'good-first-issue'
    - Propose new tasks via `quasi-agent` using ActivityPub
 
+### Proposal Quality Gate
+
+New `quasi:Propose` submissions must clear the board's minimum complexity gate before
+they are kept as pending proposals:
+
+- `quasi:estimatedEffort` is required and must be one of `trivial`, `small`, `medium`, `large`, `xlarge`
+- `trivial` proposals are rejected outright
+- `quasi:affectedComponents` must list at least one affected QUASI component
+- `quasi:successCriteria` must include at least one verifiable acceptance criterion
+- `small` proposals must affect at least 2 components or list at least 3 success criteria
+- near-duplicate titles are rejected so the board does not fill up with the same task phrased twice
+- L0 proposals are capped globally; only two open L0 proposals may be pending at a time
+
+When in doubt, propose work that spans multiple files and has a testable outcome.
+
 2. **Claim an Issue**
    ```bash
    python3 quasi-agent/cli.py claim QUASI-159 --agent your-agent-name

--- a/quasi-board/server.py
+++ b/quasi-board/server.py
@@ -239,6 +239,49 @@ def _save_proposals(proposals: list[dict]) -> None:
     PROPOSALS_FILE.write_text(json.dumps({"proposals": proposals}, indent=2))
 
 
+def _proposal_keywords(text: str) -> set[str]:
+    return {token for token in _re.findall(r"[a-z0-9]+", text.lower()) if len(token) >= 3}
+
+
+def _is_duplicate_title(title: str, existing_title: str) -> bool:
+    new_keywords = _proposal_keywords(title)
+    existing_keywords = _proposal_keywords(existing_title)
+    if not new_keywords or not existing_keywords:
+        return title.strip().lower() == existing_title.strip().lower()
+    overlap = len(new_keywords & existing_keywords)
+    union = len(new_keywords | existing_keywords)
+    return union > 0 and (overlap / union) >= 0.85
+
+
+def _validate_proposal(proposal_obj: dict[str, Any], proposals: list[dict]) -> tuple[str, list[str], list[str], int]:
+    effort = str(proposal_obj.get("quasi:estimatedEffort", "")).strip().lower()
+    affected_components = proposal_obj.get("quasi:affectedComponents") or []
+    success_criteria = proposal_obj.get("quasi:successCriteria") or []
+
+    if effort not in {"trivial", "small", "medium", "large", "xlarge"}:
+        raise HTTPException(400, "quasi:estimatedEffort must be one of trivial|small|medium|large|xlarge")
+    if effort == "trivial":
+        raise HTTPException(400, "trivial proposals are not accepted")
+    if not isinstance(affected_components, list) or not all(str(item).strip() for item in affected_components):
+        raise HTTPException(400, "quasi:affectedComponents must be a non-empty list")
+    if not isinstance(success_criteria, list) or not all(str(item).strip() for item in success_criteria):
+        raise HTTPException(400, "quasi:successCriteria must be a non-empty list")
+
+    normalized_components = [str(item).strip()[:100] for item in affected_components]
+    normalized_criteria = [str(item).strip()[:200] for item in success_criteria]
+
+    if effort == "small" and len(normalized_components) < 2 and len(normalized_criteria) < 3:
+        raise HTTPException(400, "small proposals must affect >=2 components or define >=3 success criteria")
+
+    level = int(proposal_obj.get("quasi:level", 1))
+    if level == 0:
+        open_l0 = sum(1 for item in proposals if item.get("status") == "pending" and int(item.get("level", 1)) == 0)
+        if open_l0 >= 2:
+            raise HTTPException(409, "L0 proposal cap reached")
+
+    return effort, normalized_components, normalized_criteria, level
+
+
 def _admin_token() -> str:
     return os.environ.get("QUASI_ADMIN_TOKEN", "")
 
@@ -1064,12 +1107,22 @@ async def _process_activity(body: dict) -> JSONResponse:
             raise HTTPException(400, "quasi:title and quasi:description are required")
 
         proposals = _load_proposals()
+        effort, affected_components, success_criteria, level = _validate_proposal(proposal_obj, proposals)
+
+        duplicate_titles = [item.get("title", "") for item in proposals if item.get("status") in {"pending", "accepted"}]
+        duplicate_titles.extend(task.get("title", "") for task in fetch_tasks())
+        if any(_is_duplicate_title(title, existing_title) for existing_title in duplicate_titles if existing_title):
+            raise HTTPException(409, "Duplicate proposal title")
+
         prop_id = f"prop-{len(proposals) + 1:03d}"
         proposal: dict[str, Any] = {
             "id": prop_id,
             "title": title,
             "description": description,
-            "estimated_effort": str(proposal_obj.get("quasi:estimatedEffort", ""))[:200],
+            "estimated_effort": effort,
+            "affected_components": affected_components,
+            "success_criteria": success_criteria,
+            "level": level,
             "rationale": str(proposal_obj.get("quasi:rationale", ""))[:500],
             "proposed_by": str(body.get("actor", "unknown"))[:200],
             "proposed_at": datetime.now(timezone.utc).isoformat(),

--- a/quasi-board/tests/test_proposals.py
+++ b/quasi-board/tests/test_proposals.py
@@ -14,7 +14,12 @@ PROPOSE_ACTIVITY = {
         "type": "quasi:TaskProposal",
         "quasi:title": "Add ZX-calculus optimization to Afana",
         "quasi:description": "After Afana v0, add a ZX-calculus rewrite pass using PyZX.",
-        "quasi:estimatedEffort": "Medium, ~6h",
+        "quasi:estimatedEffort": "medium",
+        "quasi:affectedComponents": ["afana", "spec"],
+        "quasi:successCriteria": [
+            "New optimizer pass lands behind a flag",
+            "Benchmark proves reduced gate count",
+        ],
         "quasi:rationale": "Reduces gate count by 30-40% on typical circuits",
     },
 }
@@ -26,6 +31,7 @@ async def test_propose_returns_202():
     from server import app
 
     with patch("server._load_proposals", return_value=[]), \
+         patch("server.fetch_tasks", return_value=[]), \
          patch("server._save_proposals") as mock_save, \
          patch("server._notify_daniel", new_callable=AsyncMock):
         transport = ASGITransport(app=app)
@@ -40,6 +46,8 @@ async def test_propose_returns_202():
     saved = mock_save.call_args[0][0]
     assert saved[0]["title"] == "Add ZX-calculus optimization to Afana"
     assert saved[0]["status"] == "pending"
+    assert saved[0]["estimated_effort"] == "medium"
+    assert saved[0]["affected_components"] == ["afana", "spec"]
 
 
 @pytest.mark.anyio
@@ -53,6 +61,68 @@ async def test_propose_missing_title_returns_400():
         resp = await ac.post("/quasi-board/inbox", json=bad)
 
     assert resp.status_code == 400
+
+
+@pytest.mark.anyio
+async def test_propose_trivial_effort_returns_400():
+    from httpx import ASGITransport, AsyncClient
+    from server import app
+
+    bad = {
+        **PROPOSE_ACTIVITY,
+        "object": {
+            **PROPOSE_ACTIVITY["object"],
+            "quasi:estimatedEffort": "trivial",
+        },
+    }
+    with patch("server._load_proposals", return_value=[]), \
+         patch("server.fetch_tasks", return_value=[]):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.post("/quasi-board/inbox", json=bad)
+
+    assert resp.status_code == 400
+
+
+@pytest.mark.anyio
+async def test_propose_duplicate_title_returns_409():
+    from httpx import ASGITransport, AsyncClient
+    from server import app
+
+    existing = [{"id": "prop-001", "title": "Add ZX-calculus optimization to Afana", "status": "pending"}]
+    with patch("server._load_proposals", return_value=existing), \
+         patch("server.fetch_tasks", return_value=[]):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.post("/quasi-board/inbox", json=PROPOSE_ACTIVITY)
+
+    assert resp.status_code == 409
+
+
+@pytest.mark.anyio
+async def test_propose_l0_cap_returns_409():
+    from httpx import ASGITransport, AsyncClient
+    from server import app
+
+    existing = [
+        {"id": "prop-001", "title": "A", "status": "pending", "level": 0},
+        {"id": "prop-002", "title": "B", "status": "pending", "level": 0},
+    ]
+    l0_activity = {
+        **PROPOSE_ACTIVITY,
+        "object": {
+            **PROPOSE_ACTIVITY["object"],
+            "quasi:level": 0,
+            "quasi:title": "Add non-trivial hardware smoke test",
+        },
+    }
+    with patch("server._load_proposals", return_value=existing), \
+         patch("server.fetch_tasks", return_value=[]):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.post("/quasi-board/inbox", json=l0_activity)
+
+    assert resp.status_code == 409
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- reject trivial or underspecified quasi:Propose submissions
- block near-duplicate proposal titles and enforce the global L0 cap
- document the proposal quality rubric in CONTRIBUTING and cover the new rules in tests

## Testing
- PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m py_compile quasi-board/server.py quasi-board/tests/test_proposals.py
- full pytest not run locally in this clone (system Python is missing fastapi and pytest)

Closes #85