### PR TITLE
fix: #374 — Define and validate HAL Contract JSON schema for backend exe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,45 @@ jobs:
           echo "✅ CLI loads cleanly"
 
 
+  # ── HAL Contract Validation ───────────────────────────────────────────
+  hal-contract:
+    name: "Layer 0 · HAL Contract validation"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install jsonschema
+        run: pip install jsonschema
+
+      - name: Validate HAL Contract schema
+        run: |
+          python3 -c "
+          import json
+          import jsonschema
+          import os
+          
+          # Load the HAL contract schema
+          with open('afana/hal-contract.json', 'r') as f:
+              schema = json.load(f)
+          
+          # Validate all fixture files against the schema
+          fixtures_dir = 'afana/tests/fixtures/hal_requests/'
+          if os.path.exists(fixtures_dir):
+              for filename in os.listdir(fixtures_dir):
+                  if filename.endswith('.json'):
+                      with open(os.path.join(fixtures_dir, filename), 'r') as f:
+                          instance = json.load(f)
+                      jsonschema.validate(instance, schema)
+                      print(f'✅ {filename} validates against HAL contract')
+          print('✅ HAL Contract validation passed')
+          "
+
   # ── Quality Radar ①: Compiler boundary — no vendor SDKs in afana/ ────────
   compiler-boundary:
     name: "Quality Radar ① · Compiler boundary"

--- a/afana/hal-contract.json
+++ b/afana/hal-contract.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "HAL Contract for Quantum Execution Requests",
+  "description": "Schema for quantum hardware execution requests in the QUASI OS",
+  "type": "object",
+  "required": [
+    "circuit_payload",
+    "backend_policy",
+    "shots",
+    "error_mitigation",
+    "signature_blob"
+  ],
+  "properties": {
+    "circuit_payload": {
+      "type": "object",
+      "description": "The quantum circuit to execute, in a backend-agnostic format"
+    },
+    "backend_policy": {
+      "type": "string",
+      "description": "Backend selection policy for execution",
+      "enum": ["least_busy", "simulator", "specific_backend"]
+    },
+    "shots": {
+      "type": "integer",
+      "description": "Number of shots to execute",
+      "minimum": 1
+    },
+    "error_mitigation": {
+      "type": "object",
+      "description": "Error mitigation settings",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "technique": {
+          "type": "string",
+          "enum": ["none", "zero_noise_extrapolation", "probabilistic_error_cancellation"]
+        }
+      },
+      "required": ["enabled"]
+    },
+    "signature_blob": {
+      "type": "string",
+      "description": "Deterministic signature for request authentication"
+    }
+  }
+}

--- a/afana/tests/fixtures/hal_requests/sample_request_1.json
+++ b/afana/tests/fixtures/hal_requests/sample_request_1.json
@@ -1,0 +1,15 @@
+{
+  "circuit_payload": {
+    "operations": [
+      {"gate": "H", "qubits": [0]},
+      {"gate": "CX", "qubits": [0, 1]}
+    ]
+  },
+  "backend_policy": "least_busy",
+  "shots": 1024,
+  "error_mitigation": {
+    "enabled": true,
+    "technique": "zero_noise_extrapolation"
+  },
+  "signature_blob": "abc123signature"
+}

--- a/afana/tests/fixtures/hal_requests/sample_request_2.json
+++ b/afana/tests/fixtures/hal_requests/sample_request_2.json
@@ -1,0 +1,14 @@
+{
+  "circuit_payload": {
+    "operations": [
+      {"gate": "RX", "qubits": [0], "parameters": [1.57]},
+      {"gate": "RY", "qubits": [1], "parameters": [0.78]}
+    ]
+  },
+  "backend_policy": "simulator",
+  "shots": 2048,
+  "error_mitigation": {
+    "enabled": false
+  },
+  "signature_blob": "def456signature"
+}


### PR DESCRIPTION
Closes #374

**Solver:** `qwen3-coder` (qwen/qwen3-coder)
**Provider:** openrouter
**License:** Apache-2.0
**Origin:** China / Alibaba

**Reasoning:** I need to create a HAL Contract JSON schema file and update the CI workflow to validate it. Based on the issue description, I'll create the schema with required fields: circuit payload, backend selection policy, shot count, error-mitigation flags, and a deterministic signature blob.

---
*Autonomous completion — Pauli-Test Leaderboard B*
*Contribution-Agent: qwen3-coder*