### PR TITLE
fix(grafana): Hall of Fame / Shame stat panels — numeric value with model label

### DIFF
--- a/quasi-senate/grafana/model-performance.json
+++ b/quasi-senate/grafana/model-performance.json
@@ -26,7 +26,7 @@
   "annotations": {
     "list": []
   },
-  "description": "Rolling 7-day model performance: approval rate, JSON compliance, latency, provider fidelity \u2014 across all five Senate Loop roles.",
+  "description": "Rolling 7-day model performance: approval rate, JSON compliance, latency, provider fidelity — across all five Senate Loop roles.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -435,7 +435,9 @@
             "fixedColor": "green",
             "mode": "fixed"
           },
-          "mappings": []
+          "mappings": [],
+          "unit": "percent",
+          "decimals": 0
         }
       },
       "gridPos": {
@@ -455,10 +457,10 @@
           ]
         },
         "text": {
-          "titleSize": 16,
-          "valueSize": 28
+          "titleSize": 14,
+          "valueSize": 32
         },
-        "textMode": "value"
+        "textMode": "value_and_name"
       },
       "targets": [
         {
@@ -467,10 +469,10 @@
             "uid": "ffeagtzfyvvnkf"
           },
           "format": "table",
-          "rawSql": "SELECT base_model || ' \u2014 ' || coalesce(round(100.0 * sum(CASE WHEN downstream_verdict='approved' THEN 1 ELSE 0 END) / NULLIF(count(CASE WHEN downstream_verdict IN ('approved','rejected','json_fail') THEN 1 END),0),0)::text,'?') || '% approval' AS \"Best Model\" FROM senate_telemetry WHERE timestamp > now() - interval '7 days' AND dry_run = false GROUP BY base_model HAVING count(*) >= 10 ORDER BY round(100.0 * sum(CASE WHEN downstream_verdict='approved' THEN 1 ELSE 0 END) / NULLIF(count(CASE WHEN downstream_verdict IN ('approved','rejected','json_fail') THEN 1 END),0),2) DESC NULLS LAST LIMIT 1"
+          "rawSql": "SELECT base_model AS \"metric\", coalesce(round(100.0 * sum(CASE WHEN downstream_verdict='approved' THEN 1 ELSE 0 END) / NULLIF(count(CASE WHEN downstream_verdict IN ('approved','rejected','json_fail') THEN 1 END),0),0),0) AS \"Approval %\" FROM senate_telemetry WHERE timestamp > now() - interval '7 days' AND dry_run = false GROUP BY base_model HAVING count(*) >= 10 ORDER BY 2 DESC NULLS LAST LIMIT 1"
         }
       ],
-      "title": "\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd Top Performer (7 days, \u226510 calls)",
+      "title": "������ Top Performer (7 days, ≥10 calls)",
       "type": "stat"
     },
     {
@@ -484,7 +486,9 @@
             "fixedColor": "red",
             "mode": "fixed"
           },
-          "mappings": []
+          "mappings": [],
+          "unit": "percent",
+          "decimals": 0
         }
       },
       "gridPos": {
@@ -504,10 +508,10 @@
           ]
         },
         "text": {
-          "titleSize": 16,
-          "valueSize": 28
+          "titleSize": 14,
+          "valueSize": 32
         },
-        "textMode": "value"
+        "textMode": "value_and_name"
       },
       "targets": [
         {
@@ -516,10 +520,10 @@
             "uid": "ffeagtzfyvvnkf"
           },
           "format": "table",
-          "rawSql": "SELECT base_model || ' \u2014 ' || coalesce(round(100.0 * sum(CASE WHEN downstream_verdict='approved' THEN 1 ELSE 0 END) / NULLIF(count(CASE WHEN downstream_verdict IN ('approved','rejected','json_fail') THEN 1 END),0),0)::text,'?') || '% approval' AS \"Sir Slopalot\" FROM senate_telemetry WHERE timestamp > now() - interval '7 days' AND dry_run = false GROUP BY base_model HAVING count(*) >= 10 ORDER BY round(100.0 * sum(CASE WHEN downstream_verdict='approved' THEN 1 ELSE 0 END) / NULLIF(count(CASE WHEN downstream_verdict IN ('approved','rejected','json_fail') THEN 1 END),0),2) ASC NULLS LAST LIMIT 1"
+          "rawSql": "SELECT base_model AS \"metric\", coalesce(round(100.0 * sum(CASE WHEN downstream_verdict='approved' THEN 1 ELSE 0 END) / NULLIF(count(CASE WHEN downstream_verdict IN ('approved','rejected','json_fail') THEN 1 END),0),0),0) AS \"Approval %\" FROM senate_telemetry WHERE timestamp > now() - interval '7 days' AND dry_run = false GROUP BY base_model HAVING count(*) >= 10 ORDER BY 2 ASC NULLS LAST LIMIT 1"
         }
       ],
-      "title": "\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd Sir Slopalot (7 days, \u226510 calls)",
+      "title": "������ Sir Slopalot (7 days, ≥10 calls)",
       "type": "stat"
     },
     {
@@ -565,10 +569,10 @@
             "uid": "ffeagtzfyvvnkf"
           },
           "format": "table",
-          "rawSql": "SELECT base_model || ' \u2014 ' || round(avg(latency_ms)/1000.0,1)::text || 's avg' AS \"Fastest\" FROM senate_telemetry WHERE timestamp > now() - interval '7 days' AND dry_run = false GROUP BY base_model HAVING count(*) >= 10 ORDER BY avg(latency_ms) ASC LIMIT 1"
+          "rawSql": "SELECT base_model || ' — ' || round(avg(latency_ms)/1000.0,1)::text || 's avg' AS \"Fastest\" FROM senate_telemetry WHERE timestamp > now() - interval '7 days' AND dry_run = false GROUP BY base_model HAVING count(*) >= 10 ORDER BY avg(latency_ms) ASC LIMIT 1"
         }
       ],
-      "title": "\u26a1 Fastest Model (7 days, \u226510 calls)",
+      "title": "⚡ Fastest Model (7 days, ≥10 calls)",
       "type": "stat"
     },
     {
@@ -799,7 +803,7 @@
           "rawSql": "SELECT base_model AS \"Model\", count(*) AS \"Calls\", round(100.0 * sum(CASE WHEN downstream_verdict='approved' THEN 1 ELSE 0 END) / NULLIF(count(CASE WHEN downstream_verdict IN ('approved','rejected','json_fail') THEN 1 END),0),1) AS \"Approval %\", round(100.0 * sum(CASE WHEN json_parse_ok = true THEN 1 ELSE 0 END) / count(*),1) AS \"JSON %\", round(avg(latency_ms)/1000.0,1) AS \"Latency (s)\", round(avg(retries),2) AS \"Avg Retries\", round(100.0 * sum(CASE WHEN model_verified = true THEN 1 ELSE 0 END) / NULLIF(count(CASE WHEN model_verified IS NOT NULL THEN 1 END),0),1) AS \"Fidelity %\" FROM senate_telemetry WHERE timestamp > now() - interval '7 days' AND dry_run = false GROUP BY base_model HAVING count(*) >= 3 ORDER BY \"Approval %\" DESC NULLS LAST"
         }
       ],
-      "title": "Model Performance \u2014 7 Days (sorted by approval rate)",
+      "title": "Model Performance — 7 Days (sorted by approval rate)",
       "type": "table"
     },
     {
@@ -811,7 +815,7 @@
         "y": 28
       },
       "id": 103,
-      "title": "Role Heatmap \u2014 Approval Rate by Model \u00d7 Role",
+      "title": "Role Heatmap — Approval Rate by Model × Role",
       "type": "row"
     },
     {
@@ -852,7 +856,7 @@
               },
               {
                 "id": "noValue",
-                "value": "\u2014"
+                "value": "—"
               },
               {
                 "id": "thresholds",
@@ -908,7 +912,7 @@
           "rawSql": "SELECT base_model AS \"Model\", count(*) AS \"Calls\", round(100.0 * sum(CASE WHEN downstream_verdict='approved' AND role='A1_council' THEN 1 ELSE 0 END) / NULLIF(sum(CASE WHEN role='A1_council' AND downstream_verdict IN ('approved','rejected','json_fail') THEN 1 ELSE 0 END),0),0) AS \"A1 Council\", round(100.0 * sum(CASE WHEN downstream_verdict='approved' AND role='A2_drafter' THEN 1 ELSE 0 END) / NULLIF(sum(CASE WHEN role='A2_drafter' AND downstream_verdict IN ('approved','rejected','json_fail') THEN 1 ELSE 0 END),0),0) AS \"A2 Drafter\", round(100.0 * sum(CASE WHEN downstream_verdict='approved' AND role='A3_gate' THEN 1 ELSE 0 END) / NULLIF(sum(CASE WHEN role='A3_gate' AND downstream_verdict IN ('approved','rejected','json_fail') THEN 1 ELSE 0 END),0),0) AS \"A3 Gate\", round(100.0 * sum(CASE WHEN downstream_verdict='approved' AND role='B1_solver' THEN 1 ELSE 0 END) / NULLIF(sum(CASE WHEN role='B1_solver' AND downstream_verdict IN ('approved','rejected','json_fail') THEN 1 ELSE 0 END),0),0) AS \"B1 Solver\", round(100.0 * sum(CASE WHEN downstream_verdict='approved' AND role='B2_reviewer' THEN 1 ELSE 0 END) / NULLIF(sum(CASE WHEN role='B2_reviewer' AND downstream_verdict IN ('approved','rejected','json_fail') THEN 1 ELSE 0 END),0),0) AS \"B2 Reviewer\" FROM senate_telemetry WHERE timestamp > now() - interval '7 days' AND dry_run = false GROUP BY base_model HAVING count(*) >= 2 ORDER BY count(*) DESC"
         }
       ],
-      "title": "Approval % by Model \u00d7 Role (7 days)",
+      "title": "Approval % by Model × Role (7 days)",
       "type": "table"
     },
     {
@@ -972,7 +976,7 @@
           "rawSql": "SELECT date_trunc('hour', timestamp) + (floor(extract(epoch from timestamp - date_trunc('day',timestamp)) / 14400) * interval '4 hours') AS time, base_model AS metric, round(100.0 * sum(CASE WHEN downstream_verdict='approved' THEN 1 ELSE 0 END) / NULLIF(count(CASE WHEN downstream_verdict IN ('approved','rejected','json_fail') THEN 1 END),0),1) AS \"Approval %\" FROM senate_telemetry WHERE $__timeFilter(timestamp) AND dry_run = false GROUP BY 1, 2 HAVING count(*) >= 2 ORDER BY 1, 2"
         }
       ],
-      "title": "Approval Rate Trend \u2014 4-Hour Bins",
+      "title": "Approval Rate Trend — 4-Hour Bins",
       "type": "timeseries"
     },
     {
@@ -1023,7 +1027,7 @@
           "rawSql": "SELECT date_trunc('hour', timestamp) + (floor(extract(epoch from timestamp - date_trunc('day',timestamp)) / 14400) * interval '4 hours') AS time, base_model AS metric, round(100.0 * sum(CASE WHEN json_parse_ok = true THEN 1 ELSE 0 END) / count(*),1) AS \"JSON %\" FROM senate_telemetry WHERE $__timeFilter(timestamp) AND dry_run = false GROUP BY 1, 2 HAVING count(*) >= 2 ORDER BY 1, 2"
         }
       ],
-      "title": "JSON Compliance Trend \u2014 4-Hour Bins",
+      "title": "JSON Compliance Trend — 4-Hour Bins",
       "type": "timeseries"
     },
     {
@@ -1072,7 +1076,7 @@
           "rawSql": "SELECT date_trunc('hour', timestamp) + (floor(extract(epoch from timestamp - date_trunc('day',timestamp)) / 14400) * interval '4 hours') AS time, base_model AS metric, round(avg(latency_ms)/1000.0,2) AS \"Latency (s)\" FROM senate_telemetry WHERE $__timeFilter(timestamp) AND dry_run = false GROUP BY 1, 2 HAVING count(*) >= 2 ORDER BY 1, 2"
         }
       ],
-      "title": "Latency Trend \u2014 4-Hour Bins",
+      "title": "Latency Trend — 4-Hour Bins",
       "type": "timeseries"
     },
     {
@@ -1165,7 +1169,7 @@
           "rawSql": "SELECT model_id AS \"Model (ID)\", model_string AS \"Requested Model\", count(*) AS \"Calls (OR)\", round(100.0 * sum(CASE WHEN model_verified = true THEN 1 ELSE 0 END) / count(*),1) AS \"Verified %\", string_agg(DISTINCT served_model, ', ' ORDER BY served_model) FILTER (WHERE model_verified = false) AS \"Substituted With\" FROM senate_telemetry WHERE timestamp > now() - interval '7 days' AND dry_run = false AND model_verified IS NOT NULL GROUP BY model_id, model_string HAVING count(*) >= 2 ORDER BY \"Verified %\" ASC"
         }
       ],
-      "title": "Model Substitution \u2014 OpenRouter (7 days)",
+      "title": "Model Substitution — OpenRouter (7 days)",
       "type": "table"
     },
     {
@@ -1793,7 +1797,7 @@
           "refId": "A"
         }
       ],
-      "title": "A3 Gate \u2014 Recent Rejections with Reasoning",
+      "title": "A3 Gate — Recent Rejections with Reasoning",
       "type": "table"
     },
     {
@@ -1863,7 +1867,7 @@
           "refId": "A"
         }
       ],
-      "title": "B2 Reviewer \u2014 Recent Verdicts with Reasoning & Issues",
+      "title": "B2 Reviewer — Recent Verdicts with Reasoning & Issues",
       "type": "table"
     },
     {
@@ -2083,19 +2087,19 @@
                     "options": {
                       "error": {
                         "color": "orange",
-                        "text": "\u26a0\ufe0f error"
+                        "text": "⚠️ error"
                       },
                       "failing": {
                         "color": "red",
-                        "text": "\u274c failing"
+                        "text": "❌ failing"
                       },
                       "passing": {
                         "color": "green",
-                        "text": "\u2705 passing"
+                        "text": "✅ passing"
                       },
                       "pending": {
                         "color": "blue",
-                        "text": "\u23f3 pending"
+                        "text": "⏳ pending"
                       }
                     },
                     "type": "value"
@@ -2172,6 +2176,6 @@
   },
   "timepicker": {},
   "timezone": "utc",
-  "title": "QUASI Pauli-Test \u2014 Model Performance",
+  "title": "QUASI Pauli-Test — Model Performance",
   "uid": "quasi-model-performance"
 }


### PR DESCRIPTION
## Summary

- Grafana Stat panels with `lastNotNull` reducer show **"No data"** when the SQL query returns only a text column — they need a numeric field to reduce
- Both **Top Performer** (panel 10) and **Sir Slopalot** (panel 11) were affected
- Fix: restructure SQL to return two columns — `base_model AS "metric"` (label) + `Approval %` (numeric) — and set `textMode: "value_and_name"`
- Added `unit: "percent"`, `decimals: 0` for proper rendering

## Test plan

- [ ] Import updated `quasi-senate/grafana/model-performance.json` into Grafana
- [ ] Verify Top Performer panel shows `<model-name>` + `<N>%` (e.g. `llama4  42%`)
- [ ] Verify Sir Slopalot panel shows worst performer numerically
- [ ] Confirm no regression on other panels in the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)