### PR TITLE
Add noise-aware backend selection to Afana CLI

### DIFF
--- a/afana/backend_selector.py
+++ b/afana/backend_selector.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, List, Optional
+from math import inf
+from typing import List, Optional
 
 
 @dataclass(frozen=True)
@@ -35,7 +36,10 @@ def _meets_requirements(
         return False
     if backend.n_qubits < req.n_qubits_min:
         return False
-    if req.gate_fidelity_min is not None and backend.gate_fidelity < req.gate_fidelity_min:
+    if (
+        req.gate_fidelity_min is not None
+        and backend.gate_fidelity < req.gate_fidelity_min
+    ):
         return False
     return True
 
@@ -45,7 +49,12 @@ def _score_backend(backend: BackendCapabilities, req: NoiseRequirements) -> floa
     t1_headroom = backend.t1_us - req.t1_us_min
     t2_headroom = backend.t2_us - req.t2_us_min
     qubit_headroom = backend.n_qubits - req.n_qubits_min
-    return (backend.gate_fidelity * 1000.0) + t1_headroom + t2_headroom + (qubit_headroom * 0.1)
+    return (
+        (backend.gate_fidelity * 1000.0)
+        + t1_headroom
+        + t2_headroom
+        + (qubit_headroom * 0.1)
+    )
 
 
 def select_backends(
@@ -68,3 +77,53 @@ def select_best_backend(
     if not ranked:
         raise RuntimeError("No backend satisfies the program noise requirements")
     return ranked[0]
+
+
+def simulator_capabilities(n_qubits: int = 32) -> BackendCapabilities:
+    """Return the static idealized simulator capability row."""
+    return BackendCapabilities(
+        name="simulator",
+        t1_us=inf,
+        t2_us=inf,
+        gate_fidelity=1.0,
+        n_qubits=n_qubits,
+    )
+
+
+def ibm_backend_capabilities(backend_name: str = "ibm_torino") -> BackendCapabilities:
+    """Fetch IBM backend calibration data through Qiskit Runtime."""
+    from .backends.ibm import _load_qiskit
+
+    _QuantumCircuit, _transpile, QiskitRuntimeService = _load_qiskit()
+    service = QiskitRuntimeService()
+    backend = service.backend(backend_name)
+    properties = backend.properties()
+
+    t1_values = [
+        float(item.t1)
+        for item in getattr(properties, "qubits", [])
+        if getattr(item, "t1", None) is not None
+    ]
+    t2_values = [
+        float(item.t2)
+        for item in getattr(properties, "qubits", [])
+        if getattr(item, "t2", None) is not None
+    ]
+
+    fidelity_values: list[float] = []
+    for gate in getattr(properties, "gates", []):
+        for param in getattr(gate, "parameters", []):
+            if getattr(param, "name", "") in {"gate_error", "error"}:
+                fidelity_values.append(max(0.0, 1.0 - float(param.value)))
+
+    t1_us = min(t1_values) / 1_000 if t1_values else 0.0
+    t2_us = min(t2_values) / 1_000 if t2_values else 0.0
+    gate_fidelity = min(fidelity_values) if fidelity_values else 0.0
+
+    return BackendCapabilities(
+        name=backend_name,
+        t1_us=t1_us,
+        t2_us=t2_us,
+        gate_fidelity=gate_fidelity,
+        n_qubits=int(getattr(backend, "num_qubits", 0)),
+    )

--- a/afana/cli.py
+++ b/afana/cli.py
@@ -3,9 +3,16 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from pathlib import Path
 from typing import Iterable, Optional
 
+from .backend_selector import (
+    NoiseRequirements,
+    ibm_backend_capabilities,
+    select_backends,
+    simulator_capabilities,
+)
 from .compile import compile_qasm
 
 
@@ -20,10 +27,41 @@ def _print_gate_report(path: str, stats: dict) -> None:
     )
 
 
-def cmd_compile(path: str, optimize: bool, output: Optional[str]) -> int:
+def _print_backend_selection(
+    requirements: NoiseRequirements,
+    backends: Iterable,
+    selected_backend: Optional[str],
+) -> None:
+    print(
+        "backend ranking: "
+        f"t1>={requirements.t1_us_min:g}us "
+        f"t2>={requirements.t2_us_min:g}us "
+        f"qubits>={requirements.n_qubits_min}"
+    )
+    if requirements.gate_fidelity_min is not None:
+        print(f"minimum gate fidelity: {requirements.gate_fidelity_min:.6f}")
+    for backend in backends:
+        marker = "*" if backend.name == selected_backend else "-"
+        t1 = "inf" if backend.t1_us == float("inf") else f"{backend.t1_us:.1f}"
+        t2 = "inf" if backend.t2_us == float("inf") else f"{backend.t2_us:.1f}"
+        print(
+            f"{marker} {backend.name}: t1={t1}us "
+            f"t2={t2}us fidelity={backend.gate_fidelity:.6f} "
+            f"qubits={backend.n_qubits}"
+        )
+
+
+def cmd_compile(
+    path: str,
+    optimize: bool,
+    output: Optional[str],
+    backend: Optional[str] = None,
+) -> int:
     qasm = _read_text(path)
     result = compile_qasm(qasm, optimize=optimize)
     _print_gate_report(path, result["stats"])
+    if backend:
+        print(f"selected backend: {backend}")
     if output:
         Path(output).write_text(result["qasm"], encoding="utf-8")
     else:
@@ -55,16 +93,85 @@ def main() -> int:
 
     p_compile = sub.add_parser("compile", help="Compile OpenQASM input")
     p_compile.add_argument("input", help="Path to OpenQASM file")
-    p_compile.add_argument("--optimize", action="store_true", help="Enable ZX optimization")
+    p_compile.add_argument(
+        "--optimize",
+        action="store_true",
+        help="Enable ZX optimization",
+    )
     p_compile.add_argument("--output", help="Optional output path for compiled QASM")
+    p_compile.add_argument("--backend", help="Preferred IBM backend to inspect")
+    p_compile.add_argument(
+        "--select-backend",
+        action="store_true",
+        help="Rank available backends against noise requirements before compiling",
+    )
+    p_compile.add_argument(
+        "--noise-t1-us",
+        type=float,
+        default=0.0,
+        help="Minimum acceptable T1 coherence time in microseconds",
+    )
+    p_compile.add_argument(
+        "--noise-t2-us",
+        type=float,
+        default=0.0,
+        help="Minimum acceptable T2 coherence time in microseconds",
+    )
+    p_compile.add_argument(
+        "--gate-fidelity-min",
+        type=float,
+        help="Minimum acceptable per-gate fidelity",
+    )
+    p_compile.add_argument(
+        "--n-qubits",
+        type=int,
+        default=1,
+        help="Minimum qubit capacity required by the program",
+    )
 
     p_bench = sub.add_parser("benchmark", help="Benchmark gate count before/after")
     p_bench.add_argument("inputs", nargs="+", help="One or more OpenQASM files")
-    p_bench.add_argument("--optimize", action="store_true", help="Enable ZX optimization")
+    p_bench.add_argument(
+        "--optimize",
+        action="store_true",
+        help="Enable ZX optimization",
+    )
 
     args = parser.parse_args()
     if args.cmd == "compile":
-        return cmd_compile(args.input, optimize=args.optimize, output=args.output)
+        selected_backend = args.backend
+        if args.select_backend:
+            requirements = NoiseRequirements(
+                t1_us_min=args.noise_t1_us,
+                t2_us_min=args.noise_t2_us,
+                n_qubits_min=args.n_qubits,
+                gate_fidelity_min=args.gate_fidelity_min,
+            )
+            available = [simulator_capabilities(n_qubits=max(args.n_qubits, 32))]
+            backend_name = selected_backend or "ibm_torino"
+            try:
+                available.append(ibm_backend_capabilities(backend_name))
+            except Exception as exc:  # pragma: no cover - network/auth dependent
+                print(
+                    f"warning: could not load IBM backend '{backend_name}': {exc}",
+                    file=sys.stderr,
+                )
+            ranked = select_backends(available, requirements)
+            if not ranked:
+                print(
+                    "no backend satisfies the requested noise profile",
+                    file=sys.stderr,
+                )
+                return 2
+            if selected_backend is None:
+                selected_backend = ranked[0].name
+            _print_backend_selection(requirements, ranked, selected_backend)
+        return cmd_compile(
+            args.input,
+            optimize=args.optimize,
+            output=args.output,
+            backend=selected_backend,
+        )
     if args.cmd == "benchmark":
         return cmd_benchmark(args.inputs, optimize=args.optimize)
     parser.print_help()

--- a/afana/tests/test_backend_selector.py
+++ b/afana/tests/test_backend_selector.py
@@ -3,27 +3,57 @@ import pytest
 from afana.backend_selector import (
     BackendCapabilities,
     NoiseRequirements,
+    ibm_backend_capabilities,
     select_backends,
     select_best_backend,
+    simulator_capabilities,
 )
 
 
 def _sample_backends():
     return [
-        BackendCapabilities(name="sim", t1_us=1000.0, t2_us=1500.0, gate_fidelity=0.999, n_qubits=32),
-        BackendCapabilities(name="ibm_torino", t1_us=250.0, t2_us=300.0, gate_fidelity=0.987, n_qubits=133),
-        BackendCapabilities(name="iqm_garnet", t1_us=180.0, t2_us=220.0, gate_fidelity=0.981, n_qubits=20),
+        BackendCapabilities(
+            name="sim",
+            t1_us=1000.0,
+            t2_us=1500.0,
+            gate_fidelity=0.999,
+            n_qubits=32,
+        ),
+        BackendCapabilities(
+            name="ibm_torino",
+            t1_us=250.0,
+            t2_us=300.0,
+            gate_fidelity=0.987,
+            n_qubits=133,
+        ),
+        BackendCapabilities(
+            name="iqm_garnet",
+            t1_us=180.0,
+            t2_us=220.0,
+            gate_fidelity=0.981,
+            n_qubits=20,
+        ),
     ]
 
 
 def test_select_backends_filters_and_ranks():
-    req = NoiseRequirements(t1_us_min=150.0, t2_us_min=200.0, n_qubits_min=16, gate_fidelity_min=0.98)
+    req = NoiseRequirements(
+        t1_us_min=150.0,
+        t2_us_min=200.0,
+        n_qubits_min=16,
+        gate_fidelity_min=0.98,
+    )
     ranked = select_backends(_sample_backends(), req)
     assert [b.name for b in ranked] == ["sim", "ibm_torino", "iqm_garnet"]
 
 
 def test_select_best_backend_rejects_when_no_backend_matches():
-    req = NoiseRequirements(t1_us_min=5000.0, t2_us_min=6000.0, n_qubits_min=8, gate_fidelity_min=0.9999)
+    req = NoiseRequirements(
+        t1_us_min=5000.0,
+        t2_us_min=6000.0,
+        n_qubits_min=8,
+        gate_fidelity_min=0.9999,
+    )
     with pytest.raises(RuntimeError):
         select_best_backend(_sample_backends(), req)
 
@@ -33,3 +63,66 @@ def test_invalid_requirements_raise_value_error():
     req = NoiseRequirements(t1_us_min=10.0, t2_us_min=25.0, n_qubits_min=2)
     with pytest.raises(ValueError):
         select_backends(_sample_backends(), req)
+
+
+def test_simulator_capabilities_always_passes():
+    sim = simulator_capabilities(48)
+    req = NoiseRequirements(
+        t1_us_min=10_000.0,
+        t2_us_min=20_000.0,
+        n_qubits_min=48,
+        gate_fidelity_min=0.999999,
+    )
+
+    assert sim.name == "simulator"
+    assert sim.t1_us == float("inf")
+    assert sim.t2_us == float("inf")
+    assert sim.gate_fidelity == 1.0
+    assert select_best_backend([sim], req) == sim
+
+
+def test_ibm_backend_capabilities_reads_runtime_properties(monkeypatch):
+    class _Param:
+        def __init__(self, name, value):
+            self.name = name
+            self.value = value
+
+    class _Gate:
+        def __init__(self, parameters):
+            self.parameters = parameters
+
+    class _Qubit:
+        def __init__(self, t1, t2):
+            self.t1 = t1
+            self.t2 = t2
+
+    class _Props:
+        qubits = [_Qubit(180_000.0, 260_000.0), _Qubit(200_000.0, 300_000.0)]
+        gates = [
+            _Gate([_Param("gate_error", 0.01)]),
+            _Gate([_Param("error", 0.015)]),
+        ]
+
+    class _Backend:
+        num_qubits = 127
+
+        @staticmethod
+        def properties():
+            return _Props()
+
+    class _Service:
+        def backend(self, name):
+            assert name == "ibm_sherbrooke"
+            return _Backend()
+
+    monkeypatch.setattr(
+        "afana.backends.ibm._load_qiskit",
+        lambda: (object, object, _Service),
+    )
+
+    caps = ibm_backend_capabilities("ibm_sherbrooke")
+    assert caps.name == "ibm_sherbrooke"
+    assert caps.t1_us == 180.0
+    assert caps.t2_us == 260.0
+    assert caps.gate_fidelity == 0.985
+    assert caps.n_qubits == 127

--- a/afana/tests/test_cli.py
+++ b/afana/tests/test_cli.py
@@ -1,4 +1,5 @@
-from afana.cli import cmd_benchmark, cmd_compile
+from afana.backend_selector import BackendCapabilities
+from afana.cli import cmd_benchmark, cmd_compile, main
 
 
 QASM_IN = "\n".join(
@@ -49,3 +50,63 @@ def test_cmd_benchmark_prints_json(tmp_path, monkeypatch, capsys):
     printed = capsys.readouterr().out
     assert "before=2 after=2" in printed
     assert "\"results\"" in printed
+
+
+def test_main_select_backend_prints_ranked_backends(tmp_path, monkeypatch, capsys):
+    src = tmp_path / "in.qasm"
+    src.write_text(QASM_IN, encoding="utf-8")
+
+    monkeypatch.setattr(
+        "afana.cli.simulator_capabilities",
+        lambda n_qubits=32: BackendCapabilities(
+            name="simulator",
+            t1_us=float("inf"),
+            t2_us=float("inf"),
+            gate_fidelity=1.0,
+            n_qubits=n_qubits,
+        ),
+    )
+    monkeypatch.setattr(
+        "afana.cli.ibm_backend_capabilities",
+        lambda name="ibm_torino": BackendCapabilities(
+            name=name,
+            t1_us=210.0,
+            t2_us=260.0,
+            gate_fidelity=0.991,
+            n_qubits=127,
+        ),
+    )
+    monkeypatch.setattr("afana.cli.select_backends", lambda backends, req: list(backends))
+
+    seen = {}
+
+    def _fake_cmd_compile(path, optimize, output, backend=None):
+        seen["backend"] = backend
+        return 0
+
+    monkeypatch.setattr("afana.cli.cmd_compile", _fake_cmd_compile)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "afana",
+            "compile",
+            str(src),
+            "--select-backend",
+            "--noise-t1-us",
+            "150",
+            "--noise-t2-us",
+            "200",
+            "--gate-fidelity-min",
+            "0.98",
+            "--n-qubits",
+            "12",
+        ],
+    )
+
+    rc = main()
+    assert rc == 0
+    assert seen["backend"] == "simulator"
+    printed = capsys.readouterr().out
+    assert "backend ranking:" in printed
+    assert "* simulator:" in printed
+    assert "- ibm_torino:" in printed


### PR DESCRIPTION
Implements issue #24.

Summary:
- add simulator and IBM capability helpers to backend selection
- add afana compile --select-backend with noise thresholds and ranked backend output
- add tests for simulator eligibility, mocked IBM calibration loading, and CLI selection flow

Local verification:
- python3 -m py_compile on updated files
- targeted smoke test for backend ranking and compile flow
- pytest could not run locally because pytest is not installed in the system Python in this workspace