### PR TITLE
#49 Add quasi-board WebSocket task stream

### DIFF
--- a/quasi-board/server.py
+++ b/quasi-board/server.py
@@ -24,7 +24,7 @@ from typing import Any
 from urllib.parse import urlparse
 
 import httpx
-from fastapi import FastAPI, Header, HTTPException, Request
+from fastapi import FastAPI, Header, HTTPException, Request, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, PlainTextResponse
 import hmac as _hmac
@@ -50,6 +50,7 @@ PENDING_MERGES_FILE = Path("/home/vops/quasi-board/pending-merges.json")
 ACTOR_KEY_ID = f"{ACTOR_URL}#main-key"
 
 AP_CONTENT_TYPE = "application/activity+json"
+_STREAM_CLIENTS: list[WebSocket] = []
 
 
 @asynccontextmanager
@@ -237,6 +238,20 @@ async def _deliver_to_followers(activity: dict) -> None:
                         await _deliver(inbox, activity)
         except Exception:
             pass
+
+
+async def _broadcast_stream_event(event_type: str, task: dict[str, Any]) -> None:
+    """Broadcast a real-time task event to connected dashboard clients."""
+    stale: list[WebSocket] = []
+    payload = {"type": event_type, "task": task}
+    for client in _STREAM_CLIENTS:
+        try:
+            await client.send_json(payload)
+        except Exception:
+            stale.append(client)
+    for client in stale:
+        if client in _STREAM_CLIENTS:
+            _STREAM_CLIENTS.remove(client)
 
 
 # ── Proposals ─────────────────────────────────────────────────────────────────
@@ -1028,6 +1043,16 @@ async def _process_activity(body: dict) -> JSONResponse:
             "quasi:agent": agent,
             "quasi:ledgerEntry": entry["id"],
         })
+        await _broadcast_stream_event(
+            "task_claimed",
+            {
+                "id": task_id,
+                "url": f"{ACTOR_URL}/tasks/{task_id}",
+                "status": "claimed",
+                "agent": agent,
+                "ledger_entry": entry["id"],
+            },
+        )
         return JSONResponse({"status": "claimed", "ledger_entry": entry["id"], "entry_hash": entry["entry_hash"]})
 
     if activity_type == "Create" and body.get("quasi:type") == "patch":
@@ -1149,6 +1174,16 @@ async def _process_activity(body: dict) -> JSONResponse:
                 "quasi:ledgerEntry": entry["id"],
             },
         })
+        await _broadcast_stream_event(
+            "task_completed",
+            {
+                "id": task_id,
+                "url": pr_url or f"https://github.com/{GITHUB_REPO}",
+                "status": "done",
+                "agent": agent,
+                "ledger_entry": entry["id"],
+            },
+        )
         return JSONResponse({"status": "recorded", "ledger_entry": entry["id"], "entry_hash": entry["entry_hash"]})
 
     if activity_type == "Create" and body.get("quasi:type") == "issue_generated":
@@ -1160,6 +1195,15 @@ async def _process_activity(body: dict) -> JSONResponse:
             "issue_url": str(body.get("quasi:issueUrl", ""))[:500],
         }
         entry = append_ledger(gen_entry)
+        await _broadcast_stream_event(
+            "new_task",
+            {
+                "url": gen_entry["issue_url"],
+                "level": gen_entry["level"],
+                "generator_model": gen_entry["generator_model"],
+                "ledger_entry": entry["id"],
+            },
+        )
         return JSONResponse({"status": "recorded", "ledger_entry": entry["id"], "entry_hash": entry["entry_hash"]})
 
     if activity_type == "quasi:Propose":
@@ -1368,6 +1412,23 @@ async def openapi_spec():
 
 
 # ── Health ────────────────────────────────────────────────────────────────────
+
+@app.websocket("/quasi-board/stream")
+async def stream(websocket: WebSocket):
+    """WebSocket stream for real-time task activity updates."""
+    await websocket.accept()
+    _STREAM_CLIENTS.append(websocket)
+    try:
+        while True:
+            message = await websocket.receive()
+            if message["type"] == "websocket.disconnect":
+                break
+    except WebSocketDisconnect:
+        pass
+    finally:
+        if websocket in _STREAM_CLIENTS:
+            _STREAM_CLIENTS.remove(websocket)
+
 
 @app.get("/quasi-board/health")
 async def health():

--- a/quasi-board/tests/test_stream.py
+++ b/quasi-board/tests/test_stream.py
@@ -1,0 +1,92 @@
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+def _client():
+    from server import app
+
+    return TestClient(app)
+
+
+def test_stream_emits_new_task_event():
+    with patch("server.append_ledger", return_value={"id": 7, "entry_hash": "a" * 64}):
+        client = _client()
+        with client.websocket_connect("/quasi-board/stream") as ws:
+            resp = client.post(
+                "/quasi-board/inbox",
+                json={
+                    "@context": "https://www.w3.org/ns/activitystreams",
+                    "type": "Create",
+                    "quasi:type": "issue_generated",
+                    "quasi:generator_model": "deepseek-v3",
+                    "quasi:generator_provider": "openrouter",
+                    "quasi:level": 2,
+                    "quasi:issueUrl": "https://github.com/ehrenfest-quantum/quasi/issues/338",
+                },
+            )
+            assert resp.status_code == 200
+            event = ws.receive_json()
+
+    assert event["type"] == "new_task"
+    assert event["task"]["url"].endswith("/338")
+    assert event["task"]["ledger_entry"] == 7
+
+
+def test_stream_emits_task_claimed_event():
+    with (
+        patch("server._effective_task_status", return_value={"status": "open"}),
+        patch("server.append_ledger", return_value={"id": 8, "entry_hash": "b" * 64}),
+        patch("server._notify_daniel", new_callable=AsyncMock),
+        patch("server._deliver_to_followers", new_callable=AsyncMock),
+    ):
+        client = _client()
+        with client.websocket_connect("/quasi-board/stream") as ws:
+            resp = client.post(
+                "/quasi-board/inbox",
+                json={
+                    "@context": "https://www.w3.org/ns/activitystreams",
+                    "type": "Announce",
+                    "actor": "gpt-5-codex",
+                    "quasi:taskId": "QUASI-029",
+                },
+            )
+            assert resp.status_code == 200
+            event = ws.receive_json()
+
+    assert event["type"] == "task_claimed"
+    assert event["task"]["id"] == "QUASI-029"
+    assert event["task"]["status"] == "claimed"
+
+
+def test_stream_emits_task_completed_event():
+    with (
+        patch("server.append_ledger", return_value={"id": 9, "entry_hash": "c" * 64}),
+        patch("server._notify_daniel", new_callable=AsyncMock),
+        patch("server._deliver_to_followers", new_callable=AsyncMock),
+    ):
+        client = _client()
+        with client.websocket_connect("/quasi-board/stream") as ws:
+            resp = client.post(
+                "/quasi-board/inbox",
+                json={
+                    "@context": "https://www.w3.org/ns/activitystreams",
+                    "type": "Create",
+                    "quasi:type": "completion",
+                    "actor": "gpt-5-codex",
+                    "quasi:taskId": "QUASI-029",
+                    "quasi:commitHash": "abc123",
+                    "quasi:prUrl": "https://github.com/ehrenfest-quantum/quasi/pull/342",
+                },
+            )
+            assert resp.status_code == 200
+            event = ws.receive_json()
+
+    assert event["type"] == "task_completed"
+    assert event["task"]["id"] == "QUASI-029"
+    assert event["task"]["status"] == "done"


### PR DESCRIPTION
## Summary
- add a WebSocket endpoint at /quasi-board/stream for real-time task events
- broadcast new_task, task_claimed, and task_completed events to connected clients
- add stream tests covering all three event types

## Testing
- PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m py_compile quasi-board/server.py quasi-board/tests/test_stream.py

Closes #49