### PR TITLE
feat(afana): error mitigation wrapper for IBM backend executions

### DIFF
--- a/afana/backends/__init__.py
+++ b/afana/backends/__init__.py
@@ -1,5 +1,21 @@
 """Backend-specific Afana compilation paths."""
 
-from .ibm import EhrenfestProgram, ehrenfest_to_ibm
+from .error_mitigation import (
+    MeasurementErrorMitigation,
+    MitigationStrategy,
+    RandomizedCompiling,
+    available_strategies,
+    mitigate,
+)
+from .ibm import EhrenfestProgram, ehrenfest_to_ibm, transpile_for_ibm
 
-__all__ = ["EhrenfestProgram", "ehrenfest_to_ibm"]
+__all__ = [
+    "EhrenfestProgram",
+    "ehrenfest_to_ibm",
+    "transpile_for_ibm",
+    "MitigationStrategy",
+    "MeasurementErrorMitigation",
+    "RandomizedCompiling",
+    "mitigate",
+    "available_strategies",
+]

--- a/afana/backends/error_mitigation.py
+++ b/afana/backends/error_mitigation.py
@@ -1,0 +1,314 @@
+"""Error mitigation strategies for IBM backend executions.
+
+Two strategies are provided:
+
+1. **MeasurementErrorMitigation** — applies a calibration-matrix correction to
+   raw measurement counts, compensating for qubit readout errors.
+
+2. **RandomizedCompiling** — performs Pauli twirling around CNOT gates, inserting
+   random conjugate Pauli pairs before and after each two-qubit gate to convert
+   coherent gate errors into stochastic Pauli noise (which is more tractable for
+   error-correction decoders and reduces systematic bias in expectation values).
+
+Both strategies operate on OpenQASM 2.0 source and/or raw shot-count dicts so
+that they integrate cleanly with the Afana ZX-IR pipeline without requiring Qiskit
+at import time.
+
+No external dependencies — stdlib only.
+"""
+from __future__ import annotations
+
+import random
+import re
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+
+# ── Base ──────────────────────────────────────────────────────────────────────
+
+class MitigationStrategy(ABC):
+    """Abstract base for error mitigation strategies."""
+
+    @abstractmethod
+    def apply(self, qasm: str) -> str:
+        """Return a modified (or instrumented) QASM string."""
+
+    @abstractmethod
+    def description(self) -> str:
+        """Human-readable description of the strategy."""
+
+
+# ── Strategy 1: Measurement Error Mitigation ─────────────────────────────────
+
+class MeasurementErrorMitigation(MitigationStrategy):
+    """Correct raw measurement counts using a per-qubit calibration matrix.
+
+    The calibration matrix ``A`` is a 2×2 matrix where ``A[i, j]`` is the
+    empirical probability of measuring outcome *i* when qubit was prepared in
+    state *j*::
+
+        A = [[P(0|0), P(0|1)],
+             [P(1|0), P(1|1)]]
+
+    The corrected quasi-probability vector is obtained by applying the
+    pseudo-inverse of the tensor-product calibration matrix to the raw counts.
+
+    For multi-qubit systems the per-qubit matrices are tensor-producted.
+
+    Parameters
+    ----------
+    calibration:
+        Optional dict mapping qubit index → 2×2 calibration matrix
+        (as a list-of-lists).  When ``None`` an identity calibration is used
+        (no correction applied).
+    """
+
+    def __init__(self, calibration: Optional[Dict[int, List[List[float]]]] = None) -> None:
+        self.calibration = calibration or {}
+
+    # ── Classical post-processing ────────────────────────────────────────────
+
+    @staticmethod
+    def _invert_2x2(m: List[List[float]]) -> List[List[float]]:
+        """Return the inverse of a 2×2 matrix, raising ValueError if singular."""
+        det = m[0][0] * m[1][1] - m[0][1] * m[1][0]
+        if abs(det) < 1e-12:
+            raise ValueError("Calibration matrix is singular — cannot invert")
+        inv_det = 1.0 / det
+        return [
+            [m[1][1] * inv_det, -m[0][1] * inv_det],
+            [-m[1][0] * inv_det, m[0][0] * inv_det],
+        ]
+
+    @staticmethod
+    def _tensor_product(a: List[List[float]], b: List[List[float]]) -> List[List[float]]:
+        """Compute the Kronecker (tensor) product of two matrices."""
+        ra, ca = len(a), len(a[0])
+        rb, cb = len(b), len(b[0])
+        result: List[List[float]] = [
+            [0.0] * (ca * cb) for _ in range(ra * rb)
+        ]
+        for i in range(ra):
+            for j in range(ca):
+                for k in range(rb):
+                    for ll in range(cb):
+                        result[i * rb + k][j * cb + ll] = a[i][j] * b[k][ll]
+        return result
+
+    @staticmethod
+    def _matvec(m: List[List[float]], v: List[float]) -> List[float]:
+        """Multiply matrix *m* by column vector *v*."""
+        return [sum(m[i][j] * v[j] for j in range(len(v))) for i in range(len(m))]
+
+    def correct_counts(self, counts: Dict[str, int], n_qubits: int) -> Dict[str, float]:
+        """Return corrected quasi-probability counts.
+
+        Parameters
+        ----------
+        counts:
+            Raw shot counts, e.g. ``{"00": 480, "11": 520}``.
+        n_qubits:
+            Number of measured qubits (determines bitstring width).
+
+        Returns
+        -------
+        dict
+            Corrected quasi-probabilities (may be negative due to inversion).
+            Sum is normalised to match the total shot count.
+        """
+        dim = 2 ** n_qubits
+        total = sum(counts.values()) or 1
+
+        # Build the full calibration matrix (tensor product of per-qubit matrices).
+        identity = [[1.0, 0.0], [0.0, 1.0]]
+        cal_matrix: List[List[float]] = [[1.0]]  # 1×1 identity to start
+        for q in range(n_qubits):
+            per_qubit = self.calibration.get(q, identity)
+            cal_matrix = self._tensor_product(cal_matrix, per_qubit)
+
+        inv_cal = self._invert_2x2(cal_matrix) if n_qubits == 1 else self._invert_nxn(cal_matrix)
+
+        # Convert counts to a probability vector (little-endian bitstring ordering).
+        raw_vec = [0.0] * dim
+        for bitstring, cnt in counts.items():
+            idx = int(bitstring, 2)
+            raw_vec[idx] = cnt / total
+
+        corrected_vec = self._matvec(inv_cal, raw_vec)
+
+        # Convert back to counts-like dict.
+        return {
+            format(i, f"0{n_qubits}b"): corrected_vec[i] * total
+            for i in range(dim)
+        }
+
+    @staticmethod
+    def _invert_nxn(m: List[List[float]]) -> List[List[float]]:
+        """Invert an n×n matrix via Gaussian elimination with partial pivoting."""
+        n = len(m)
+        aug = [[m[i][j] for j in range(n)] + [1.0 if i == j else 0.0 for j in range(n)]
+               for i in range(n)]
+        for col in range(n):
+            # Partial pivot
+            pivot = max(range(col, n), key=lambda r: abs(aug[r][col]))
+            aug[col], aug[pivot] = aug[pivot], aug[col]
+            if abs(aug[col][col]) < 1e-12:
+                raise ValueError("Calibration matrix is singular — cannot invert")
+            scale = aug[col][col]
+            aug[col] = [x / scale for x in aug[col]]
+            for row in range(n):
+                if row != col:
+                    factor = aug[row][col]
+                    aug[row] = [aug[row][j] - factor * aug[col][j] for j in range(2 * n)]
+        return [[aug[i][n + j] for j in range(n)] for i in range(n)]
+
+    # ── QASM instrumentation ─────────────────────────────────────────────────
+
+    def apply(self, qasm: str) -> str:
+        """Return QASM with calibration-annotation comments injected.
+
+        In a live execution workflow the QASM is unchanged; post-processing
+        (``correct_counts``) is applied to the result histogram instead.
+        This method records the calibration metadata as comments so that the
+        provenance is captured inside the QASM artefact.
+        """
+        qubit_indices = sorted(self.calibration.keys())
+        annotation = "// MeasurementErrorMitigation applied"
+        if qubit_indices:
+            annotation += f" — calibrated qubits: {qubit_indices}"
+        return annotation + "\n" + qasm
+
+    def description(self) -> str:
+        return (
+            "MeasurementErrorMitigation: invert per-qubit calibration matrix "
+            "to remove readout-assignment errors from shot counts"
+        )
+
+
+# ── Strategy 2: Randomized Compiling (Pauli Twirling) ────────────────────────
+
+# Twirling table for CNOT_{control, target}.
+# Each entry is (pre_control, pre_target, post_control, post_target).
+# The Pauli pairs satisfy:
+#   (P_c ⊗ P_t) · CNOT · (Q_c ⊗ Q_t) = CNOT  (up to global phase)
+#
+# Derived from the relation CNOT · (A ⊗ B) · CNOT = (A·Z^b ⊗ X^a·B)
+# where a = bit-action of A on control and b = phase-action of B on target.
+_CNOT_TWIRL_TABLE: List[Tuple[str, str, str, str]] = [
+    ("i",  "i",  "i",  "i"),
+    ("x",  "i",  "x",  "x"),
+    ("y",  "i",  "y",  "x"),
+    ("z",  "i",  "z",  "i"),
+    ("i",  "x",  "i",  "x"),
+    ("x",  "x",  "x",  "i"),
+    ("y",  "x",  "y",  "i"),
+    ("z",  "x",  "z",  "x"),
+    ("i",  "z",  "z",  "z"),
+    ("x",  "z",  "y",  "z"),  # up to phase
+    ("y",  "z",  "x",  "z"),  # up to phase
+    ("z",  "z",  "i",  "z"),
+    ("i",  "y",  "z",  "y"),
+    ("x",  "y",  "y",  "y"),
+    ("y",  "y",  "x",  "y"),
+    ("z",  "y",  "i",  "y"),
+]
+
+# Regex to match a CNOT / CX gate line and capture control/target qubit refs.
+_CNOT_RE = re.compile(
+    r"^(cx|cnot)\s+(q\[\d+\])\s*,\s*(q\[\d+\])\s*;$",
+    re.IGNORECASE,
+)
+
+
+class RandomizedCompiling(MitigationStrategy):
+    """Apply Pauli twirling around CNOT gates to convert coherent gate errors
+    into stochastic Pauli noise.
+
+    For each CNOT gate in the circuit a random Pauli pair from the CNOT twirling
+    group is inserted before the gate and the conjugate compensating Pauli pair
+    is inserted after, so that the net logical operation is unchanged.  When
+    averaged over many shots with different random seeds the coherent part of
+    any CNOT error channel is projected out, leaving only a Pauli channel that
+    is amenable to standard error-correction techniques.
+
+    Parameters
+    ----------
+    n_samples:
+        Number of randomized circuit variants to generate when
+        :meth:`generate_twirled_circuits` is called (default 10).
+    seed:
+        Optional RNG seed for reproducibility.
+    """
+
+    def __init__(self, n_samples: int = 10, seed: int | None = None) -> None:
+        self.n_samples = n_samples
+        self._rng = random.Random(seed)
+
+    def _twirl_qasm(self, qasm: str) -> str:
+        """Return a single Pauli-twirled variant of *qasm*."""
+        out_lines: List[str] = []
+        for raw_line in qasm.splitlines():
+            line = raw_line.strip()
+            m = _CNOT_RE.match(line)
+            if not m:
+                out_lines.append(raw_line)
+                continue
+
+            ctrl, tgt = m.group(2), m.group(3)
+            pre_c, pre_t, post_c, post_t = self._rng.choice(_CNOT_TWIRL_TABLE)
+
+            def _gate_line(gate: str, qubit: str) -> str | None:
+                if gate == "i":
+                    return None
+                return f"{gate} {qubit};"
+
+            for gl in [
+                _gate_line(pre_c, ctrl),
+                _gate_line(pre_t, tgt),
+                raw_line,
+                _gate_line(post_c, ctrl),
+                _gate_line(post_t, tgt),
+            ]:
+                if gl is not None:
+                    out_lines.append(gl)
+
+        return "\n".join(out_lines)
+
+    def apply(self, qasm: str) -> str:
+        """Return a single Pauli-twirled QASM circuit (one sample)."""
+        return self._twirl_qasm(qasm)
+
+    def generate_twirled_circuits(self, qasm: str) -> List[str]:
+        """Return *n_samples* independent twirled circuit variants."""
+        return [self._twirl_qasm(qasm) for _ in range(self.n_samples)]
+
+    def description(self) -> str:
+        return (
+            "RandomizedCompiling: Pauli twirling around CNOT gates converts "
+            "coherent gate errors into stochastic Pauli noise"
+        )
+
+
+# ── Convenience wrapper ───────────────────────────────────────────────────────
+
+def mitigate(
+    qasm: str,
+    strategies: Sequence[MitigationStrategy],
+) -> str:
+    """Apply a sequence of mitigation strategies to *qasm* in order.
+
+    Each strategy's :meth:`~MitigationStrategy.apply` is called in turn and
+    the result is fed into the next strategy.
+    """
+    result = qasm
+    for strategy in strategies:
+        result = strategy.apply(result)
+    return result
+
+
+def available_strategies() -> Dict[str, Any]:
+    """Return a mapping of strategy names to their classes."""
+    return {
+        "measurement_error_mitigation": MeasurementErrorMitigation,
+        "randomized_compiling": RandomizedCompiling,
+    }

--- a/afana/tests/test_error_mitigation.py
+++ b/afana/tests/test_error_mitigation.py
@@ -1,0 +1,187 @@
+"""Integration tests for afana.backends.error_mitigation.
+
+The tests verify both strategies without requiring real IBM hardware:
+- MeasurementErrorMitigation: calibration matrix inversion and count correction
+- RandomizedCompiling: Pauli-twirled circuit structure and idempotency
+"""
+from __future__ import annotations
+
+from afana.backends.error_mitigation import (
+    MeasurementErrorMitigation,
+    RandomizedCompiling,
+    MitigationStrategy,
+    mitigate,
+    available_strategies,
+)
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+_BELL_QASM = "\n".join([
+    "OPENQASM 2.0;",
+    'include "qelib1.inc";',
+    "qreg q[2];",
+    "creg c[2];",
+    "h q[0];",
+    "cx q[0],q[1];",
+    "measure q[0] -> c[0];",
+    "measure q[1] -> c[1];",
+])
+
+# Perfect calibration (identity — no readout error)
+_PERFECT_CAL = {0: [[1.0, 0.0], [0.0, 1.0]]}
+# Typical readout error: 2% flip probability
+_NOISY_CAL = {0: [[0.98, 0.02], [0.02, 0.98]]}
+
+
+# ── MeasurementErrorMitigation ─────────────────────────────────────────────────
+
+class TestMeasurementErrorMitigation:
+
+    def test_is_mitigation_strategy(self):
+        assert isinstance(MeasurementErrorMitigation(), MitigationStrategy)
+
+    def test_description_nonempty(self):
+        assert len(MeasurementErrorMitigation().description()) > 0
+
+    def test_apply_adds_annotation(self):
+        mem = MeasurementErrorMitigation(calibration=_NOISY_CAL)
+        annotated = mem.apply(_BELL_QASM)
+        assert "MeasurementErrorMitigation" in annotated
+        assert _BELL_QASM in annotated
+
+    def test_perfect_calibration_no_correction(self):
+        """Identity calibration matrix leaves counts unchanged."""
+        mem = MeasurementErrorMitigation(calibration=_PERFECT_CAL)
+        counts = {"0": 500, "1": 500}
+        corrected = mem.correct_counts(counts, n_qubits=1)
+        assert abs(corrected["0"] - 500.0) < 1e-6
+        assert abs(corrected["1"] - 500.0) < 1e-6
+
+    def test_noisy_calibration_improves_fidelity(self):
+        """With a biased readout, correction increases counts for |0> when it was over-counted."""
+        # Calibration: 98% chance of reading correctly, 2% flip.
+        # Simulate: prepared all |0>, but 2% are measured as |1|.
+        cal = {0: [[0.98, 0.02], [0.02, 0.98]]}
+        mem = MeasurementErrorMitigation(calibration=cal)
+        raw_counts = {"0": 980, "1": 20}   # 1000 shots, 2% readout error
+        corrected = mem.correct_counts(raw_counts, n_qubits=1)
+        # After correction, |0> should be ≈ 1000 and |1> ≈ 0.
+        assert corrected["0"] > 990, f"Expected >990 for |0>, got {corrected['0']}"
+        assert corrected["1"] < 10, f"Expected <10 for |1>, got {corrected['1']}"
+
+    def test_no_calibration_returns_unchanged_counts(self):
+        """With no calibration data, correction is identity."""
+        mem = MeasurementErrorMitigation()  # empty calibration
+        counts = {"0": 600, "1": 400}
+        corrected = mem.correct_counts(counts, n_qubits=1)
+        assert abs(corrected["0"] - 600.0) < 1e-6
+        assert abs(corrected["1"] - 400.0) < 1e-6
+
+    def test_sum_of_corrected_counts_equals_total(self):
+        """Corrected quasi-probabilities sum to the original total shot count."""
+        cal = {0: [[0.95, 0.05], [0.05, 0.95]]}
+        mem = MeasurementErrorMitigation(calibration=cal)
+        counts = {"0": 700, "1": 300}
+        corrected = mem.correct_counts(counts, n_qubits=1)
+        total = sum(corrected.values())
+        assert abs(total - 1000.0) < 1e-4
+
+
+# ── RandomizedCompiling ────────────────────────────────────────────────────────
+
+class TestRandomizedCompiling:
+
+    def test_is_mitigation_strategy(self):
+        assert isinstance(RandomizedCompiling(), MitigationStrategy)
+
+    def test_description_nonempty(self):
+        assert len(RandomizedCompiling().description()) > 0
+
+    def test_apply_returns_string(self):
+        rc = RandomizedCompiling(seed=42)
+        result = rc.apply(_BELL_QASM)
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_twirled_circuit_preserves_cx(self):
+        """The CNOT gate is present in the twirled output."""
+        rc = RandomizedCompiling(seed=42)
+        result = rc.apply(_BELL_QASM)
+        assert "cx q[0],q[1];" in result
+
+    def test_twirled_circuit_has_more_lines_than_original(self):
+        """Twirling injects extra gates, so line count should be >= original."""
+        rc = RandomizedCompiling(seed=42)
+        result = rc.apply(_BELL_QASM)
+        # May be equal if twirl selects identity; generally greater.
+        assert len(result.splitlines()) >= len(_BELL_QASM.splitlines())
+
+    def test_generate_twirled_circuits_count(self):
+        """generate_twirled_circuits returns exactly n_samples variants."""
+        rc = RandomizedCompiling(n_samples=5, seed=0)
+        variants = rc.generate_twirled_circuits(_BELL_QASM)
+        assert len(variants) == 5
+
+    def test_generate_twirled_circuits_all_strings(self):
+        rc = RandomizedCompiling(n_samples=3, seed=7)
+        for v in rc.generate_twirled_circuits(_BELL_QASM):
+            assert isinstance(v, str)
+            assert "cx q[0],q[1];" in v
+
+    def test_different_seeds_may_differ(self):
+        """Two different seeds produce at least one different circuit."""
+        rc_a = RandomizedCompiling(n_samples=10, seed=1)
+        rc_b = RandomizedCompiling(n_samples=10, seed=2)
+        variants_a = rc_a.generate_twirled_circuits(_BELL_QASM)
+        variants_b = rc_b.generate_twirled_circuits(_BELL_QASM)
+        # Very unlikely to be all the same
+        assert variants_a != variants_b
+
+    def test_twirled_circuits_contain_only_known_gates(self):
+        """All gates in twirled output are from the standard Pauli + CNOT set."""
+        rc = RandomizedCompiling(n_samples=20, seed=99)
+        known = {"h", "cx", "cnot", "x", "y", "z", "measure", "qreg", "creg",
+                 "OPENQASM", "include", "barrier", "//", ""}
+        for variant in rc.generate_twirled_circuits(_BELL_QASM):
+            for line in variant.splitlines():
+                first = line.strip().split()[0] if line.strip() else ""
+                assert first in known or first.startswith("//"), (
+                    f"Unexpected gate in twirled circuit: {first!r}"
+                )
+
+
+# ── mitigate() wrapper ─────────────────────────────────────────────────────────
+
+def test_mitigate_chains_strategies():
+    """mitigate() applies strategies in order."""
+    mem = MeasurementErrorMitigation(calibration=_NOISY_CAL)
+    rc = RandomizedCompiling(seed=0)
+    result = mitigate(_BELL_QASM, [mem, rc])
+    assert "MeasurementErrorMitigation" in result
+    assert "cx q[0],q[1];" in result
+
+
+def test_mitigate_empty_strategies_passthrough():
+    """mitigate() with an empty strategy list returns the original QASM."""
+    assert mitigate(_BELL_QASM, []) == _BELL_QASM
+
+
+# ── available_strategies() ─────────────────────────────────────────────────────
+
+def test_available_strategies_has_two_entries():
+    """Two strategies are registered (acceptance criterion)."""
+    strategies = available_strategies()
+    assert len(strategies) >= 2
+
+
+def test_available_strategies_names():
+    strategies = available_strategies()
+    assert "measurement_error_mitigation" in strategies
+    assert "randomized_compiling" in strategies
+
+
+def test_available_strategies_instantiable():
+    for _name, cls in available_strategies().items():
+        obj = cls()
+        assert isinstance(obj, MitigationStrategy)


### PR DESCRIPTION
## Summary

Adds `afana/backends/error_mitigation.py` with two standard error mitigation strategies for IBM backend executions:

**1. `MeasurementErrorMitigation`** — corrects raw shot count histograms by inverting the per-qubit calibration matrix. For multi-qubit systems the per-qubit matrices are tensor-producted and the full 2ⁿ×2ⁿ matrix is inverted via Gaussian elimination. Demonstrates improved fidelity: simulated noisy readout (98/2% flip probability) is fully corrected back to the ground truth distribution.

**2. `RandomizedCompiling`** — applies Pauli twirling around CNOT gates using the full 16-entry CNOT twirling table. Each CNOT is wrapped with a random Pauli pair before and the compensating pair after, preserving the logical operation while converting coherent gate errors into stochastic Pauli noise. `generate_twirled_circuits(n)` produces *n* independent variants for ensemble averaging.

Also adds:
- `mitigate(qasm, strategies)` — convenience wrapper to chain strategies
- `available_strategies()` — registry mapping names to classes
- Exports from `afana.backends`

## Test plan

- [x] Both strategies implement `MitigationStrategy` ABC
- [x] `MeasurementErrorMitigation.correct_counts` — identity cal → no change; noisy cal → corrected counts improve fidelity
- [x] Corrected counts sum to original total (normalisation preserved)
- [x] `RandomizedCompiling.apply` preserves CNOT, adds twirling gates
- [x] `generate_twirled_circuits` returns exact `n_samples` variants, all with CNOT
- [x] Different seeds produce different circuits
- [x] Twirled circuits only contain known Pauli/CNOT gates
- [x] `mitigate()` chains both strategies correctly
- [x] `available_strategies()` registers exactly 2+ strategies (acceptance criterion)

All 56 tests pass; flake8 clean (max-line-length=120).

Closes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)