### PR TITLE
feat(afana): variational loop support in Ehrenfest AST for VQE/QAOA

### DIFF
--- a/afana/__init__.py
+++ b/afana/__init__.py
@@ -16,7 +16,11 @@ from .noise_model import (
 )
 from .optimize import optimize_qasm, optimize_qasm_with_stats
 from .parametric import ParametricCompileError, bind_parameters, compile_parametric
-from .parser import ConditionalGate, EhrenfestAST, Gate, Measure, Expect, TypeDecl, ParseError, parse, parse_file
+from .parser import (
+    ConditionalGate, EhrenfestAST, Gate, Measure, Expect,
+    TypeDecl, VariationalGate, VariationalLoop,
+    ParseError, parse, parse_file,
+)
 from .phase_kickback import phase_kickback
 
 __all__ = [
@@ -48,6 +52,8 @@ __all__ = [
     "Measure",
     "Expect",
     "TypeDecl",
+    "VariationalGate",
+    "VariationalLoop",
     "ParseError",
     "parse",
     "parse_file",

--- a/afana/parser.py
+++ b/afana/parser.py
@@ -5,11 +5,15 @@ Grammar summary (v0.2):
   type_decl ::= 'type' NAME '=' type_expr
   type_expr ::= NAME | '(' NAME (',' NAME)* ')'
   header   ::= 'program' STRING 'qubits' INT ('prepare' 'basis' STATE)?
-  stmt     ::= gate_stmt | measure_stmt | expect_stmt | comment
-  gate_stmt    ::= GATE qubit_list
-  measure_stmt ::= 'measure' QUBIT '->' CBIT
-  expect_stmt  ::= 'expect' ('state' | 'counts') STRING
-  comment  ::= '//' REST_OF_LINE
+  stmt     ::= gate_stmt | measure_stmt | expect_stmt | variational_block | comment
+  gate_stmt       ::= GATE qubit_list
+  measure_stmt    ::= 'measure' QUBIT '->' CBIT
+  expect_stmt     ::= 'expect' ('state' | 'counts') STRING
+  variational_block ::= 'variational' 'params' NAME+ ['max_iter' INT]
+                        vgate_stmt*
+                        'end'
+  vgate_stmt      ::= GATE (NAME | FLOAT)* QUBIT+
+  comment         ::= '//' REST_OF_LINE
 
 Supported gates (case-insensitive): h, x, y, z, s, t, sdg, tdg,
   cx / cnot, cz, swap, ccx / toffoli, rx, ry, rz.
@@ -80,6 +84,75 @@ class TypeDecl:
 
 
 @dataclass
+class VariationalGate:
+    """A gate inside a variational loop with symbolic (named) parameters.
+
+    E.g. ``rx theta q0`` where ``theta`` is a variational parameter name.
+    ``param_refs`` contains either parameter names (str) or resolved float values.
+    """
+    name: str               # lower-cased gate name, e.g. "rx"
+    qubits: List[int]       # qubit indices
+    param_refs: List[str]   # parameter names, e.g. ["theta"]
+
+
+@dataclass
+class VariationalLoop:
+    """A variational optimisation block (VQE/QAOA ansatz).
+
+    Syntax::
+
+        variational params theta phi max_iter 100
+          rx theta q0
+          ry phi q1
+          cnot q0 q1
+        end
+
+    The block compiles to a QASM3 circuit that accepts ``input float[64]``
+    parameters so that a classical optimizer can drive repeated execution.
+    """
+    params: List[str]         # ordered parameter names, e.g. ["theta", "phi"]
+    max_iter: int             # maximum optimisation iterations (hint only)
+    body: List[VariationalGate]  # gate sequence within the ansatz
+
+    def to_qasm3(self, n_qubits: int) -> str:
+        """Emit an OpenQASM 3.0 snippet for this variational ansatz.
+
+        The emitted QASM uses ``input float[64]`` declarations for each
+        parameter so that a classical optimizer loop can re-submit the circuit
+        with updated parameter values.
+        """
+        _GATE_QASM3 = {
+            "cx": "cx", "cnot": "cx", "cz": "cz", "swap": "swap",
+            "ccx": "ccx", "toffoli": "ccx",
+            "h": "h", "x": "x", "y": "y", "z": "z",
+            "s": "s", "t": "t", "sdg": "sdg", "tdg": "tdg",
+            "rx": "rx", "ry": "ry", "rz": "rz",
+        }
+
+        lines = [
+            "OPENQASM 3.0;",
+            'include "stdgates.inc";',
+            "",
+            f"// Variational ansatz — max_iter={self.max_iter} (classical loop managed by caller)",
+        ]
+        for p in self.params:
+            lines.append(f"input float[64] {p};")
+        lines.append("")
+        lines.append(f"qubit[{n_qubits}] q;")
+        lines.append(f"bit[{n_qubits}] c;")
+        lines.append("")
+        for vg in self.body:
+            gname = _GATE_QASM3.get(vg.name, vg.name)
+            qubit_args = ", ".join(f"q[{idx}]" for idx in vg.qubits)
+            if vg.param_refs:
+                param_args = ", ".join(vg.param_refs)
+                lines.append(f"{gname}({param_args}) {qubit_args};")
+            else:
+                lines.append(f"{gname} {qubit_args};")
+        return "\n".join(lines)
+
+
+@dataclass
 class EhrenfestAST:
     """Root AST node for a parsed .ef program."""
     name: str
@@ -90,6 +163,7 @@ class EhrenfestAST:
     conditionals: List[ConditionalGate]
     expects: List[Expect]
     type_decls: List["TypeDecl"] = field(default_factory=list)
+    variational_loops: List["VariationalLoop"] = field(default_factory=list)
 
 
 # ── Tokenisation helpers ───────────────────────────────────────────────────────
@@ -101,6 +175,7 @@ _GATE_RE = re.compile(
 _QUBIT_RE = re.compile(r"^q(\d+)$", re.IGNORECASE)
 _CBIT_RE = re.compile(r"^c(\d+)$", re.IGNORECASE)
 _FLOAT_RE = re.compile(r"^-?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?(pi)?$", re.IGNORECASE)
+_PARAM_NAME_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 
 
 def _parse_qubit(token: str, lineno: int) -> int:
@@ -236,6 +311,83 @@ def parse(source: str) -> EhrenfestAST:
     measures: List[Measure] = []
     conditionals: List[ConditionalGate] = []
     expects: List[Expect] = []
+    variational_loops: List[VariationalLoop] = []
+
+    def _parse_variational_block(header_lineno: int, header_toks: List[str]) -> VariationalLoop:
+        """Parse a ``variational params … [max_iter N]`` block, consuming until ``end``."""
+        # header_toks: ["variational", "params", name1, name2, ..., ["max_iter", N]]
+        if len(header_toks) < 2 or header_toks[1].lower() != "params":
+            raise ParseError(
+                f"line {header_lineno}: 'variational' syntax: "
+                "variational params NAME+ [max_iter INT]"
+            )
+        rest = header_toks[2:]
+        max_iter = 100  # default
+        params: List[str] = []
+        i = 0
+        while i < len(rest):
+            tok = rest[i]
+            if tok.lower() == "max_iter":
+                if i + 1 >= len(rest) or not rest[i + 1].isdigit():
+                    raise ParseError(
+                        f"line {header_lineno}: 'max_iter' must be followed by a positive integer"
+                    )
+                max_iter = int(rest[i + 1])
+                i += 2
+            elif _PARAM_NAME_RE.match(tok) and not _QUBIT_RE.match(tok) and not _CBIT_RE.match(tok):
+                params.append(tok)
+                i += 1
+            else:
+                raise ParseError(
+                    f"line {header_lineno}: unexpected token in 'variational' header: {tok!r}"
+                )
+        if not params:
+            raise ParseError(
+                f"line {header_lineno}: 'variational' block requires at least one parameter name"
+            )
+
+        # Collect body lines until 'end'
+        body: List[VariationalGate] = []
+        for body_lineno, body_toks in it:
+            bkw = body_toks[0].lower()
+            if bkw == "end":
+                return VariationalLoop(params=params, max_iter=max_iter, body=body)
+            if not _GATE_RE.match(bkw):
+                raise ParseError(
+                    f"line {body_lineno}: variational body expects a gate or 'end', got {body_toks[0]!r}"
+                )
+            vgate_name = bkw
+            if vgate_name == "cnot":
+                vgate_name = "cx"
+            if vgate_name == "toffoli":
+                vgate_name = "ccx"
+            # Tokens after gate name: mix of param names and qubit refs
+            param_refs: List[str] = []
+            qubit_indices_vg: List[int] = []
+            for tok in body_toks[1:]:
+                if _QUBIT_RE.match(tok):
+                    idx = _parse_qubit(tok, body_lineno)
+                    if idx >= n_qubits:
+                        raise ParseError(
+                            f"line {body_lineno}: qubit q{idx} out of range (n_qubits={n_qubits})"
+                        )
+                    qubit_indices_vg.append(idx)
+                elif _PARAM_NAME_RE.match(tok):
+                    param_refs.append(tok)
+                elif _FLOAT_RE.match(tok):
+                    param_refs.append(tok)  # literal float — kept as-is
+                else:
+                    raise ParseError(
+                        f"line {body_lineno}: unexpected token in variational gate: {tok!r}"
+                    )
+            if not qubit_indices_vg:
+                raise ParseError(
+                    f"line {body_lineno}: variational gate {body_toks[0]!r} requires at least one qubit"
+                )
+            body.append(VariationalGate(name=vgate_name, qubits=qubit_indices_vg, param_refs=param_refs))
+        raise ParseError(
+            f"line {header_lineno}: 'variational' block opened here is never closed with 'end'"
+        )
 
     for lineno, toks in it:
         kw = toks[0].lower()
@@ -349,6 +501,9 @@ def parse(source: str) -> EhrenfestAST:
             # type declarations may also appear inside the program body
             type_decls.append(_parse_type_decl(lineno, toks))
 
+        elif kw == "variational":
+            variational_loops.append(_parse_variational_block(lineno, toks))
+
         else:
             raise ParseError(f"line {lineno}: unknown directive {toks[0]!r}")
 
@@ -361,6 +516,7 @@ def parse(source: str) -> EhrenfestAST:
         conditionals=conditionals,
         expects=expects,
         type_decls=type_decls,
+        variational_loops=variational_loops,
     )
 
 

--- a/afana/tests/test_parser.py
+++ b/afana/tests/test_parser.py
@@ -3,6 +3,7 @@
 import pytest
 from afana.parser import (
     EhrenfestAST, Gate, Measure, Expect, TypeDecl,
+    VariationalGate, VariationalLoop,
     ParseError, parse, parse_file,
 )
 
@@ -345,3 +346,156 @@ def test_parse_types_ef_example():
     assert "QubitPair" in names
     assert "QubitTriple" in names
     assert "AngleRad" in names
+
+
+# ── Variational loops ─────────────────────────────────────────────────────────
+
+def test_variational_loop_basic():
+    """A simple variational block is parsed into a VariationalLoop AST node."""
+    src = _src(
+        'program "vqe"',
+        "qubits 2",
+        "variational params theta phi max_iter 50",
+        "  ry theta q0",
+        "  ry phi q1",
+        "  cnot q0 q1",
+        "end",
+    )
+    ast = parse(src)
+    assert isinstance(ast, EhrenfestAST)
+    assert len(ast.variational_loops) == 1
+    vl = ast.variational_loops[0]
+    assert isinstance(vl, VariationalLoop)
+    assert vl.params == ["theta", "phi"]
+    assert vl.max_iter == 50
+    assert len(vl.body) == 3
+
+
+def test_variational_loop_body_gates():
+    """Body gates have correct names, qubits, and param_refs."""
+    src = _src(
+        'program "vqe"',
+        "qubits 2",
+        "variational params theta phi max_iter 100",
+        "  ry theta q0",
+        "  ry phi q1",
+        "  cnot q0 q1",
+        "end",
+    )
+    ast = parse(src)
+    vl = ast.variational_loops[0]
+    ry0, ry1, cnot = vl.body
+    assert isinstance(ry0, VariationalGate)
+    assert ry0.name == "ry"
+    assert ry0.qubits == [0]
+    assert ry0.param_refs == ["theta"]
+    assert ry1.name == "ry"
+    assert ry1.qubits == [1]
+    assert ry1.param_refs == ["phi"]
+    assert cnot.name == "cx"   # normalised
+    assert cnot.qubits == [0, 1]
+    assert cnot.param_refs == []
+
+
+def test_variational_loop_default_max_iter():
+    """max_iter defaults to 100 when not specified."""
+    src = _src(
+        'program "p"',
+        "qubits 1",
+        "variational params alpha",
+        "  rx alpha q0",
+        "end",
+    )
+    ast = parse(src)
+    assert ast.variational_loops[0].max_iter == 100
+
+
+def test_variational_loop_to_qasm3():
+    """VariationalLoop.to_qasm3() emits valid QASM3 with input float declarations."""
+    vl = VariationalLoop(
+        params=["theta", "phi"],
+        max_iter=100,
+        body=[
+            VariationalGate(name="ry", qubits=[0], param_refs=["theta"]),
+            VariationalGate(name="ry", qubits=[1], param_refs=["phi"]),
+            VariationalGate(name="cx", qubits=[0, 1], param_refs=[]),
+        ],
+    )
+    qasm3 = vl.to_qasm3(n_qubits=2)
+    assert "OPENQASM 3.0;" in qasm3
+    assert "input float[64] theta;" in qasm3
+    assert "input float[64] phi;" in qasm3
+    assert "ry(theta) q[0];" in qasm3
+    assert "ry(phi) q[1];" in qasm3
+    assert "cx q[0], q[1];" in qasm3
+
+
+def test_variational_loop_no_loops_gives_empty_list():
+    """Programs without variational blocks have an empty variational_loops list."""
+    src = _src('program "p"', "qubits 1", "h q0")
+    ast = parse(src)
+    assert ast.variational_loops == []
+
+
+def test_variational_loop_and_regular_gates_coexist():
+    """Variational blocks and regular gates coexist in the same program."""
+    src = _src(
+        'program "hybrid"',
+        "qubits 2",
+        "h q0",
+        "variational params theta max_iter 10",
+        "  rx theta q1",
+        "end",
+        "measure q0 -> c0",
+    )
+    ast = parse(src)
+    assert len(ast.gates) == 1
+    assert ast.gates[0].name == "h"
+    assert len(ast.variational_loops) == 1
+    assert len(ast.measures) == 1
+
+
+def test_variational_loop_missing_end():
+    """Unclosed variational block raises ParseError."""
+    with pytest.raises(ParseError, match="never closed with 'end'"):
+        parse(_src(
+            'program "p"',
+            "qubits 1",
+            "variational params theta",
+            "  rx theta q0",
+        ))
+
+
+def test_variational_loop_missing_params_keyword():
+    """variational without 'params' keyword raises ParseError."""
+    with pytest.raises(ParseError, match="'variational' syntax"):
+        parse(_src(
+            'program "p"',
+            "qubits 1",
+            "variational theta phi",
+            "end",
+        ))
+
+
+def test_variational_loop_empty_params():
+    """variational params with no parameter names raises ParseError."""
+    with pytest.raises(ParseError, match="requires at least one parameter"):
+        parse(_src(
+            'program "p"',
+            "qubits 1",
+            "variational params",
+            "  h q0",
+            "end",
+        ))
+
+
+def test_parse_vqe_example():
+    """examples/vqe.ef parses to a valid AST with one variational loop."""
+    import pathlib
+    vqe_ef = pathlib.Path(__file__).parent.parent.parent / "examples" / "vqe.ef"
+    ast = parse_file(vqe_ef)
+    assert isinstance(ast, EhrenfestAST)
+    assert len(ast.variational_loops) == 1
+    vl = ast.variational_loops[0]
+    assert "theta" in vl.params
+    assert "phi" in vl.params

--- a/examples/vqe.ef
+++ b/examples/vqe.ef
@@ -1,0 +1,17 @@
+// VQE ansatz — 2-qubit Ry-CNOT variational circuit
+// Parameters theta and phi are optimized by a classical optimizer (e.g. COBYLA).
+// The variational block emits QASM3 with `input float[64]` parameter declarations.
+
+program "vqe-ansatz"
+qubits 2
+
+variational params theta phi max_iter 100
+  ry theta q0
+  ry phi q1
+  cnot q0 q1
+end
+
+measure q0 -> c0
+measure q1 -> c1
+
+expect counts "00,11"


### PR DESCRIPTION
## Summary

- Adds `VariationalGate` and `VariationalLoop` AST nodes to `parser.py`
- Extends the `.ef` grammar (v0.2) with a `variational params … end` block for expressing VQE/QAOA ansätze with symbolic parameters
- `VariationalLoop.to_qasm3()` emits valid OpenQASM 3.0 with `input float[64]` parameter declarations so that a classical optimizer (e.g. COBYLA) can drive repeated circuit execution on IBM or other backends
- Adds `examples/vqe.ef` — 2-qubit Ry-CNOT ansatz with `theta` / `phi` parameters
- Exports `VariationalGate` and `VariationalLoop` from `afana` package

## Test plan

- [x] `test_variational_loop_basic` — block parsed into `VariationalLoop` node
- [x] `test_variational_loop_body_gates` — gate names, qubits, and param_refs correct (including `cnot→cx` normalisation)
- [x] `test_variational_loop_default_max_iter` — defaults to 100 iterations
- [x] `test_variational_loop_to_qasm3` — QASM3 output contains `OPENQASM 3.0;`, `input float[64]` per parameter, and correct gate calls
- [x] `test_variational_loop_no_loops_gives_empty_list` — backwards-compatible
- [x] `test_variational_loop_and_regular_gates_coexist` — hybrid programs work
- [x] `test_variational_loop_missing_end` — unclosed block → `ParseError`
- [x] `test_variational_loop_missing_params_keyword` — wrong syntax → `ParseError`
- [x] `test_variational_loop_empty_params` — no params → `ParseError`
- [x] `test_parse_vqe_example` — `examples/vqe.ef` parses with theta/phi params

All 34 tests pass; flake8 clean (max-line-length=120).

Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)