### PR TITLE
feat(afana): noise-aware backend selection CLI

### DIFF
--- a/afana/cli.py
+++ b/afana/cli.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional
 
+from .backend_selector import BackendCapabilities, NoiseRequirements, select_backends
 from .compile import compile_qasm
 from .optimize import reduce_t_gates
 from .parametric import ParametricCompileError, compile_parametric
@@ -34,6 +35,17 @@ def _parse_bindings(param_args: List[str]) -> Dict[str, float]:
         except ValueError:
             raise ValueError(f"--param value must be a float, got: {value!r}")
     return bindings
+
+
+# ── Simulator backend (infinite coherence) ────────────────────────────────────
+
+_SIMULATOR = BackendCapabilities(
+    name="simulator",
+    t1_us=1e9,
+    t2_us=1e9,
+    gate_fidelity=1.0,
+    n_qubits=4096,
+)
 
 
 def cmd_compile(
@@ -96,6 +108,77 @@ def cmd_compile_parametric(path: str, param_args: List[str], output: Optional[st
     return 0
 
 
+def cmd_select_backend(
+    t1_min: float,
+    t2_min: float,
+    n_qubits_min: int,
+    fidelity_min: Optional[float],
+    backends_json: Optional[str],
+) -> int:
+    """Print ranked backends that satisfy the given noise requirements."""
+    backends = [_SIMULATOR]
+    if backends_json:
+        try:
+            extra = json.loads(Path(backends_json).read_text(encoding="utf-8"))
+            for b in extra:
+                backends.append(BackendCapabilities(
+                    name=b["name"],
+                    t1_us=float(b["t1_us"]),
+                    t2_us=float(b["t2_us"]),
+                    gate_fidelity=float(b["gate_fidelity"]),
+                    n_qubits=int(b["n_qubits"]),
+                ))
+        except Exception as exc:
+            print(f"Error loading backends JSON: {exc}")
+            return 1
+
+    req = NoiseRequirements(
+        t1_us_min=t1_min,
+        t2_us_min=t2_min,
+        n_qubits_min=n_qubits_min,
+        gate_fidelity_min=fidelity_min,
+    )
+
+    print(f"Noise requirements: T1≥{t1_min}µs, T2≥{t2_min}µs, "
+          f"n_qubits≥{n_qubits_min}"
+          + (f", fidelity≥{fidelity_min}" if fidelity_min is not None else ""))
+    print()
+
+    try:
+        ranked = select_backends(backends, req)
+    except ValueError as exc:
+        print(f"Invalid requirements: {exc}")
+        return 1
+
+    all_names = {b.name for b in backends}
+    passing = {b.name for b in ranked}
+    failing = all_names - passing
+
+    for i, b in enumerate(ranked):
+        marker = "[SELECTED]" if i == 0 else ""
+        print(f"  ✓ {b.name}: T1={b.t1_us}µs, T2={b.t2_us}µs, "
+              f"fidelity={b.gate_fidelity}, qubits={b.n_qubits}  {marker}")
+    for name in sorted(failing):
+        b_list = [b for b in backends if b.name == name]
+        if b_list:
+            b = b_list[0]
+            reasons = []
+            if b.t1_us < t1_min:
+                reasons.append(f"T1={b.t1_us}µs < required {t1_min}µs")
+            if b.t2_us < t2_min:
+                reasons.append(f"T2={b.t2_us}µs < required {t2_min}µs")
+            if b.n_qubits < n_qubits_min:
+                reasons.append(f"n_qubits={b.n_qubits} < required {n_qubits_min}")
+            if fidelity_min is not None and b.gate_fidelity < fidelity_min:
+                reasons.append(f"fidelity={b.gate_fidelity} < required {fidelity_min}")
+            print(f"  ✗ {b.name}: {'; '.join(reasons)}")
+
+    if not ranked:
+        print("No backend satisfies the requirements.")
+        return 1
+    return 0
+
+
 def cmd_benchmark(paths: Iterable[str], optimize: bool, reduce_t: bool = False) -> int:
     rows = []
     for path in paths:
@@ -141,6 +224,18 @@ def main() -> int:
     )
     p_parametric.add_argument("--output", help="Optional output path for QASM3")
 
+    p_backend = sub.add_parser("select-backend", help="Rank backends by noise requirements")
+    p_backend.add_argument("--t1", type=float, default=50.0, metavar="T1_US",
+                           help="Minimum required T1 relaxation time in µs (default: 50)")
+    p_backend.add_argument("--t2", type=float, default=30.0, metavar="T2_US",
+                           help="Minimum required T2 dephasing time in µs (default: 30)")
+    p_backend.add_argument("--qubits", type=int, default=1, metavar="N",
+                           help="Minimum number of qubits (default: 1)")
+    p_backend.add_argument("--fidelity", type=float, default=None, metavar="F",
+                           help="Minimum single-qubit gate fidelity [0,1] (optional)")
+    p_backend.add_argument("--backends", metavar="FILE",
+                           help="JSON file listing extra backend capabilities")
+
     p_bench = sub.add_parser("benchmark", help="Benchmark gate count before/after")
     p_bench.add_argument("inputs", nargs="+", help="One or more OpenQASM files")
     p_bench.add_argument("--optimize", action="store_true", help="Enable ZX optimization")
@@ -157,6 +252,12 @@ def main() -> int:
         )
     if args.cmd == "compile-parametric":
         return cmd_compile_parametric(args.input, param_args=args.params, output=args.output)
+    if args.cmd == "select-backend":
+        return cmd_select_backend(
+            t1_min=args.t1, t2_min=args.t2,
+            n_qubits_min=args.qubits, fidelity_min=args.fidelity,
+            backends_json=args.backends,
+        )
     if args.cmd == "benchmark":
         return cmd_benchmark(args.inputs, optimize=args.optimize, reduce_t=args.reduce_t)
     parser.print_help()

--- a/afana/tests/test_cli.py
+++ b/afana/tests/test_cli.py
@@ -1,4 +1,6 @@
-from afana.cli import cmd_benchmark, cmd_compile
+import json
+
+from afana.cli import cmd_benchmark, cmd_compile, cmd_select_backend
 
 
 QASM_IN = "\n".join(
@@ -49,3 +51,57 @@ def test_cmd_benchmark_prints_json(tmp_path, monkeypatch, capsys):
     printed = capsys.readouterr().out
     assert "before=2 after=2" in printed
     assert "\"results\"" in printed
+
+
+# ── cmd_select_backend tests ──────────────────────────────────────────────────
+
+def test_select_backend_simulator_always_passes(capsys):
+    """Simulator (infinite coherence) always satisfies any noise requirement."""
+    rc = cmd_select_backend(t1_min=999.0, t2_min=999.0, n_qubits_min=100,
+                            fidelity_min=0.9999, backends_json=None)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "simulator" in out
+    assert "[SELECTED]" in out
+
+
+def test_select_backend_prints_requirements(capsys):
+    """Output shows the noise requirements that were used."""
+    cmd_select_backend(t1_min=50.0, t2_min=30.0, n_qubits_min=2,
+                       fidelity_min=None, backends_json=None)
+    out = capsys.readouterr().out
+    assert "T1≥50.0" in out
+    assert "T2≥30.0" in out
+
+
+def test_select_backend_extra_from_json(tmp_path, capsys):
+    """Extra backends loaded from JSON are ranked alongside the simulator."""
+    backends_data = [
+        {"name": "ibm_test", "t1_us": 200.0, "t2_us": 150.0, "gate_fidelity": 0.99, "n_qubits": 20},
+    ]
+    bf = tmp_path / "backends.json"
+    bf.write_text(json.dumps(backends_data), encoding="utf-8")
+
+    rc = cmd_select_backend(t1_min=100.0, t2_min=80.0, n_qubits_min=5,
+                            fidelity_min=0.98, backends_json=str(bf))
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "ibm_test" in out
+    assert "✓" in out
+
+
+def test_select_backend_fails_when_backend_below_req(tmp_path, capsys):
+    """Backend that doesn't meet requirements is shown with ✗ and reason."""
+    backends_data = [
+        {"name": "weak_backend", "t1_us": 10.0, "t2_us": 8.0, "gate_fidelity": 0.95, "n_qubits": 5},
+    ]
+    bf = tmp_path / "backends.json"
+    bf.write_text(json.dumps(backends_data), encoding="utf-8")
+
+    # Require more than the weak backend can provide (simulator still passes)
+    rc = cmd_select_backend(t1_min=50.0, t2_min=30.0, n_qubits_min=5,
+                            fidelity_min=None, backends_json=str(bf))
+    assert rc == 0   # simulator passes
+    out = capsys.readouterr().out
+    assert "✗ weak_backend" in out
+    assert "T1=" in out


### PR DESCRIPTION
## Summary
- Adds `select-backend` subcommand to `afana` CLI (`--t1`, `--t2`, `--qubits`, `--fidelity`, `--backends`)
- Built-in simulator backend (infinite coherence) always satisfies any noise requirement
- Extra backends loaded from a JSON file are ranked alongside the simulator
- Passing backends shown with `✓` and `[SELECTED]` marker; failing ones shown with `✗` + reason(s)

## Test plan
- [ ] `test_select_backend_simulator_always_passes` — any T1/T2/n_qubits requirement satisfied by simulator
- [ ] `test_select_backend_prints_requirements` — output includes T1≥ and T2≥ values
- [ ] `test_select_backend_extra_from_json` — extra backends loaded from JSON appear in output
- [ ] `test_select_backend_fails_when_backend_below_req` — `✗ backend_name` with `T1=` reason shown

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)