### PR TITLE
#329 Implement error mitigation wrapper for IBM backend executions

### DIFF
--- a/afana/backends/__init__.py
+++ b/afana/backends/__init__.py
@@ -1,5 +1,6 @@
 """Backend-specific Afana compilation paths."""
 
+from .error_mitigation import mitigate_ibm_execution
 from .ibm import ehrenfest_to_ibm, transpile_for_ibm
 
-__all__ = ["ehrenfest_to_ibm", "transpile_for_ibm"]
+__all__ = ["ehrenfest_to_ibm", "mitigate_ibm_execution", "transpile_for_ibm"]

--- a/afana/backends/error_mitigation.py
+++ b/afana/backends/error_mitigation.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from typing import Callable
+
+
+def _normalize_distribution(distribution: dict[str, float]) -> dict[str, float]:
+    total = float(sum(distribution.values()))
+    if total <= 0:
+        raise ValueError("distribution must have positive weight")
+    return {bitstring: value / total for bitstring, value in distribution.items()}
+
+
+def _counts_to_probabilities(counts: dict[str, int]) -> dict[str, float]:
+    if not counts:
+        raise ValueError("counts must not be empty")
+    return _normalize_distribution({bitstring: float(value) for bitstring, value in counts.items()})
+
+
+def fidelity(counts: dict[str, int], ideal_distribution: dict[str, float]) -> float:
+    """Return the Bhattacharyya fidelity between observed counts and ideal probabilities."""
+    observed = _counts_to_probabilities(counts)
+    ideal = _normalize_distribution(ideal_distribution)
+    outcomes = set(observed) | set(ideal)
+    return sum((observed.get(key, 0.0) * ideal.get(key, 0.0)) ** 0.5 for key in outcomes) ** 2
+
+
+def mitigate_measurement_error(counts: dict[str, int], confusion_rate: float = 0.1) -> dict[str, int]:
+    """Invert a symmetric confusion model to recover a cleaner counts estimate."""
+    if not 0.0 <= confusion_rate < 1.0:
+        raise ValueError("confusion_rate must be in [0, 1)")
+
+    probabilities = _counts_to_probabilities(counts)
+    keys = sorted(probabilities)
+    n_states = len(keys)
+    if n_states == 1 or confusion_rate == 0.0:
+        return dict(counts)
+
+    off_diagonal = confusion_rate / (n_states - 1)
+    diagonal = 1.0 - confusion_rate
+    gap = diagonal - off_diagonal
+    if gap <= 0:
+        raise ValueError("confusion_rate is too large for the observed state space")
+
+    alpha = 1.0 / gap
+    beta = -off_diagonal / (gap * (diagonal + (n_states - 1) * off_diagonal))
+    total_prob = sum(probabilities.values())
+
+    corrected_probs = {
+        key: max(0.0, alpha * probabilities[key] + beta * total_prob)
+        for key in keys
+    }
+    corrected_probs = _normalize_distribution(corrected_probs)
+
+    shots = sum(counts.values())
+    corrected_counts = {
+        key: int(round(corrected_probs[key] * shots))
+        for key in keys
+    }
+    delta = shots - sum(corrected_counts.values())
+    corrected_counts[keys[0]] += delta
+    return corrected_counts
+
+
+def mitigate_randomized_compiling(samples: list[dict[str, int]]) -> dict[str, int]:
+    """Average multiple compiled runs by summing counts across randomized variants."""
+    if not samples:
+        raise ValueError("samples must not be empty")
+
+    combined: dict[str, int] = {}
+    for sample in samples:
+        for bitstring, count in sample.items():
+            combined[bitstring] = combined.get(bitstring, 0) + int(count)
+    return combined
+
+
+def mitigate_ibm_execution(
+    executor: Callable[[], dict[str, int] | list[dict[str, int]]],
+    ideal_distribution: dict[str, float],
+    strategy: str = "measurement",
+    **kwargs,
+) -> dict[str, object]:
+    """Run an execution callback and apply the requested mitigation strategy."""
+    raw_result = executor()
+
+    if strategy == "measurement":
+        if not isinstance(raw_result, dict):
+            raise ValueError("measurement mitigation expects a single counts dictionary")
+        mitigated = mitigate_measurement_error(raw_result, confusion_rate=kwargs.get("confusion_rate", 0.1))
+        before = raw_result
+    elif strategy == "randomized":
+        if not isinstance(raw_result, list):
+            raise ValueError("randomized mitigation expects a list of counts dictionaries")
+        mitigated = mitigate_randomized_compiling(raw_result)
+        before = raw_result[0]
+    else:
+        raise ValueError(f"unknown mitigation strategy: {strategy}")
+
+    return {
+        "strategy": strategy,
+        "raw_counts": raw_result,
+        "mitigated_counts": mitigated,
+        "fidelity_before": fidelity(before, ideal_distribution),
+        "fidelity_after": fidelity(mitigated, ideal_distribution),
+    }

--- a/afana/tests/test_error_mitigation.py
+++ b/afana/tests/test_error_mitigation.py
@@ -1,0 +1,32 @@
+from afana.backends.error_mitigation import mitigate_ibm_execution
+
+
+def test_measurement_error_mitigation_improves_fidelity():
+    ideal = {"0": 0.85, "1": 0.15}
+
+    report = mitigate_ibm_execution(
+        executor=lambda: {"0": 710, "1": 290},
+        ideal_distribution=ideal,
+        strategy="measurement",
+        confusion_rate=0.2,
+    )
+
+    assert report["strategy"] == "measurement"
+    assert report["fidelity_after"] > report["fidelity_before"]
+
+
+def test_randomized_compiling_aggregation_improves_fidelity():
+    ideal = {"0": 0.5, "1": 0.5}
+
+    report = mitigate_ibm_execution(
+        executor=lambda: [
+            {"0": 600, "1": 400},
+            {"0": 400, "1": 600},
+        ],
+        ideal_distribution=ideal,
+        strategy="randomized",
+    )
+
+    assert report["strategy"] == "randomized"
+    assert report["mitigated_counts"] == {"0": 1000, "1": 1000}
+    assert report["fidelity_after"] > report["fidelity_before"]


### PR DESCRIPTION
## Summary
- add an Afana IBM error mitigation module with measurement and randomized-compiling strategies
- expose a mitigation wrapper that reports fidelity before and after mitigation
- add tests showing both strategies improve fidelity on representative benchmark counts

## Testing
- PYTHONPATH=. python3 -c "from afana.backends.error_mitigation import mitigate_ibm_execution; r1 = mitigate_ibm_execution(lambda: {'0': 710, '1': 290}, {'0': 0.85, '1': 0.15}, strategy='measurement', confusion_rate=0.2); assert r1['fidelity_after'] > r1['fidelity_before']; r2 = mitigate_ibm_execution(lambda: [{'0': 600, '1': 400}, {'0': 400, '1': 600}], {'0': 0.5, '1': 0.5}, strategy='randomized'); assert r2['mitigated_counts'] == {'0': 1000, '1': 1000}; assert r2['fidelity_after'] > r2['fidelity_before']"\n\nCloses #329