### PR TITLE
feat(afana): dynamical decoupling pulse sequences for IBM backend

### DIFF
--- a/afana/backends/__init__.py
+++ b/afana/backends/__init__.py
@@ -1,5 +1,6 @@
 """Backend-specific Afana compilation paths."""
 
+from .dynamical_decoupling import DD_SEQUENCES, apply_dynamical_decoupling
 from .error_mitigation import (
     MeasurementErrorMitigation,
     MitigationStrategy,
@@ -10,6 +11,8 @@ from .error_mitigation import (
 from .ibm import EhrenfestProgram, ehrenfest_to_ibm, transpile_for_ibm
 
 __all__ = [
+    "DD_SEQUENCES",
+    "apply_dynamical_decoupling",
     "EhrenfestProgram",
     "ehrenfest_to_ibm",
     "transpile_for_ibm",

--- a/afana/backends/dynamical_decoupling.py
+++ b/afana/backends/dynamical_decoupling.py
@@ -1,0 +1,184 @@
+"""Dynamical decoupling pulse sequences for OpenQASM circuits.
+
+Inserts XY4, CPMG, or XY8 pulse sequences into idle qubit windows to
+counteract decoherence errors during execution on real hardware.  Works
+directly on OpenQASM 2.0 strings without requiring Qiskit or hardware
+access.
+
+Typical usage::
+
+    from afana.backends.dynamical_decoupling import apply_dynamical_decoupling
+
+    qasm_with_dd = apply_dynamical_decoupling(qasm, sequence="xy4", min_idle_layers=2)
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Dict, List, Set
+
+# ---------------------------------------------------------------------------
+# Regex helpers
+# ---------------------------------------------------------------------------
+
+_QREG_RE = re.compile(r"^\s*qreg\s+(\w+)\[(\d+)\]\s*;")
+_QUBIT_REF_RE = re.compile(r"\b(\w+)\[(\d+)\]")
+_HEADER_RE = re.compile(r"^\s*(OPENQASM|include|gate|opaque|if|qreg|creg)\b")
+
+# ---------------------------------------------------------------------------
+# Supported DD sequences
+# ---------------------------------------------------------------------------
+
+#: Map of sequence name → ordered list of gate names for each pulse.
+DD_SEQUENCES: Dict[str, List[str]] = {
+    "cpmg": ["x"],
+    "xy4": ["x", "y", "x", "y"],
+    "xy8": ["x", "y", "x", "y", "y", "x", "y", "x"],
+}
+
+
+# ---------------------------------------------------------------------------
+# Internal layer scheduler
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Layer:
+    """One parallel layer of gate lines."""
+
+    gates: List[str] = field(default_factory=list)
+    qubits: Set[str] = field(default_factory=set)
+
+
+def _get_qubit_refs(line: str) -> Set[str]:
+    """Return all qubit references (e.g. ``'q[0]'``) found in *line*."""
+    return {f"{m.group(1)}[{m.group(2)}]" for m in _QUBIT_REF_RE.finditer(line)}
+
+
+def _is_header_line(line: str) -> bool:
+    stripped = line.strip()
+    if not stripped or stripped.startswith("//"):
+        return True
+    return bool(_HEADER_RE.match(stripped))
+
+
+def _schedule_layers(gate_lines: List[str]) -> List[_Layer]:
+    """Greedily schedule *gate_lines* into parallel execution layers.
+
+    Two gates land in the same layer only if their qubit sets are disjoint.
+    Lines with no qubit references are placed in a singleton layer.
+    """
+    layers: List[_Layer] = []
+    current = _Layer()
+    for line in gate_lines:
+        qrefs = _get_qubit_refs(line)
+        if not qrefs:
+            if current.gates:
+                layers.append(current)
+                current = _Layer()
+            layers.append(_Layer(gates=[line], qubits=set()))
+            continue
+        if current.qubits & qrefs:
+            layers.append(current)
+            current = _Layer()
+        current.gates.append(line)
+        current.qubits |= qrefs
+    if current.gates:
+        layers.append(current)
+    return layers
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def apply_dynamical_decoupling(
+    qasm: str,
+    sequence: str = "xy4",
+    min_idle_layers: int = 2,
+) -> str:
+    """Insert dynamical decoupling pulses into idle qubit windows.
+
+    The circuit is first partitioned into *parallel layers* (groups of gates
+    with disjoint qubit sets).  Whenever a qubit has been idle for at least
+    *min_idle_layers* consecutive layers and then becomes active again (or the
+    circuit ends), a full DD sequence is injected just before the reactivating
+    gate.  Each inserted line is annotated with ``// dd:<sequence>``.
+
+    Args:
+        qasm: OpenQASM 2.0 source string.
+        sequence: DD sequence name — one of ``'cpmg'``, ``'xy4'``, ``'xy8'``.
+        min_idle_layers: Minimum consecutive idle layers before DD is applied.
+            Must be >= 1.
+
+    Returns:
+        Modified QASM string with DD pulses inserted.
+
+    Raises:
+        ValueError: If *sequence* is not recognised or *min_idle_layers* < 1.
+    """
+    if sequence not in DD_SEQUENCES:
+        raise ValueError(
+            f"Unknown DD sequence {sequence!r}. "
+            f"Choose from {sorted(DD_SEQUENCES)}"
+        )
+    if min_idle_layers < 1:
+        raise ValueError(f"min_idle_layers must be >= 1, got {min_idle_layers}")
+
+    lines = qasm.splitlines()
+    header: List[str] = []
+    gate_lines: List[str] = []
+    n_qubits_by_reg: Dict[str, int] = {}
+
+    for line in lines:
+        m = _QREG_RE.match(line)
+        if m:
+            n_qubits_by_reg[m.group(1)] = int(m.group(2))
+        if not gate_lines and _is_header_line(line):
+            header.append(line)
+        else:
+            gate_lines.append(line)
+
+    all_qubits: List[str] = sorted(
+        f"{reg}[{i}]"
+        for reg, n in n_qubits_by_reg.items()
+        for i in range(n)
+    )
+
+    if not gate_lines or not all_qubits:
+        return qasm
+
+    pulses = DD_SEQUENCES[sequence]
+    layers = _schedule_layers(gate_lines)
+
+    idle_streak: Dict[str, int] = {q: 0 for q in all_qubits}
+    output_layers: List[List[str]] = []
+
+    for layer in layers:
+        active = layer.qubits
+        dd_before: List[str] = []
+        for qubit in all_qubits:
+            if qubit in active:
+                if idle_streak[qubit] >= min_idle_layers:
+                    for pulse in pulses:
+                        dd_before.append(f"{pulse} {qubit};  // dd:{sequence}")
+                idle_streak[qubit] = 0
+            else:
+                idle_streak[qubit] += 1
+        output_layers.append(dd_before + layer.gates)
+
+    # Flush DD for qubits still idle at circuit end
+    trailing: List[str] = []
+    for qubit in all_qubits:
+        if idle_streak[qubit] >= min_idle_layers:
+            for pulse in pulses:
+                trailing.append(f"{pulse} {qubit};  // dd:{sequence}")
+
+    parts = list(header)
+    for layer_lines in output_layers:
+        parts.extend(layer_lines)
+    parts.extend(trailing)
+
+    return "\n".join(parts)

--- a/afana/tests/test_dynamical_decoupling.py
+++ b/afana/tests/test_dynamical_decoupling.py
@@ -1,0 +1,250 @@
+"""Tests for afana.backends.dynamical_decoupling."""
+
+import pytest
+
+from afana.backends.dynamical_decoupling import DD_SEQUENCES, apply_dynamical_decoupling
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_qasm(*gate_lines: str, n_qubits: int = 2) -> str:
+    header = [
+        "OPENQASM 2.0;",
+        'include "qelib1.inc";',
+        f"qreg q[{n_qubits}];",
+    ]
+    return "\n".join(header + list(gate_lines))
+
+
+def _dd_lines(out: str) -> list:
+    """Return lines that contain a DD annotation."""
+    return [ln.strip() for ln in out.splitlines() if "// dd:" in ln]
+
+
+def _non_dd_gate_lines(out: str) -> list:
+    """Return original gate lines (no DD annotation, no header)."""
+    return [
+        ln.strip()
+        for ln in out.splitlines()
+        if ln.strip() and not ln.strip().startswith(("OPENQASM", "include", "qreg", "//"))
+        and "// dd:" not in ln
+    ]
+
+
+# ---------------------------------------------------------------------------
+# DD_SEQUENCES registry
+# ---------------------------------------------------------------------------
+
+
+def test_available_sequences():
+    assert "cpmg" in DD_SEQUENCES
+    assert "xy4" in DD_SEQUENCES
+    assert "xy8" in DD_SEQUENCES
+
+
+def test_cpmg_is_single_x():
+    assert DD_SEQUENCES["cpmg"] == ["x"]
+
+
+def test_xy4_is_four_pulses():
+    assert DD_SEQUENCES["xy4"] == ["x", "y", "x", "y"]
+
+
+def test_xy8_is_eight_pulses():
+    assert DD_SEQUENCES["xy8"] == ["x", "y", "x", "y", "y", "x", "y", "x"]
+
+
+# ---------------------------------------------------------------------------
+# Basic insertion
+# ---------------------------------------------------------------------------
+
+
+def test_xy4_inserts_four_pulses():
+    """q[1] idle while q[0] runs 3 gates → XY4 injected before cx."""
+    qasm = _make_qasm(
+        "h q[0];",
+        "h q[0];",
+        "h q[0];",
+        "cx q[0],q[1];",
+    )
+    out = apply_dynamical_decoupling(qasm, sequence="xy4", min_idle_layers=2)
+    dd = _dd_lines(out)
+    # Should see x, y, x, y for q[1]
+    assert len(dd) == 4
+    assert all("q[1]" in ln for ln in dd)
+    assert "x q[1]" in dd[0]
+    assert "y q[1]" in dd[1]
+    assert "x q[1]" in dd[2]
+    assert "y q[1]" in dd[3]
+
+
+def test_cpmg_inserts_single_x():
+    qasm = _make_qasm(
+        "h q[0];",
+        "h q[0];",
+        "h q[0];",
+        "cx q[0],q[1];",
+    )
+    out = apply_dynamical_decoupling(qasm, sequence="cpmg", min_idle_layers=2)
+    dd = _dd_lines(out)
+    assert len(dd) == 1
+    assert "x q[1]" in dd[0]
+
+
+def test_xy8_inserts_eight_pulses():
+    qasm = _make_qasm(
+        "h q[0];",
+        "h q[0];",
+        "h q[0];",
+        "cx q[0],q[1];",
+    )
+    out = apply_dynamical_decoupling(qasm, sequence="xy8", min_idle_layers=2)
+    dd = _dd_lines(out)
+    assert len(dd) == 8
+    assert all("q[1]" in ln for ln in dd)
+
+
+# ---------------------------------------------------------------------------
+# Threshold enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_no_dd_below_threshold():
+    """Only 1 idle layer — threshold of 2 not reached — no DD inserted."""
+    qasm = _make_qasm(
+        "h q[0];",         # layer 0: q[1] idle (streak=1)
+        "cx q[0],q[1];",   # layer 1: q[1] active — streak < 2, no DD
+    )
+    out = apply_dynamical_decoupling(qasm, sequence="xy4", min_idle_layers=2)
+    assert _dd_lines(out) == []
+
+
+def test_dd_inserted_at_exact_threshold():
+    """Exactly min_idle_layers consecutive idle layers triggers insertion."""
+    qasm = _make_qasm(
+        "h q[0];",
+        "h q[0];",          # q[1] idle for 2 layers
+        "cx q[0],q[1];",
+    )
+    out = apply_dynamical_decoupling(qasm, sequence="cpmg", min_idle_layers=2)
+    assert len(_dd_lines(out)) == 1
+
+
+# ---------------------------------------------------------------------------
+# Always-active qubit gets no DD
+# ---------------------------------------------------------------------------
+
+
+def test_no_dd_on_always_active_qubit():
+    """A qubit that participates in every layer is never idle → no DD."""
+    qasm = _make_qasm(
+        "h q[0];",
+        "h q[0];",
+        "h q[0];",
+    )
+    # q[0] is active every layer; q[1] is idle but never reactivated
+    # (trailing flush only if there's a reactivation or explicit trailing check)
+    out = apply_dynamical_decoupling(qasm, sequence="xy4", min_idle_layers=2)
+    # q[0] lines should not have DD annotations
+    q0_dd = [ln for ln in _dd_lines(out) if "q[0]" in ln]
+    assert q0_dd == []
+
+
+# ---------------------------------------------------------------------------
+# Trailing idle qubit
+# ---------------------------------------------------------------------------
+
+
+def test_dd_trailing_idle_qubit():
+    """Qubit idle at end of circuit also receives DD (trailing flush)."""
+    qasm = _make_qasm(
+        "cx q[0],q[1];",
+        "h q[0];",   # q[1] idle after cx
+        "h q[0];",
+        "h q[0];",   # 3 trailing idle layers for q[1]
+    )
+    out = apply_dynamical_decoupling(qasm, sequence="xy4", min_idle_layers=2)
+    dd = _dd_lines(out)
+    assert len(dd) == 4
+    assert all("q[1]" in ln for ln in dd)
+
+
+# ---------------------------------------------------------------------------
+# Original gate ordering preserved
+# ---------------------------------------------------------------------------
+
+
+def test_original_gates_preserved():
+    """All original gates appear in the output (DD only adds, never removes)."""
+    qasm = _make_qasm(
+        "h q[0];",
+        "h q[0];",
+        "h q[0];",
+        "cx q[0],q[1];",
+        "measure q[0] -> c[0];",
+        n_qubits=2,
+    )
+    # Rebuild with creg
+    qasm_full = qasm.replace("qreg q[2];", "qreg q[2];\ncreg c[2];")
+    out = apply_dynamical_decoupling(qasm_full, sequence="cpmg", min_idle_layers=2)
+    for gate in ("h q[0];", "cx q[0],q[1];"):
+        assert gate in out
+
+
+# ---------------------------------------------------------------------------
+# Empty / trivial circuits
+# ---------------------------------------------------------------------------
+
+
+def test_no_gates_returns_unchanged():
+    """Circuit with no gate lines returns the input unchanged."""
+    qasm = "\n".join([
+        "OPENQASM 2.0;",
+        'include "qelib1.inc";',
+        "qreg q[2];",
+    ])
+    assert apply_dynamical_decoupling(qasm, sequence="xy4") == qasm
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_sequence_raises():
+    qasm = _make_qasm("h q[0];")
+    with pytest.raises(ValueError, match="Unknown DD sequence"):
+        apply_dynamical_decoupling(qasm, sequence="bad_seq")
+
+
+def test_min_idle_layers_zero_raises():
+    qasm = _make_qasm("h q[0];")
+    with pytest.raises(ValueError, match="min_idle_layers"):
+        apply_dynamical_decoupling(qasm, sequence="xy4", min_idle_layers=0)
+
+
+# ---------------------------------------------------------------------------
+# Multi-qubit register
+# ---------------------------------------------------------------------------
+
+
+def test_dd_only_injected_for_idle_qubits():
+    """In a 3-qubit circuit, always-active qubit gets no DD; idle one does."""
+    # q[0] is active in every layer, q[2] is idle for the first 3 layers
+    qasm = _make_qasm(
+        "h q[0];",
+        "h q[0];",
+        "h q[0];",
+        "cx q[0],q[2];",  # q[2] reactivated after 3 idle layers
+        n_qubits=3,
+    )
+    out = apply_dynamical_decoupling(qasm, sequence="cpmg", min_idle_layers=2)
+    dd = _dd_lines(out)
+    # q[0] is always active — must never receive DD pulses
+    q0_dd = [ln for ln in dd if "q[0]" in ln]
+    assert q0_dd == []
+    # q[2] was idle for 3 layers — must receive at least one DD pulse
+    q2_dd = [ln for ln in dd if "q[2]" in ln]
+    assert len(q2_dd) >= 1


### PR DESCRIPTION
## Summary
- Adds `afana/backends/dynamical_decoupling.py` with CPMG, XY4, and XY8 DD sequences
- `apply_dynamical_decoupling(qasm, sequence, min_idle_layers)` inserts DD pulses into idle qubit windows
- Circuit is partitioned into parallel layers; qubits idle for ≥ `min_idle_layers` consecutive layers receive the full pulse sequence
- Inserted lines are annotated with `// dd:<sequence>` for traceability
- `DD_SEQUENCES` registry exposed from `afana.backends`

## Test plan
- [ ] All three sequences (CPMG/XY4/XY8) insert the correct number and order of pulses
- [ ] `min_idle_layers` threshold is respected (no insertion below threshold)
- [ ] Always-active qubits receive no DD pulses
- [ ] Trailing idle qubits are flushed at circuit end
- [ ] Original gate lines are preserved unchanged
- [ ] Invalid sequence name raises `ValueError`
- [ ] `min_idle_layers=0` raises `ValueError`
- [ ] Multi-qubit register: only genuinely idle qubits get DD

Closes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)