### PR TITLE
#338 Implement Optimization Pass for Reducing T Gates in ZX-IR

### DIFF
--- a/afana/cli.py
+++ b/afana/cli.py
@@ -14,10 +14,16 @@ def _read_text(path: str) -> str:
 
 
 def _print_gate_report(path: str, stats: dict) -> None:
-    print(
+    line = (
         f"{path}: before={stats['gate_count_before']} "
         f"after={stats['gate_count_after']}"
     )
+    if "t_gate_count_before" in stats and "t_gate_count_after" in stats:
+        line += (
+            f" t_before={stats['t_gate_count_before']}"
+            f" t_after={stats['t_gate_count_after']}"
+        )
+    print(line)
 
 
 def cmd_compile(path: str, optimize: bool, output: Optional[str]) -> int:
@@ -44,6 +50,9 @@ def cmd_benchmark(paths: Iterable[str], optimize: bool) -> int:
                 "after": stats["gate_count_after"],
             }
         )
+        if "t_gate_count_before" in stats and "t_gate_count_after" in stats:
+            rows[-1]["t_before"] = stats["t_gate_count_before"]
+            rows[-1]["t_after"] = stats["t_gate_count_after"]
         _print_gate_report(path, stats)
     print(json.dumps({"results": rows}, indent=2))
     return 0
@@ -55,12 +64,12 @@ def main() -> int:
 
     p_compile = sub.add_parser("compile", help="Compile OpenQASM input")
     p_compile.add_argument("input", help="Path to OpenQASM file")
-    p_compile.add_argument("--optimize", action="store_true", help="Enable ZX optimization")
+    p_compile.add_argument("--optimize", action="store_true", help="Enable ZX optimization, including T-gate reduction")
     p_compile.add_argument("--output", help="Optional output path for compiled QASM")
 
     p_bench = sub.add_parser("benchmark", help="Benchmark gate count before/after")
     p_bench.add_argument("inputs", nargs="+", help="One or more OpenQASM files")
-    p_bench.add_argument("--optimize", action="store_true", help="Enable ZX optimization")
+    p_bench.add_argument("--optimize", action="store_true", help="Enable ZX optimization, including T-gate reduction")
 
     args = parser.parse_args()
     if args.cmd == "compile":

--- a/afana/compile.py
+++ b/afana/compile.py
@@ -26,20 +26,33 @@ def _count_qasm_ops(qasm: str) -> int:
     return count
 
 
+def _count_qasm_t_ops(qasm: str) -> int:
+    count = 0
+    for raw in qasm.splitlines():
+        if raw.strip().startswith("t ") and raw.strip().endswith(";"):
+            count += 1
+    return count
+
+
 def compile_qasm(qasm: str, optimize: bool = False) -> Dict[str, Any]:
     """Compile raw OpenQASM and optionally run ZX optimization."""
     gate_count_before = _count_qasm_ops(qasm)
+    t_gate_count_before = _count_qasm_t_ops(qasm)
     if optimize:
         out_qasm, stats = optimize_qasm_with_stats(qasm)
         gate_count_after = stats["after"]
+        t_gate_count_after = stats["t_after"]
     else:
         out_qasm = qasm
         gate_count_after = gate_count_before
+        t_gate_count_after = t_gate_count_before
     return {
         "qasm": out_qasm,
         "stats": {
             "gate_count_before": gate_count_before,
             "gate_count_after": gate_count_after,
+            "t_gate_count_before": t_gate_count_before,
+            "t_gate_count_after": t_gate_count_after,
             "optimized": optimize,
         },
     }

--- a/afana/optimize.py
+++ b/afana/optimize.py
@@ -3,6 +3,14 @@ from __future__ import annotations
 from typing import Dict, Tuple
 
 
+def _is_t_gate(line: str) -> bool:
+    return line.startswith("t ") and line.endswith(";")
+
+
+def _target_qubit(line: str) -> str:
+    return line[:-1].split(None, 1)[1].strip()
+
+
 def _count_qasm_gates(qasm_str: str) -> int:
     count = 0
     for raw in qasm_str.splitlines():
@@ -15,35 +23,82 @@ def _count_qasm_gates(qasm_str: str) -> int:
     return count
 
 
+def _count_t_gates(qasm_str: str) -> int:
+    count = 0
+    for raw in qasm_str.splitlines():
+        if _is_t_gate(raw.strip()):
+            count += 1
+    return count
+
+
+def _reduce_t_gates(qasm_str: str) -> str:
+    """Collapse adjacent T gates on the same qubit into the equivalent S gate."""
+    reduced: list[str] = []
+    pending_t: str | None = None
+
+    for raw in qasm_str.splitlines():
+        line = raw.strip()
+        if _is_t_gate(line):
+            if pending_t is not None and _target_qubit(pending_t) == _target_qubit(line):
+                reduced.append(f"s {_target_qubit(line)};")
+                pending_t = None
+            else:
+                if pending_t is not None:
+                    reduced.append(pending_t)
+                pending_t = line
+            continue
+
+        if pending_t is not None:
+            reduced.append(pending_t)
+            pending_t = None
+        reduced.append(raw)
+
+    if pending_t is not None:
+        reduced.append(pending_t)
+
+    return "\n".join(reduced)
+
+
 def optimize_qasm_with_stats(qasm_str: str) -> Tuple[str, Dict[str, int]]:
     """Run ZX-calculus simplification with a never-worse gate-count guarantee."""
     before = _count_qasm_gates(qasm_str)
-    candidate = qasm_str
+    t_before = _count_t_gates(qasm_str)
+    baseline = _reduce_t_gates(qasm_str)
+    candidate = baseline
 
     try:
         import pyzx as zx  # type: ignore
     except Exception:
-        return qasm_str, {"before": before, "after": before}
+        after = _count_qasm_gates(baseline)
+        t_after = _count_t_gates(baseline)
+        if after > before:
+            return qasm_str, {"before": before, "after": before, "t_before": t_before, "t_after": t_before}
+        return baseline, {"before": before, "after": after, "t_before": t_before, "t_after": t_after}
 
     try:
-        circuit = zx.Circuit.from_qasm(qasm_str)
+        circuit = zx.Circuit.from_qasm(baseline)
         graph = circuit.to_graph()
         zx.simplify.full_reduce(graph)
         optimized = zx.extract_circuit(graph)
         # Keep compatibility with varying pyzx API names.
         to_qasm = getattr(optimized, "to_qasm", None)
         if callable(to_qasm):
-            candidate = to_qasm()
+            candidate = _reduce_t_gates(to_qasm())
         to_qasm_v3 = getattr(optimized, "to_qasm3", None)
-        if callable(to_qasm_v3) and candidate == qasm_str:
-            candidate = to_qasm_v3()
+        if callable(to_qasm_v3) and candidate == baseline:
+            candidate = _reduce_t_gates(to_qasm_v3())
     except Exception:
-        return qasm_str, {"before": before, "after": before}
+        after = _count_qasm_gates(baseline)
+        t_after = _count_t_gates(baseline)
+        if after > before:
+            return qasm_str, {"before": before, "after": before, "t_before": t_before, "t_after": t_before}
+        return baseline, {"before": before, "after": after, "t_before": t_before, "t_after": t_after}
 
     after = _count_qasm_gates(candidate)
+    t_after = _count_t_gates(candidate)
     if after > before:
-        return qasm_str, {"before": before, "after": before}
-    return candidate, {"before": before, "after": after}
+        return qasm_str, {"before": before, "after": before, "t_before": t_before, "t_after": t_before}
+    return candidate, {"before": before, "after": after, "t_before": t_before, "t_after": t_after}
 
 
 def optimize_qasm(qasm_str: str) -> str:

--- a/afana/tests/test_optimize.py
+++ b/afana/tests/test_optimize.py
@@ -61,3 +61,26 @@ def test_optimize_accepts_better_candidate(monkeypatch):
     assert out == qasm_better
     assert stats["before"] == 2
     assert stats["after"] == 1
+
+
+def test_optimize_reduces_adjacent_t_gates(monkeypatch):
+    qasm_t = "\n".join(
+        [
+            "OPENQASM 2.0;",
+            'include "qelib1.inc";',
+            "qreg q[1];",
+            "t q[0];",
+            "t q[0];",
+            "h q[0];",
+        ]
+    )
+
+    monkeypatch.setitem(sys.modules, "pyzx", _fake_pyzx(qasm_t))
+    out, stats = optimize_qasm_with_stats(qasm_t)
+
+    assert "s q[0];" in out
+    assert "t q[0];\nt q[0];" not in out
+    assert stats["before"] == 3
+    assert stats["after"] == 2
+    assert stats["t_before"] == 2
+    assert stats["t_after"] == 0

--- a/docs/optimization.md
+++ b/docs/optimization.md
@@ -1,0 +1,39 @@
+# Afana Optimization
+
+Afana's `--optimize` flag runs the ZX optimization pipeline and now includes a
+lightweight T-gate reduction pass before the PyZX simplifier runs.
+
+## T-gate reduction
+
+The optimizer looks for adjacent `T` gates on the same qubit and rewrites them
+to the equivalent `S` gate. This reduces the T-count without increasing total
+gate count.
+
+Example input:
+
+```qasm
+OPENQASM 2.0;
+include "qelib1.inc";
+qreg q[1];
+t q[0];
+t q[0];
+h q[0];
+```
+
+Run the optimization via the CLI:
+
+```bash
+python3 -m afana.cli compile sample.qasm --optimize
+```
+
+Expected report:
+
+```text
+sample.qasm: before=3 after=2 t_before=2 t_after=0
+```
+
+Use `benchmark` to compare several circuits at once:
+
+```bash
+python3 -m afana.cli benchmark sample.qasm other.qasm --optimize
+```


### PR DESCRIPTION
## Summary
- add a lightweight T-gate reduction pass to Afana's optimization pipeline
- surface T-gate counts in compile and benchmark CLI output
- document the CLI workflow in docs/optimization.md and cover T-gate reduction in test_optimize.py

## Testing
- PYTHONPATH=. python3 - <<'PY'
from afana.optimize import optimize_qasm_with_stats
from afana.compile import compile_qasm
from afana.cli import cmd_compile
from pathlib import Path
import tempfile, io, contextlib
qasm = '\n'.join(['OPENQASM 2.0;','include "qelib1.inc";','qreg q[1];','t q[0];','t q[0];','h q[0];'])
out, stats = optimize_qasm_with_stats(qasm)
assert 's q[0];' in out
assert stats['before'] == 3 and stats['after'] == 2
assert stats['t_before'] == 2 and stats['t_after'] == 0
compiled = compile_qasm(qasm, optimize=True)
assert compiled['stats']['t_gate_count_before'] == 2
assert compiled['stats']['t_gate_count_after'] == 0
with tempfile.TemporaryDirectory() as tmp:
    src = Path(tmp) / 'sample.qasm'
    src.write_text(qasm, encoding='utf-8')
    buf = io.StringIO()
    with contextlib.redirect_stdout(buf):
        rc = cmd_compile(str(src), optimize=True, output=None)
    text = buf.getvalue()
    assert rc == 0
    assert 't_before=2 t_after=0' in text
print('ok')
PY

Closes #338