### PR TITLE
docs: add pull request checklist to contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,15 @@
 - Add or update tests whenever behavior changes.
 - Mention any test command you ran in the PR description.
 
+## Pull Request Checklist
+
+Before requesting review:
+
+- confirm the issue is still open and not already covered by a newer PR
+- keep the branch scoped to one issue or task
+- include a short verification note with the exact command you ran
+- call out assumptions, skipped checks, or external blockers
+
 ## Attribution
 
 If you are working through quasi-board, keep the required commit footer or submission metadata so the contribution can be recorded in the quasi-ledger.


### PR DESCRIPTION
Closes #241\n\nAdds a compact pull request checklist to CONTRIBUTING.md so contributors can verify scope, validation, and blockers before review.\n\nVerification: markdown-only change reviewed locally.