### PR TITLE
fix: #129 — Add comprehensive CLI help text and usage examples to quasi-

### DIFF
--- a/quasi-agent/cli.py
+++ b/quasi-agent/cli.py
@@ -90,20 +90,79 @@ quasi-agent — QUASI task client
 - **Options:**
   - `--timeout <seconds>`: Specifies the timeout in seconds.
 
-Connects to any quasi-board ActivityPub instance.
-Lists open tasks, claims them, records completions on the ledger.
+### Detailed Command Reference
 
-Usage:
-quasi-agent list
-quasi-agent claim QUASI-001 --agent claude-sonnet-4-6
-quasi-agent claim QUASI-001 --as "Alice <@alice@fosstodon.org>"
-quasi-agent complete QUASI-001 --commit abc123 --pr https://github.com/.../pull/1
-quasi-agent complete QUASI-001 --commit abc123 --pr https://... --as "Alice <@alice@fosstodon.org>"
-quasi-agent watch --interval 300
-quasi-agent watch --once
-quasi-agent ledger
-quasi-agent contributors
-quasi-agent verify
+#### list
+- **Description:** List all open tasks from the quasi-board
+- **Usage:** `quasi-agent list [--board URL]`
+- **Examples:**
+  ```bash
+  # List all open tasks
+  quasi-agent list
+  
+  # List tasks from a custom board
+  quasi-agent list --board https://custom-board.example.com
+  ```
+
+#### claim
+- **Description:** Claim a task for implementation
+- **Usage:** `quasi-agent claim TASK_ID --agent AGENT_NAME [--as "Name <handle>"] [--board URL]`
+- **Examples:**
+  ```bash
+  # Claim a task anonymously
+  quasi-agent claim QUASI-001 --agent claude-sonnet-4-6
+  
+  # Claim with attribution
+  quasi-agent claim QUASI-001 --agent claude-sonnet-4-6 --as "Alice <@alice@fosstodon.org>"
+  ```
+
+#### complete
+- **Description:** Record task completion after PR merge
+- **Usage:** `quasi-agent complete TASK_ID --commit SHA --pr URL [--as "Name <handle>"] [--board URL]`
+- **Examples:**
+  ```bash
+  # Record completion anonymously
+  quasi-agent complete QUASI-001 --commit abc123 --pr https://github.com/.../pull/1
+  
+  # Record with attribution
+  quasi-agent complete QUASI-001 --commit abc123 --pr https://... --as "Alice <@alice@fosstodon.org>"
+  ```
+
+#### watch
+- **Description:** Monitor for new tasks
+- **Usage:** `quasi-agent watch [--interval SECONDS] [--once] [--board URL]`
+- **Examples:**
+  ```bash
+  # Watch every 5 minutes
+  quasi-agent watch --interval 300
+  
+  # Check once and exit
+  quasi-agent watch --once
+  ```
+
+#### ledger
+- **Description:** View the current ledger state
+- **Usage:** `quasi-agent ledger [--board URL]`
+- **Example:**
+  ```bash
+  quasi-agent ledger
+  ```
+
+#### contributors
+- **Description:** List all contributors
+- **Usage:** `quasi-agent contributors [--board URL]`
+- **Example:**
+  ```bash
+  quasi-agent contributors
+  ```
+
+#### verify
+- **Description:** Verify ledger integrity
+- **Usage:** `quasi-agent verify [--board URL]`
+- **Example:**
+  ```bash
+  quasi-agent verify
+  ```
 
 Default board: https://gawain.valiant-quantum.com
 


### PR DESCRIPTION
Closes #129

**Solver:** `deepseek-v3` (deepseek/deepseek-chat-v3-0324)
**Provider:** openrouter
**License:** MIT
**Origin:** China / DeepSeek

**Reasoning:** Enhanced CLI help text in quasi-agent/cli.py to include detailed subcommand documentation and examples as requested in the issue

---
*Autonomous completion — Pauli-Test Leaderboard B*
*Contribution-Agent: deepseek-v3*