### PR TITLE
feat(afana): user-defined type declarations in Ehrenfest parser and AST

### DIFF
--- a/afana/__init__.py
+++ b/afana/__init__.py
@@ -16,7 +16,7 @@ from .noise_model import (
 )
 from .optimize import optimize_qasm, optimize_qasm_with_stats
 from .parametric import ParametricCompileError, bind_parameters, compile_parametric
-from .parser import ConditionalGate, EhrenfestAST, Gate, Measure, Expect, ParseError, parse, parse_file
+from .parser import ConditionalGate, EhrenfestAST, Gate, Measure, Expect, TypeDecl, ParseError, parse, parse_file
 from .phase_kickback import phase_kickback
 
 __all__ = [
@@ -39,14 +39,15 @@ __all__ = [
     "validate_noise_channels",
     "optimize_qasm",
     "optimize_qasm_with_stats",
+    "ParametricCompileError",
+    "bind_parameters",
+    "compile_parametric",
     "ConditionalGate",
     "EhrenfestAST",
     "Gate",
     "Measure",
     "Expect",
-    "ParametricCompileError",
-    "bind_parameters",
-    "compile_parametric",
+    "TypeDecl",
     "ParseError",
     "parse",
     "parse_file",

--- a/afana/parser.py
+++ b/afana/parser.py
@@ -1,7 +1,9 @@
 """Ehrenfest (.ef) text parser — converts .ef source to an AST.
 
-Grammar summary (v0.1):
-  program  ::= header stmt*
+Grammar summary (v0.2):
+  program  ::= type_decl* header stmt*
+  type_decl ::= 'type' NAME '=' type_expr
+  type_expr ::= NAME | '(' NAME (',' NAME)* ')'
   header   ::= 'program' STRING 'qubits' INT ('prepare' 'basis' STATE)?
   stmt     ::= gate_stmt | measure_stmt | expect_stmt | comment
   gate_stmt    ::= GATE qubit_list
@@ -11,6 +13,8 @@ Grammar summary (v0.1):
 
 Supported gates (case-insensitive): h, x, y, z, s, t, sdg, tdg,
   cx / cnot, cz, swap, ccx / toffoli, rx, ry, rz.
+
+Type declarations use schema tag ``quasi.org/ast/type-alias`` (CBOR schema v0.3+).
 
 No external dependencies — stdlib only.
 """
@@ -57,6 +61,25 @@ class Expect:
 
 
 @dataclass
+class TypeDecl:
+    """A user-defined type alias: ``type QubitPair = (Qubit, Qubit)``.
+
+    Serialises to CBOR schema v0.3+ using the ``quasi.org/ast/type-alias`` tag.
+    The ``definition`` field holds the raw type expression exactly as written.
+    """
+
+    #: CBOR schema tag for type alias nodes (schema v0.3+).
+    CBOR_TAG = "quasi.org/ast/type-alias"
+
+    name: str            # alias name, e.g. "QubitPair"
+    definition: str      # raw type expression, e.g. "(Qubit, Qubit)"
+
+    def to_dict(self) -> dict:
+        """Return a CBOR-compatible dict representation (schema v0.3+)."""
+        return {"_tag": self.CBOR_TAG, "name": self.name, "definition": self.definition}
+
+
+@dataclass
 class EhrenfestAST:
     """Root AST node for a parsed .ef program."""
     name: str
@@ -66,6 +89,7 @@ class EhrenfestAST:
     measures: List[Measure]
     conditionals: List[ConditionalGate]
     expects: List[Expect]
+    type_decls: List["TypeDecl"] = field(default_factory=list)
 
 
 # ── Tokenisation helpers ───────────────────────────────────────────────────────
@@ -147,9 +171,49 @@ def parse(source: str) -> EhrenfestAST:
         except StopIteration:
             raise ParseError(f"unexpected end of file while expecting {expect_what}")
 
+    def _parse_type_decl(lineno: int, toks: List[str]) -> TypeDecl:
+        """Parse ``type NAME = TYPE_EXPR`` and return a :class:`TypeDecl`."""
+        # toks[0] == "type"; toks[1] == NAME; toks[2] == "="; toks[3:] == type expr
+        if len(toks) < 2:
+            raise ParseError(
+                f"line {lineno}: 'type' syntax: type NAME = TYPE_EXPR"
+            )
+        type_name = toks[1]
+        if not type_name.isidentifier():
+            raise ParseError(
+                f"line {lineno}: 'type' name must be a valid identifier, got {type_name!r}"
+            )
+        if len(toks) < 3 or toks[2] != "=":
+            got = toks[2] if len(toks) >= 3 else "<end of line>"
+            raise ParseError(
+                f"line {lineno}: 'type' declaration expects '=', got {got!r}"
+            )
+        # Reconstruct the definition from remaining tokens
+        definition = " ".join(toks[3:])
+        if not definition:
+            raise ParseError(f"line {lineno}: 'type' declaration requires a type expression")
+        return TypeDecl(name=type_name, definition=definition)
+
+    # ── Pre-header: collect type declarations ─────────────────────────────────
+
+    type_decls: List[TypeDecl] = []
+    peeked: Optional[Tuple[int, List[str]]] = None
+
+    for lineno, toks in it:
+        kw = toks[0].lower()
+        if kw == "type":
+            type_decls.append(_parse_type_decl(lineno, toks))
+        else:
+            peeked = (lineno, toks)
+            break
+
     # ── Header ────────────────────────────────────────────────────────────────
 
-    lineno, toks = _next_line("'program' declaration")
+    if peeked is not None:
+        lineno, toks = peeked
+    else:
+        lineno, toks = _next_line("'program' declaration")
+
     if toks[0].lower() != "program":
         raise ParseError(f"line {lineno}: expected 'program', got {toks[0]!r}")
     if len(toks) < 2:
@@ -281,6 +345,10 @@ def parse(source: str) -> EhrenfestAST:
 
             gates.append(Gate(name=gate_name, qubits=qubit_indices, params=params))
 
+        elif kw == "type":
+            # type declarations may also appear inside the program body
+            type_decls.append(_parse_type_decl(lineno, toks))
+
         else:
             raise ParseError(f"line {lineno}: unknown directive {toks[0]!r}")
 
@@ -292,6 +360,7 @@ def parse(source: str) -> EhrenfestAST:
         measures=measures,
         conditionals=conditionals,
         expects=expects,
+        type_decls=type_decls,
     )
 
 

--- a/afana/tests/test_parser.py
+++ b/afana/tests/test_parser.py
@@ -2,7 +2,7 @@
 
 import pytest
 from afana.parser import (
-    EhrenfestAST, Gate, Measure, Expect,
+    EhrenfestAST, Gate, Measure, Expect, TypeDecl,
     ParseError, parse, parse_file,
 )
 
@@ -241,3 +241,107 @@ def test_parse_file_examples(tmp_path):
         ast = parse_file(ef)
         assert ast.n_qubits >= 1
         assert ast.name  # non-empty
+
+
+# ── Type declarations ─────────────────────────────────────────────────────────
+
+def test_type_decl_simple():
+    """A single type alias before the program header is collected."""
+    src = _src(
+        "type AngleRad = Float",
+        'program "p"',
+        "qubits 1",
+    )
+    ast = parse(src)
+    assert len(ast.type_decls) == 1
+    td = ast.type_decls[0]
+    assert td.name == "AngleRad"
+    assert td.definition == "Float"
+
+
+def test_type_decl_tuple():
+    """Tuple type expressions are preserved verbatim."""
+    src = _src(
+        "type QubitPair = ( Qubit Qubit )",
+        'program "p"',
+        "qubits 2",
+    )
+    ast = parse(src)
+    assert len(ast.type_decls) == 1
+    assert ast.type_decls[0].name == "QubitPair"
+    assert ast.type_decls[0].definition == "( Qubit Qubit )"
+
+
+def test_type_decl_multiple():
+    """Three or more type declarations are all collected (acceptance criterion)."""
+    src = _src(
+        "type QubitPair = ( Qubit Qubit )",
+        "type QubitTriple = ( Qubit Qubit Qubit )",
+        "type AngleRad = Float",
+        'program "types-demo"',
+        "qubits 3",
+        "h q0",
+        "cnot q0 q1",
+        "cnot q0 q2",
+    )
+    ast = parse(src)
+    assert isinstance(ast, EhrenfestAST)
+    assert len(ast.type_decls) == 3
+    names = [td.name for td in ast.type_decls]
+    assert names == ["QubitPair", "QubitTriple", "AngleRad"]
+
+
+def test_type_decl_cbor_tag():
+    """TypeDecl.to_dict() returns a CBOR-compatible dict with the schema v0.3+ tag."""
+    td = TypeDecl(name="QubitPair", definition="( Qubit Qubit )")
+    d = td.to_dict()
+    assert d["_tag"] == "quasi.org/ast/type-alias"
+    assert d["name"] == "QubitPair"
+    assert d["definition"] == "( Qubit Qubit )"
+
+
+def test_type_decl_no_decls_gives_empty_list():
+    """Programs without type declarations have an empty type_decls list."""
+    src = _src('program "p"', "qubits 1")
+    ast = parse(src)
+    assert ast.type_decls == []
+
+
+def test_type_decl_in_body():
+    """Type declarations inside the program body (after qubits) are also parsed."""
+    src = _src(
+        'program "p"',
+        "qubits 1",
+        "type Angle = Float",
+        "h q0",
+    )
+    ast = parse(src)
+    assert len(ast.type_decls) == 1
+    assert ast.type_decls[0].name == "Angle"
+    assert len(ast.gates) == 1
+
+
+def test_type_decl_missing_equals():
+    """Missing '=' in type declaration raises ParseError."""
+    with pytest.raises(ParseError, match="'type' declaration expects '='"):
+        # 4 tokens but wrong separator: "type Foo Bar Baz" -> toks[2]=="Bar" != "="
+        parse(_src("type Foo Bar Baz", 'program "p"', "qubits 1"))
+
+
+def test_type_decl_missing_expression():
+    """Type declaration without a type expression raises ParseError."""
+    with pytest.raises(ParseError, match="'type' declaration requires a type expression"):
+        parse(_src("type Foo =", 'program "p"', "qubits 1"))
+
+
+def test_parse_types_ef_example():
+    """examples/types.ef parses to a valid TypedAST with 3 type declarations."""
+    import pathlib
+    types_ef = pathlib.Path(__file__).parent.parent.parent / "examples" / "types.ef"
+    ast = parse_file(types_ef)
+    assert isinstance(ast, EhrenfestAST)
+    assert len(ast.type_decls) >= 3
+    names = [td.name for td in ast.type_decls]
+    assert "QubitPair" in names
+    assert "QubitTriple" in names
+    assert "AngleRad" in names

--- a/examples/types.ef
+++ b/examples/types.ef
@@ -1,0 +1,23 @@
+// Ehrenfest type declarations example
+// Demonstrates user-defined type aliases (schema v0.3+)
+
+// Type aliases declared before the program header
+type QubitPair = ( Qubit Qubit )
+type QubitTriple = ( Qubit Qubit Qubit )
+type AngleRad = Float
+
+program "types-demo"
+qubits 3
+prepare basis |000>
+
+// Entangle all three qubits
+h q0
+cnot q0 q1
+cnot q0 q2
+
+measure q0 -> c0
+measure q1 -> c1
+measure q2 -> c2
+
+expect state "(|000> + |111>) / sqrt(2)"
+expect counts "000,111"


### PR DESCRIPTION
## Summary

- Adds `TypeDecl` AST node with `CBOR_TAG = "quasi.org/ast/type-alias"` and `to_dict()` serialisation (CBOR schema v0.3+)
- Extends parser grammar to handle `type NAME = TYPE_EXPR` syntax both before the program header and in the body
- Creates `examples/types.ef` with `QubitPair`, `QubitTriple`, and `AngleRad` type declarations (satisfying the 3+ requirement)
- Exports `TypeDecl` from `afana` package

## Test plan

- [x] `test_type_decl_simple` — single alias before header
- [x] `test_type_decl_tuple` — tuple type expression preserved verbatim
- [x] `test_type_decl_multiple` — 3+ declarations collected (acceptance criterion)
- [x] `test_type_decl_cbor_tag` — `to_dict()` returns correct `_tag` / `name` / `definition`
- [x] `test_type_decl_no_decls_gives_empty_list` — backwards-compatible empty list
- [x] `test_type_decl_in_body` — declarations inside program body also parsed
- [x] `test_type_decl_missing_equals` — parse error on malformed declaration
- [x] `test_type_decl_missing_expression` — parse error when RHS is absent
- [x] `test_parse_types_ef_example` — parses `examples/types.ef` to a valid `EhrenfestAST` with 3 named aliases

All 33 tests pass; flake8 clean (max-line-length=120).

Closes #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)