### PR TITLE
feat(quasi-board): Pauli-Test complexity gate for task proposals

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,41 @@ Before requesting review:
 4. Include the issue reference and verification notes in the PR description.
 5. Push follow-up fixes to the same branch if review requests changes.
 
+## Proposing New Tasks (Pauli-Test Quality Gate)
+
+Before submitting a `quasi:Propose` activity to the inbox, proposals are
+automatically screened by the **Pauli-Test complexity gate**.
+
+### Required fields
+
+Every proposal **must** include:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `quasi:estimatedEffort` | string | One of: `trivial`, `small`, `medium`, `large`, `xlarge` (or phrases like `"Medium, ~6h"`) |
+| `quasi:affectedComponents` | string[] | QUASI stack layers affected (e.g. `["afana", "spec"]`) |
+| `quasi:successCriteria` | string[] | ≥1 verifiable acceptance criterion |
+
+### Complexity rules
+
+- **`trivial`** proposals are **always rejected** — they are too small to justify
+  a task-claim cycle.
+- **`small`** proposals must either:
+  - Affect **≥ 2 components**, OR
+  - List **≥ 3 success criteria**.
+- `medium`, `large`, `xlarge` have no additional scope check.
+
+### L0 global cap
+
+L0 tasks are for core bootstrapping infrastructure only.  At most **2 open L0
+proposals** may exist at any time.  A third L0 proposal returns `HTTP 429`.
+
+### Near-duplicate detection
+
+Proposals whose title shares **≥ 60% of keywords** (words longer than 3
+characters) with an existing *pending* proposal are rejected as duplicates
+(`HTTP 409`).  Previously accepted/rejected proposals are not checked.
+
 ## Attribution
 
 If you are working through quasi-board, keep the required commit footer or submission metadata so the contribution can be recorded in the quasi-ledger.

--- a/quasi-board/server.py
+++ b/quasi-board/server.py
@@ -1221,14 +1221,79 @@ async def _process_activity(body: dict) -> JSONResponse:
         if not title or not description:
             raise HTTPException(400, "quasi:title and quasi:description are required")
 
-        proposals = _load_proposals()
+        # ── Pauli-Test quality gate ────────────────────────────────────────────
+        effort_raw = str(proposal_obj.get("quasi:estimatedEffort", "")).strip()
+        affected = proposal_obj.get("quasi:affectedComponents", [])
+        criteria = proposal_obj.get("quasi:successCriteria", [])
+
+        if not effort_raw:
+            raise HTTPException(400, "quasi:estimatedEffort is required (trivial|small|medium|large|xlarge)")
+
+        # Accept both exact labels and phrases like "Medium, ~6h"
+        _EFFORT_RE = _re.compile(r"\b(trivial|small|medium|large|xlarge)\b", _re.IGNORECASE)
+        _effort_match = _EFFORT_RE.search(effort_raw)
+        if not _effort_match:
+            raise HTTPException(400, "quasi:estimatedEffort must contain one of: trivial, small, medium, large, xlarge")
+        effort = _effort_match.group(1).lower()
+
+        if effort == "trivial":
+            raise HTTPException(400, "trivial-effort proposals are not accepted — minimum scope is 'small'")
+
+        if not isinstance(affected, list) or len(affected) == 0:
+            raise HTTPException(400, "quasi:affectedComponents (list) is required")
+
+        if not isinstance(criteria, list) or len(criteria) == 0:
+            raise HTTPException(400, "quasi:successCriteria (list with at least one criterion) is required")
+
+        if effort == "small" and len(affected) < 2 and len(criteria) < 3:
+            raise HTTPException(
+                400,
+                "'small' effort proposals must affect ≥2 components OR have ≥3 success criteria"
+            )
+
+        # L0 global cap: reject if ≥2 open L0 proposals already exist
+        level = str(proposal_obj.get("quasi:level", "")).strip().upper()
+        if level == "L0":
+            existing = _load_proposals()
+            open_l0 = sum(
+                1 for p in existing
+                if p.get("status") == "pending"
+                and str(p.get("level", "")).upper() == "L0"
+            )
+            if open_l0 >= 2:
+                raise HTTPException(
+                    429,
+                    "L0 task cap reached: maximum 2 open L0 proposals at a time"
+                )
+
+        # Semantic dedup: reject near-duplicates by title keyword overlap
+        _title_words = {w.lower() for w in _re.findall(r"\w+", title) if len(w) > 3}
+        existing_proposals = _load_proposals()
+        for p in existing_proposals:
+            if p.get("status") in ("accepted", "rejected"):
+                continue
+            existing_words = {w.lower() for w in _re.findall(r"\w+", p.get("title", "")) if len(w) > 3}
+            if existing_words and _title_words:
+                overlap = len(_title_words & existing_words) / max(len(_title_words), len(existing_words))
+                if overlap >= 0.6:
+                    raise HTTPException(
+                        409,
+                        f"Near-duplicate proposal detected (similarity {overlap:.0%}) — "
+                        f"see existing proposal {p['id']}: {p['title']!r}"
+                    )
+        # ── End Pauli-Test gate ────────────────────────────────────────────────
+
+        proposals = existing_proposals
         prop_id = f"prop-{len(proposals) + 1:03d}"
         proposal: dict[str, Any] = {
             "id": prop_id,
             "title": title,
             "description": description,
-            "estimated_effort": str(proposal_obj.get("quasi:estimatedEffort", ""))[:200],
+            "estimated_effort": effort,
+            "affected_components": [str(c)[:100] for c in affected],
+            "success_criteria": [str(c)[:500] for c in criteria],
             "rationale": str(proposal_obj.get("quasi:rationale", ""))[:500],
+            "level": level or "L1",
             "proposed_by": str(body.get("actor", "unknown"))[:200],
             "proposed_at": datetime.now(timezone.utc).isoformat(),
             "status": "pending",

--- a/quasi-board/tests/test_pauli_test_gate.py
+++ b/quasi-board/tests/test_pauli_test_gate.py
@@ -1,0 +1,344 @@
+"""Tests for the Pauli-Test complexity gate on task proposals (issue #85)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+def _propose_body(
+    title="Add ZX-calculus optimization Afana compiler",
+    description="Detailed description of the proposed work.",
+    effort="medium",
+    components=None,
+    criteria=None,
+    level="L1",
+    rationale="Reduces gate count by 30%",
+):
+    return {
+        "@context": "https://www.w3.org/ns/activitystreams",
+        "type": "quasi:Propose",
+        "actor": "https://agent.example.com/actor",
+        "object": {
+            "type": "quasi:TaskProposal",
+            "quasi:title": title,
+            "quasi:description": description,
+            "quasi:estimatedEffort": effort,
+            "quasi:affectedComponents": components if components is not None else ["afana", "spec"],
+            "quasi:successCriteria": criteria if criteria is not None else ["Tests pass", "Benchmark improves"],
+            "quasi:rationale": rationale,
+            "quasi:level": level,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Valid proposal — should be accepted (202)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_valid_proposal_accepted():
+    """A well-formed medium-effort proposal is accepted with 202."""
+    from server import app
+
+    with patch("server._load_proposals", return_value=[]), \
+         patch("server._save_proposals"), \
+         patch("server._notify_daniel", new_callable=AsyncMock):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post("/quasi-board/inbox", json=_propose_body())
+    assert resp.status_code == 202
+    assert resp.json()["status"] == "proposed"
+
+
+@pytest.mark.anyio
+async def test_effort_phrase_accepted():
+    """Effort phrases like 'Medium, ~6h' are accepted (backward-compat)."""
+    from server import app
+
+    with patch("server._load_proposals", return_value=[]), \
+         patch("server._save_proposals"), \
+         patch("server._notify_daniel", new_callable=AsyncMock):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post("/quasi-board/inbox", json=_propose_body(effort="Medium, ~6h"))
+    assert resp.status_code == 202
+
+
+# ---------------------------------------------------------------------------
+# Missing required fields
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_missing_effort_rejected():
+    from server import app
+
+    body = _propose_body(effort="")
+    with patch("server._load_proposals", return_value=[]):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post("/quasi-board/inbox", json=body)
+    assert resp.status_code == 400
+    assert "estimatedEffort" in resp.json()["detail"]
+
+
+@pytest.mark.anyio
+async def test_invalid_effort_rejected():
+    from server import app
+
+    body = _propose_body(effort="easy")
+    with patch("server._load_proposals", return_value=[]):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post("/quasi-board/inbox", json=body)
+    assert resp.status_code == 400
+
+
+@pytest.mark.anyio
+async def test_missing_components_rejected():
+    from server import app
+
+    body = _propose_body(components=[])
+    with patch("server._load_proposals", return_value=[]):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post("/quasi-board/inbox", json=body)
+    assert resp.status_code == 400
+    assert "affectedComponents" in resp.json()["detail"]
+
+
+@pytest.mark.anyio
+async def test_missing_criteria_rejected():
+    from server import app
+
+    body = _propose_body(criteria=[])
+    with patch("server._load_proposals", return_value=[]):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post("/quasi-board/inbox", json=body)
+    assert resp.status_code == 400
+    assert "successCriteria" in resp.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Trivial effort gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_trivial_effort_rejected():
+    """trivial effort proposals are always rejected."""
+    from server import app
+
+    body = _propose_body(effort="trivial")
+    with patch("server._load_proposals", return_value=[]):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post("/quasi-board/inbox", json=body)
+    assert resp.status_code == 400
+    assert "trivial" in resp.json()["detail"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Small effort scope check
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_small_effort_one_component_two_criteria_rejected():
+    """small effort with 1 component and 2 criteria fails the scope check."""
+    from server import app
+
+    body = _propose_body(effort="small", components=["afana"], criteria=["Tests pass", "Lints clean"])
+    with patch("server._load_proposals", return_value=[]):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post("/quasi-board/inbox", json=body)
+    assert resp.status_code == 400
+
+
+@pytest.mark.anyio
+async def test_small_effort_two_components_passes():
+    """small effort with ≥2 components is accepted."""
+    from server import app
+
+    body = _propose_body(effort="small", components=["afana", "spec"], criteria=["Tests pass"])
+    with patch("server._load_proposals", return_value=[]), \
+         patch("server._save_proposals"), \
+         patch("server._notify_daniel", new_callable=AsyncMock):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post("/quasi-board/inbox", json=body)
+    assert resp.status_code == 202
+
+
+@pytest.mark.anyio
+async def test_small_effort_three_criteria_passes():
+    """small effort with ≥3 criteria is accepted."""
+    from server import app
+
+    body = _propose_body(
+        effort="small", components=["afana"],
+        criteria=["Tests pass", "Lints clean", "Benchmark improves"],
+    )
+    with patch("server._load_proposals", return_value=[]), \
+         patch("server._save_proposals"), \
+         patch("server._notify_daniel", new_callable=AsyncMock):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post("/quasi-board/inbox", json=body)
+    assert resp.status_code == 202
+
+
+# ---------------------------------------------------------------------------
+# L0 global cap
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_l0_cap_enforced():
+    """Third L0 proposal is rejected with 429 when cap of 2 is reached."""
+    from server import app
+
+    existing_l0 = [
+        {"id": "prop-001", "title": "L0 task A infra bootstrap", "status": "pending", "level": "L0"},
+        {"id": "prop-002", "title": "L0 task B infra setup", "status": "pending", "level": "L0"},
+    ]
+    body = _propose_body(
+        title="L0 infrastructure something new bootstrap",
+        level="L0",
+        components=["quasi-board", "spec"],
+        effort="medium",
+    )
+    with patch("server._load_proposals", return_value=existing_l0):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post("/quasi-board/inbox", json=body)
+    assert resp.status_code == 429
+
+
+@pytest.mark.anyio
+async def test_l0_cap_not_applied_to_l1():
+    """L0 cap does not affect L1 proposals."""
+    from server import app
+
+    existing_l0 = [
+        {"id": "prop-001", "title": "L0 task A bootstrap infra", "status": "pending", "level": "L0"},
+        {"id": "prop-002", "title": "L0 task B infra setup", "status": "pending", "level": "L0"},
+    ]
+    body = _propose_body(
+        title="Implement noise model Ehrenfest CBOR channels spec",
+        level="L1",
+    )
+    with patch("server._load_proposals", return_value=existing_l0), \
+         patch("server._save_proposals"), \
+         patch("server._notify_daniel", new_callable=AsyncMock):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post("/quasi-board/inbox", json=body)
+    assert resp.status_code == 202
+
+
+# ---------------------------------------------------------------------------
+# Near-duplicate detection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_duplicate_proposal_rejected():
+    """A proposal with >60% keyword overlap with an existing pending one returns 409."""
+    from server import app
+
+    existing = [
+        {
+            "id": "prop-001",
+            "title": "Implement ZX-calculus optimization pass Afana compiler gates",
+            "status": "pending",
+        }
+    ]
+    body = _propose_body(title="Implement ZX-calculus optimization pass Afana compiler gates redux")
+    with patch("server._load_proposals", return_value=existing):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post("/quasi-board/inbox", json=body)
+    assert resp.status_code == 409
+    assert "duplicate" in resp.json()["detail"].lower()
+
+
+@pytest.mark.anyio
+async def test_distinct_proposal_not_flagged():
+    """A proposal with distinct title words is not flagged as duplicate."""
+    from server import app
+
+    existing = [
+        {"id": "prop-001", "title": "WebSocket streaming real-time dashboard feed", "status": "pending"},
+    ]
+    body = _propose_body(title="Implement noise model Ehrenfest CBOR decoherence channels")
+    with patch("server._load_proposals", return_value=existing), \
+         patch("server._save_proposals"), \
+         patch("server._notify_daniel", new_callable=AsyncMock):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post("/quasi-board/inbox", json=body)
+    assert resp.status_code == 202
+
+
+@pytest.mark.anyio
+async def test_accepted_proposal_not_checked_for_dedup():
+    """Accepted/rejected proposals are not considered for duplicate check."""
+    from server import app
+
+    existing = [
+        {
+            "id": "prop-001",
+            "title": "Implement ZX-calculus optimization pass Afana compiler gates",
+            "status": "accepted",
+        }
+    ]
+    # Same title as existing accepted proposal — should still pass
+    body = _propose_body(title="Implement ZX-calculus optimization pass Afana compiler gates")
+    with patch("server._load_proposals", return_value=existing), \
+         patch("server._save_proposals"), \
+         patch("server._notify_daniel", new_callable=AsyncMock):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post("/quasi-board/inbox", json=body)
+    assert resp.status_code == 202
+
+
+# ---------------------------------------------------------------------------
+# Stored fields
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_accepted_proposal_stores_new_fields():
+    """Accepted proposal stores affected_components and success_criteria."""
+    from server import app
+
+    saved_proposals = []
+
+    def fake_save(proposals):
+        saved_proposals.extend(proposals)
+
+    body = _propose_body(
+        components=["afana", "spec"],
+        criteria=["All tests pass", "Gate count reduced"],
+    )
+    with patch("server._load_proposals", return_value=[]), \
+         patch("server._save_proposals", side_effect=fake_save), \
+         patch("server._notify_daniel", new_callable=AsyncMock):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            await client.post("/quasi-board/inbox", json=body)
+
+    assert len(saved_proposals) == 1
+    proposal = saved_proposals[0]
+    assert "afana" in proposal["affected_components"]
+    assert "All tests pass" in proposal["success_criteria"]

--- a/quasi-board/tests/test_proposals.py
+++ b/quasi-board/tests/test_proposals.py
@@ -12,9 +12,11 @@ PROPOSE_ACTIVITY = {
     "actor": "claude-sonnet-4-6",
     "object": {
         "type": "quasi:TaskProposal",
-        "quasi:title": "Add ZX-calculus optimization to Afana",
+        "quasi:title": "Add ZX-calculus optimization to Afana compiler",
         "quasi:description": "After Afana v0, add a ZX-calculus rewrite pass using PyZX.",
         "quasi:estimatedEffort": "Medium, ~6h",
+        "quasi:affectedComponents": ["afana", "spec"],
+        "quasi:successCriteria": ["Gate count reduced by ≥20%", "All existing tests pass"],
         "quasi:rationale": "Reduces gate count by 30-40% on typical circuits",
     },
 }
@@ -38,7 +40,7 @@ async def test_propose_returns_202():
     assert data["id"] == "prop-001"
     mock_save.assert_called_once()
     saved = mock_save.call_args[0][0]
-    assert saved[0]["title"] == "Add ZX-calculus optimization to Afana"
+    assert saved[0]["title"] == "Add ZX-calculus optimization to Afana compiler"
     assert saved[0]["status"] == "pending"
 
 


### PR DESCRIPTION
## Summary
- Adds multi-layer quality gate to `quasi:Propose` inbox handler to prevent trivial/duplicate spam
- **Required fields**: `quasi:estimatedEffort`, `quasi:affectedComponents`, `quasi:successCriteria`
- **Trivial effort** → HTTP 400 always rejected
- **Small effort** → must affect ≥2 components OR have ≥3 success criteria
- **L0 global cap** → HTTP 429 when ≥2 pending L0 proposals exist
- **Near-duplicate detection** → HTTP 409 when ≥60% keyword overlap with pending proposal
- Effort phrases like `"Medium, ~6h"` are accepted (backward-compatible)
- Adds `CONTRIBUTING.md` section documenting the Pauli-Test rubric

## Test plan
- [ ] Valid medium proposal accepted (202)
- [ ] Effort phrase "Medium, ~6h" backward-compat accepted
- [ ] Missing required fields → 400
- [ ] Trivial effort → 400
- [ ] Small effort scope check (1 component, 2 criteria → 400; 2 components → 202)
- [ ] L0 cap (3rd L0 → 429, L1 unaffected)
- [ ] Duplicate detection (>60% overlap → 409, accepted proposals not checked)
- [ ] New fields stored in proposals.json

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)