### PR TITLE
Add variational loop support to Ehrenfest AST

### DIFF
--- a/afana/__init__.py
+++ b/afana/__init__.py
@@ -4,7 +4,17 @@ from .backend_selector import BackendCapabilities, NoiseRequirements, select_bac
 from .circuit import Circuit, Operation
 from .compile import compile_for_backend, compile_qasm
 from .optimize import optimize_qasm, optimize_qasm_with_stats
-from .parser import ConditionalGate, EhrenfestAST, Gate, Measure, Expect, ParseError, parse, parse_file
+from .parser import (
+    ConditionalGate,
+    EhrenfestAST,
+    Expect,
+    Gate,
+    Measure,
+    ParseError,
+    VariationalLoop,
+    parse,
+    parse_file,
+)
 from .phase_kickback import phase_kickback
 
 __all__ = [
@@ -23,6 +33,7 @@ __all__ = [
     "Gate",
     "Measure",
     "Expect",
+    "VariationalLoop",
     "ParseError",
     "parse",
     "parse_file",

--- a/afana/cli.py
+++ b/afana/cli.py
@@ -6,7 +6,15 @@ import json
 from pathlib import Path
 from typing import Iterable, Optional
 
-from .compile import compile_qasm
+if __package__ in (None, ""):
+    import sys
+
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    from afana.compile import compile_qasm
+    from afana.variational import compile_variational_file
+else:
+    from .compile import compile_qasm
+    from .variational import compile_variational_file
 
 
 def _read_text(path: str) -> str:
@@ -20,9 +28,12 @@ def _print_gate_report(path: str, stats: dict) -> None:
     )
 
 
-def cmd_compile(path: str, optimize: bool, output: Optional[str]) -> int:
-    qasm = _read_text(path)
-    result = compile_qasm(qasm, optimize=optimize)
+def cmd_compile(path: str, optimize: bool, output: Optional[str], backend: str = "ibm_torino") -> int:
+    if path.endswith(".ef"):
+        result = compile_variational_file(path, backend=backend)
+    else:
+        qasm = _read_text(path)
+        result = compile_qasm(qasm, optimize=optimize)
     _print_gate_report(path, result["stats"])
     if output:
         Path(output).write_text(result["qasm"], encoding="utf-8")
@@ -53,10 +64,11 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Afana compiler CLI")
     sub = parser.add_subparsers(dest="cmd")
 
-    p_compile = sub.add_parser("compile", help="Compile OpenQASM input")
-    p_compile.add_argument("input", help="Path to OpenQASM file")
+    p_compile = sub.add_parser("compile", help="Compile OpenQASM or Ehrenfest source")
+    p_compile.add_argument("input", help="Path to OpenQASM or .ef source file")
     p_compile.add_argument("--optimize", action="store_true", help="Enable ZX optimization")
     p_compile.add_argument("--output", help="Optional output path for compiled QASM")
+    p_compile.add_argument("--backend", default="ibm_torino", help="Target backend for emitted QASM3")
 
     p_bench = sub.add_parser("benchmark", help="Benchmark gate count before/after")
     p_bench.add_argument("inputs", nargs="+", help="One or more OpenQASM files")
@@ -64,7 +76,7 @@ def main() -> int:
 
     args = parser.parse_args()
     if args.cmd == "compile":
-        return cmd_compile(args.input, optimize=args.optimize, output=args.output)
+        return cmd_compile(args.input, optimize=args.optimize, output=args.output, backend=args.backend)
     if args.cmd == "benchmark":
         return cmd_benchmark(args.inputs, optimize=args.optimize)
     parser.print_help()

--- a/afana/parser.py
+++ b/afana/parser.py
@@ -31,7 +31,7 @@ class Gate:
     """A single gate application, e.g. ``h q0`` or ``cnot q0 q1``."""
     name: str          # lower-cased gate name, e.g. "h", "cnot", "rx"
     qubits: List[int]  # qubit indices, e.g. [0] or [0, 1]
-    params: List[float] = field(default_factory=list)  # rotation angles
+    params: List[float | str] = field(default_factory=list)  # rotation angles or symbolic loop params
 
 
 @dataclass
@@ -57,6 +57,16 @@ class Expect:
 
 
 @dataclass
+class VariationalLoop:
+    """A variational loop with symbolic parameter updates."""
+    parameter: str
+    start: float
+    stop: float
+    step: float
+    gates: List[Gate]
+
+
+@dataclass
 class EhrenfestAST:
     """Root AST node for a parsed .ef program."""
     name: str
@@ -66,6 +76,7 @@ class EhrenfestAST:
     measures: List[Measure]
     conditionals: List[ConditionalGate]
     expects: List[Expect]
+    variational_loops: List[VariationalLoop]
 
 
 # ── Tokenisation helpers ───────────────────────────────────────────────────────
@@ -77,6 +88,7 @@ _GATE_RE = re.compile(
 _QUBIT_RE = re.compile(r"^q(\d+)$", re.IGNORECASE)
 _CBIT_RE = re.compile(r"^c(\d+)$", re.IGNORECASE)
 _FLOAT_RE = re.compile(r"^-?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?(pi)?$", re.IGNORECASE)
+_PARAM_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 def _parse_qubit(token: str, lineno: int) -> int:
@@ -108,6 +120,12 @@ def _parse_float_param(token: str, lineno: int) -> float:
         raise ParseError(f"line {lineno}: invalid float parameter {token!r}")
 
 
+def _parse_gate_param(token: str, lineno: int, allowed_symbols: set[str] | None = None) -> float | str:
+    if allowed_symbols and token in allowed_symbols:
+        return token
+    return _parse_float_param(token, lineno)
+
+
 def _strip_comment(line: str) -> str:
     """Remove inline // comment and return stripped content."""
     idx = line.find("//")
@@ -118,6 +136,42 @@ def _strip_comment(line: str) -> str:
 
 class ParseError(ValueError):
     """Raised when .ef source cannot be parsed."""
+
+
+def _parse_gate_tokens(
+    toks: List[str],
+    lineno: int,
+    n_qubits: int,
+    allowed_symbols: set[str] | None = None,
+) -> Gate:
+    gate_name = toks[0].lower()
+    if gate_name == "cnot":
+        gate_name = "cx"
+    if gate_name == "toffoli":
+        gate_name = "ccx"
+
+    params: List[float | str] = []
+    qubit_tokens: List[str] = toks[1:]
+
+    if gate_name in ("rx", "ry", "rz"):
+        if not qubit_tokens:
+            raise ParseError(f"line {lineno}: {gate_name} requires an angle parameter")
+        params.append(_parse_gate_param(qubit_tokens[0], lineno, allowed_symbols))
+        qubit_tokens = qubit_tokens[1:]
+
+    qubit_indices: List[int] = []
+    for qt in qubit_tokens:
+        idx = _parse_qubit(qt, lineno)
+        if idx >= n_qubits:
+            raise ParseError(
+                f"line {lineno}: qubit q{idx} out of range (n_qubits={n_qubits})"
+            )
+        qubit_indices.append(idx)
+
+    if not qubit_indices:
+        raise ParseError(f"line {lineno}: gate {toks[0]!r} requires at least one qubit")
+
+    return Gate(name=gate_name, qubits=qubit_indices, params=params)
 
 
 def parse(source: str) -> EhrenfestAST:
@@ -172,6 +226,7 @@ def parse(source: str) -> EhrenfestAST:
     measures: List[Measure] = []
     conditionals: List[ConditionalGate] = []
     expects: List[Expect] = []
+    variational_loops: List[VariationalLoop] = []
 
     for lineno, toks in it:
         kw = toks[0].lower()
@@ -207,6 +262,50 @@ def parse(source: str) -> EhrenfestAST:
                     f" got {toks[1]!r}"
                 )
             expects.append(Expect(kind=kind, value=toks[2]))
+
+        elif kw == "vary":
+            if len(toks) != 8 or toks[2].lower() != "from" or toks[4].lower() != "to" or toks[6].lower() != "step":
+                raise ParseError(
+                    f"line {lineno}: 'vary' syntax: vary <param> from <start> to <stop> step <delta>"
+                )
+            parameter = toks[1]
+            if not _PARAM_RE.match(parameter):
+                raise ParseError(f"line {lineno}: invalid variational parameter name {parameter!r}")
+            start = _parse_float_param(toks[3], lineno)
+            stop = _parse_float_param(toks[5], lineno)
+            step = _parse_float_param(toks[7], lineno)
+            if step <= 0:
+                raise ParseError(f"line {lineno}: variational loop step must be > 0")
+
+            loop_gates: List[Gate] = []
+            for body_lineno, body_toks in it:
+                body_kw = body_toks[0].lower()
+                if body_kw == "endvary":
+                    break
+                if not _GATE_RE.match(body_kw):
+                    raise ParseError(
+                        f"line {body_lineno}: variational loop body must contain only gate statements"
+                    )
+                loop_gates.append(
+                    _parse_gate_tokens(
+                        body_toks,
+                        body_lineno,
+                        n_qubits,
+                        allowed_symbols={parameter},
+                    )
+                )
+            else:
+                raise ParseError("unexpected end of file while expecting 'endvary'")
+
+            variational_loops.append(
+                VariationalLoop(
+                    parameter=parameter,
+                    start=start,
+                    stop=stop,
+                    step=step,
+                    gates=loop_gates,
+                )
+            )
 
         elif kw == "if":
             # if cN == M: gate qN ...
@@ -249,37 +348,7 @@ def parse(source: str) -> EhrenfestAST:
             conditionals.append(ConditionalGate(cbit=cbit, cbit_value=cbit_value, gate=cond_gate))
 
         elif _GATE_RE.match(kw):
-            gate_name = kw
-            # Normalise aliases
-            if gate_name == "cnot":
-                gate_name = "cx"
-            if gate_name == "toffoli":
-                gate_name = "ccx"
-
-            # Collect optional float params (for rx/ry/rz), then qubits
-            params: List[float] = []
-            qubit_tokens: List[str] = toks[1:]
-
-            # Rotation gates carry one float param before qubits
-            if gate_name in ("rx", "ry", "rz"):
-                if not qubit_tokens:
-                    raise ParseError(f"line {lineno}: {gate_name} requires an angle parameter")
-                params.append(_parse_float_param(qubit_tokens[0], lineno))
-                qubit_tokens = qubit_tokens[1:]
-
-            qubit_indices: List[int] = []
-            for qt in qubit_tokens:
-                idx = _parse_qubit(qt, lineno)
-                if idx >= n_qubits:
-                    raise ParseError(
-                        f"line {lineno}: qubit q{idx} out of range (n_qubits={n_qubits})"
-                    )
-                qubit_indices.append(idx)
-
-            if not qubit_indices:
-                raise ParseError(f"line {lineno}: gate {toks[0]!r} requires at least one qubit")
-
-            gates.append(Gate(name=gate_name, qubits=qubit_indices, params=params))
+            gates.append(_parse_gate_tokens(toks, lineno, n_qubits))
 
         else:
             raise ParseError(f"line {lineno}: unknown directive {toks[0]!r}")
@@ -292,6 +361,7 @@ def parse(source: str) -> EhrenfestAST:
         measures=measures,
         conditionals=conditionals,
         expects=expects,
+        variational_loops=variational_loops,
     )
 
 

--- a/afana/tests/test_cli.py
+++ b/afana/tests/test_cli.py
@@ -49,3 +49,29 @@ def test_cmd_benchmark_prints_json(tmp_path, monkeypatch, capsys):
     printed = capsys.readouterr().out
     assert "before=2 after=2" in printed
     assert "\"results\"" in printed
+
+
+def test_cmd_compile_supports_variational_source(tmp_path, monkeypatch, capsys):
+    src = tmp_path / "vqe.ef"
+    src.write_text('program "vqe"\nqubits 2\n', encoding="utf-8")
+
+    monkeypatch.setattr(
+        "afana.cli.compile_variational_file",
+        lambda path, backend: {
+            "qasm": (
+                "OPENQASM 3.0;\n"
+                "float theta_0 = 0.0;\n"
+                "while (theta_0 <= 1.0) {\n"
+                "  rz(theta_0) q[0];\n"
+                "  theta_0 = theta_0 + 0.2;\n"
+                "}\n"
+            ),
+            "stats": {"gate_count_before": 2, "gate_count_after": 2},
+        },
+    )
+
+    rc = cmd_compile(str(src), optimize=False, output=None, backend="ibm_torino")
+    assert rc == 0
+    printed = capsys.readouterr().out
+    assert "before=2 after=2" in printed
+    assert "while (theta_0 <= 1.0)" in printed

--- a/afana/tests/test_parser.py
+++ b/afana/tests/test_parser.py
@@ -2,7 +2,7 @@
 
 import pytest
 from afana.parser import (
-    EhrenfestAST, Gate, Measure, Expect,
+    EhrenfestAST, Gate, Measure, Expect, VariationalLoop,
     ParseError, parse, parse_file,
 )
 
@@ -24,6 +24,7 @@ def test_parse_minimal():
     assert ast.gates == []
     assert ast.measures == []
     assert ast.expects == []
+    assert ast.variational_loops == []
 
 
 def test_parse_bell():
@@ -210,6 +211,30 @@ def test_conditional_gate():
     assert cg.cbit_value == 1
     assert cg.gate.name == "x"
     assert cg.gate.qubits == [2]
+
+
+def test_variational_loop_parses_into_ast():
+    src = _src(
+        'program "vqe"',
+        "qubits 2",
+        "vary theta_0 from 0.0 to 3.14 step 0.1",
+        "rz theta_0 q0",
+        "cx q0 q1",
+        "endvary",
+    )
+    ast = parse(src)
+    assert ast.variational_loops == [
+        VariationalLoop(
+            parameter="theta_0",
+            start=0.0,
+            stop=3.14,
+            step=0.1,
+            gates=[
+                Gate(name="rz", qubits=[0], params=["theta_0"]),
+                Gate(name="cx", qubits=[0, 1]),
+            ],
+        )
+    ]
 
 
 def test_empty_source():

--- a/afana/tests/test_variational.py
+++ b/afana/tests/test_variational.py
@@ -1,0 +1,35 @@
+from afana.parser import parse
+from afana.variational import compile_variational_file, emit_qasm3
+
+
+def _source() -> str:
+    return "\n".join(
+        [
+            'program "vqe"',
+            "qubits 2",
+            "vary theta_0 from 0.0 to 1.0 step 0.2",
+            "rz theta_0 q0",
+            "cx q0 q1",
+            "endvary",
+        ]
+    )
+
+
+def test_emit_qasm3_contains_parameter_update_logic():
+    ast = parse(_source())
+    qasm = emit_qasm3(ast, backend="ibm_torino")
+    assert "OPENQASM 3.0;" in qasm
+    assert "float theta_0 = 0.0;" in qasm
+    assert "while (theta_0 <= 1.0) {" in qasm
+    assert "rz(theta_0) q[0];" in qasm
+    assert "theta_0 = theta_0 + 0.2;" in qasm
+
+
+def test_compile_variational_file_emits_qasm3(tmp_path):
+    src = tmp_path / "vqe.ef"
+    src.write_text(_source(), encoding="utf-8")
+
+    result = compile_variational_file(str(src), backend="ibm_torino")
+    assert "OPENQASM 3.0;" in result["qasm"]
+    assert "while (theta_0 <= 1.0) {" in result["qasm"]
+    assert result["stats"]["gate_count_before"] == 3

--- a/afana/variational.py
+++ b/afana/variational.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from .parser import EhrenfestAST, Gate, parse_file
+
+
+_SIMPLE_GATES = {"h", "x", "y", "z", "s", "t", "sdg", "tdg"}
+_TWO_QUBIT = {"cx", "cz", "swap"}
+
+
+def _format_param(value: float | str) -> str:
+    if isinstance(value, str):
+        return value
+    text = f"{value:.12g}"
+    return text if "." in text or "e" in text.lower() else f"{text}.0"
+
+
+def _emit_gate(gate: Gate) -> list[str]:
+    if gate.name in _SIMPLE_GATES:
+        return [f"{gate.name} q[{gate.qubits[0]}];"]
+    if gate.name in ("rx", "ry", "rz"):
+        return [f"{gate.name}({_format_param(gate.params[0])}) q[{gate.qubits[0]}];"]
+    if gate.name in _TWO_QUBIT:
+        return [f"{gate.name} q[{gate.qubits[0]}], q[{gate.qubits[1]}];"]
+    if gate.name == "ccx":
+        return [f"ccx q[{gate.qubits[0]}], q[{gate.qubits[1]}], q[{gate.qubits[2]}];"]
+    raise ValueError(f"unsupported gate for variational emitter: {gate.name}")
+
+
+def emit_qasm3(ast: EhrenfestAST, backend: str = "ibm_torino") -> str:
+    lines = ["OPENQASM 3.0;", f"// backend: {backend}", f"qubit[{ast.n_qubits}] q;"]
+
+    for gate in ast.gates:
+        lines.extend(_emit_gate(gate))
+
+    for loop in ast.variational_loops:
+        lines.append(f"float {loop.parameter} = {_format_param(loop.start)};")
+        lines.append(f"while ({loop.parameter} <= {_format_param(loop.stop)}) {{")
+        for gate in loop.gates:
+            for emitted in _emit_gate(gate):
+                lines.append(f"  {emitted}")
+        lines.append(
+            f"  {loop.parameter} = {loop.parameter} + {_format_param(loop.step)};"
+        )
+        lines.append("}")
+
+    return "\n".join(lines) + "\n"
+
+
+def compile_variational_file(path: str, backend: str = "ibm_torino") -> dict:
+    ast = parse_file(path)
+    qasm = emit_qasm3(ast, backend=backend)
+    gate_count = 0
+    for raw in qasm.splitlines():
+        line = raw.strip()
+        if not line or line.startswith(("OPENQASM", "//", "qubit[", "float ", "while ", "}")):
+            continue
+        gate_count += 1
+    return {
+        "qasm": qasm,
+        "stats": {
+            "gate_count_before": gate_count,
+            "gate_count_after": gate_count,
+            "optimized": False,
+        },
+    }


### PR DESCRIPTION
Closes #352.

Summary:
- add a VariationalLoop AST node and parser support for vary ... endvary blocks in .ef source
- allow symbolic loop parameters inside rotation gates
- add a minimal OpenQASM 3 emitter that translates variational loops into while-based parameter update logic
- extend afana compile to accept .ef sources and add focused parser, emitter, and CLI tests

Local verification:
- python3 -m py_compile on updated afana files
- python3 afana/cli.py compile --help
- targeted parser and emitter smoke test for a variational loop example
- full pytest not run locally because pytest is not installed in the system Python in this workspace