### PR TITLE
fix: #412 — Implement HAL Contract client bindings for IBM/IQM in quasi-

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,10 @@ jobs:
           python3 quasi-agent/generate_issue.py --list-models
           echo "✅ CLI loads cleanly"
 
+      - name: Run pytest
+        working-directory: quasi-agent
+        run: pytest tests/ -v --tb=short
+
 
   # ── Afana compiler (Rust) ──────────────────────────────────────────────────
   afana:

--- a/quasi-agent/__init__.py
+++ b/quasi-agent/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright 2026 QUASI Contributors
+"""QUASI agent package."""

--- a/quasi-agent/hal_client.py
+++ b/quasi-agent/hal_client.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright 2026 QUASI Contributors
+"""
+HAL Contract client bindings for IBM/IQM backends.
+
+Implements the HAL Contract specification for job submission,
+status polling, and result retrieval from QUASI-compatible hardware.
+"""
+
+import json
+import os
+from typing import Any, Literal
+import urllib.request
+import urllib.error
+
+
+# HAL Contract v2.2 job states
+JobStatus = Literal[
+    "queued",
+    "running",
+    "completed",
+    "failed",
+    "cancelled",
+]
+
+
+# Backend identifiers
+Backend = Literal[
+    "ibm_torino",
+    "iqm_garnet",
+]
+
+
+# Default HAL endpoints (can be overridden via environment)
+DEFAULT_ENDPOINTS: dict[Backend, str] = {
+    "ibm_torino": "https://hal.ibm.example.com/v1",
+    "iqm_garnet": "https://hal.iqm.example.com/v1",
+}
+
+
+def _get_endpoint(backend: Backend) -> str:
+    """Get the HAL endpoint URL for a backend."""
+    env_key = f"HAL_{backend.upper()}_ENDPOINT"
+    return os.environ.get(env_key, DEFAULT_ENDPOINTS[backend])
+
+
+def submit_job(qasm_str: str, backend: Backend) -> str:
+    """Submit a QASM3 job to a HAL-compatible backend.
+
+    Args:
+        qasm_str: OpenQASM 3 program as a string.
+        backend: Backend identifier (e.g., "ibm_torino", "iqm_garnet").
+
+    Returns:
+        Job ID string.
+
+    Raises:
+        ValueError: If qasm_str is empty or backend is invalid.
+        RuntimeError: If the submission fails.
+    """
+    if not qasm_str or not qasm_str.strip():
+        raise ValueError("qasm_str must be a non-empty string")
+
+    if backend not in DEFAULT_ENDPOINTS:
+        raise ValueError(f"Unknown backend: {backend}")
+
+    endpoint = _get_endpoint(backend)
+    url = f"{endpoint}/jobs"
+
+    # HAL Contract v2.2 job submission schema
+    payload = {
+        "qasm": qasm_str,
+        "backend": backend,
+        "format": "qasm3",
+    }
+
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": "quasi-agent/0.1",
+        },
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            response = json.loads(resp.read())
+            job_id = response.get("job_id")
+            if not job_id:
+                raise RuntimeError("Response missing job_id field")
+            return job_id
+    except urllib.error.HTTPError as e:
+        error_body = e.read().decode()
+        raise RuntimeError(f"HTTP {e.code}: {error_body}") from e
+    except Exception as e:
+        raise RuntimeError(f"Submission failed: {e}") from e
+
+
+def get_job_status(job_id: str) -> dict[str, Any]:
+    """Query the status of a submitted job.
+
+    Args:
+        job_id: Job ID returned by submit_job.
+
+    Returns:
+        Dictionary with at least:
+            - "status": JobStatus string
+            - "backend": Backend identifier
+            - "result": Optional result data (if completed)
+
+    Raises:
+        ValueError: If job_id is empty.
+        RuntimeError: If the query fails.
+    """
+    if not job_id or not job_id.strip():
+        raise ValueError("job_id must be a non-empty string")
+
+    # For now, we need to determine which backend this job belongs to.
+    # In a real implementation, this would be stored or queried from a registry.
+    # We'll try all known backends.
+    for backend in DEFAULT_ENDPOINTS:
+        endpoint = _get_endpoint(backend)
+        url = f"{endpoint}/jobs/{job_id}"
+
+        req = urllib.request.Request(
+            url,
+            headers={
+                "Accept": "application/json",
+                "User-Agent": "quasi-agent/0.1",
+            },
+        )
+
+        try:
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                response = json.loads(resp.read())
+                # Validate response has required fields
+                if "status" not in response:
+                    raise RuntimeError("Response missing status field")
+                return response
+        except urllib.error.HTTPError as e:
+            if e.code == 404:
+                continue  # Try next backend
+            raise RuntimeError(f"HTTP {e.code}: {e.read().decode()}") from e
+        except Exception as e:
+            raise RuntimeError(f"Query failed: {e}") from e
+
+    raise RuntimeError(f"Job {job_id} not found on any known backend")

--- a/quasi-agent/tests/__init__.py
+++ b/quasi-agent/tests/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright 2026 QUASI Contributors
+"""Tests for quasi-agent."""

--- a/quasi-agent/tests/test_hal_client.py
+++ b/quasi-agent/tests/test_hal_client.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright 2026 QUASI Contributors
+"""
+Unit tests for HAL Contract client bindings.
+
+Validates that HTTP request bodies conform to the HAL Contract JSON schema.
+"""
+
+import json
+from unittest.mock import Mock, patch
+import urllib.error
+
+import pytest
+
+import sys
+from pathlib import Path
+
+# Add parent directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from hal_client import Backend, JobStatus, submit_job, get_job_status
+
+
+# Sample QASM3 program
+SAMPLE_QASM = """
+OPENQASM 3;
+include "stdgates.inc";
+qubit[2] q;
+bit[2] c;
+h q[0];
+cx q[0], q[1];
+c[0] = measure q[0];
+c[1] = measure q[1];
+"""
+
+
+class TestSubmitJob:
+    """Tests for submit_job function."""
+
+    def test_submit_job_validates_qasm_str(self):
+        """submit_job raises ValueError for empty qasm_str."""
+        with pytest.raises(ValueError, match="qasm_str must be a non-empty string"):
+            submit_job("", "ibm_torino")
+
+        with pytest.raises(ValueError, match="qasm_str must be a non-empty string"):
+            submit_job("   ", "ibm_torino")
+
+    def test_submit_job_validates_backend(self):
+        """submit_job raises ValueError for unknown backend."""
+        with pytest.raises(ValueError, match="Unknown backend"):
+            submit_job(SAMPLE_QASM, "unknown_backend")  # type: ignore
+
+    @patch("hal_client.urllib.request.urlopen")
+    def test_submit_job_sends_correct_payload(self, mock_urlopen):
+        """submit_job sends HAL Contract v2.2 compliant JSON payload."""
+        # Mock successful response
+        mock_response = Mock()
+        mock_response.read.return_value = json.dumps({"job_id": "test-job-123"}).encode()
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+
+        job_id = submit_job(SAMPLE_QASM, "ibm_torino")
+
+        # Verify request was made
+        assert mock_urlopen.called
+        req = mock_urlopen.call_args[0][0]
+
+        # Verify HTTP method and headers
+        assert req.method == "POST"
+        assert req.headers["Content-Type"] == "application/json"
+        assert req.headers["Accept"] == "application/json"
+
+        # Verify payload structure matches HAL Contract schema
+        payload = json.loads(req.data)
+        assert payload["qasm"] == SAMPLE_QASM
+        assert payload["backend"] == "ibm_torino"
+        assert payload["format"] == "qasm3"
+
+        # Verify job ID returned
+        assert job_id == "test-job-123"
+
+    @patch("hal_client.urllib.request.urlopen")
+    def test_submit_job_iqm_backend(self, mock_urlopen):
+        """submit_job works with IQM Garnet backend."""
+        mock_response = Mock()
+        mock_response.read.return_value = json.dumps({"job_id": "iqm-job-456"}).encode()
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+
+        job_id = submit_job(SAMPLE_QASM, "iqm_garnet")
+
+        req = mock_urlopen.call_args[0][0]
+        payload = json.loads(req.data)
+        assert payload["backend"] == "iqm_garnet"
+        assert job_id == "iqm-job-456"
+
+    @patch("hal_client.urllib.request.urlopen")
+    def test_submit_job_http_error(self, mock_urlopen):
+        """submit_job raises RuntimeError on HTTP error."""
+        mock_urlopen.side_effect = urllib.error.HTTPError(
+            url="http://test",
+            code=500,
+            msg="Internal Server Error",
+            hdrs={},
+            fp=None,
+        )
+
+        with pytest.raises(RuntimeError, match="HTTP 500"):
+            submit_job(SAMPLE_QASM, "ibm_torino")
+
+    @patch("hal_client.urllib.request.urlopen")
+    def test_submit_job_missing_job_id(self, mock_urlopen):
+        """submit_job raises RuntimeError when response lacks job_id."""
+        mock_response = Mock()
+        mock_response.read.return_value = json.dumps({}).encode()
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+
+        with pytest.raises(RuntimeError, match="Response missing job_id field"):
+            submit_job(SAMPLE_QASM, "ibm_torino")
+
+
+class TestGetJobStatus:
+    """Tests for get_job_status function."""
+
+    def test_get_job_status_validates_job_id(self):
+        """get_job_status raises ValueError for empty job_id."""
+        with pytest.raises(ValueError, match="job_id must be a non-empty string"):
+            get_job_status("")
+
+        with pytest.raises(ValueError, match="job_id must be a non-empty string"):
+            get_job_status("   ")
+
+    @patch("hal_client.urllib.request.urlopen")
+    def test_get_job_status_completed(self, mock_urlopen):
+        """get_job_status returns completed job status."""
+        mock_response = Mock()
+        mock_response.read.return_value = json.dumps({
+            "status": "completed",
+            "backend": "ibm_torino",
+            "result": {"counts": {"00": 500, "11": 500}},
+        }).encode()
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+
+        status = get_job_status("test-job-123")
+
+        assert status["status"] == "completed"
+        assert status["backend"] == "ibm_torino"
+        assert "result" in status
+        assert status["result"]["counts"]["00"] == 500
+
+    @patch("hal_client.urllib.request.urlopen")
+    def test_get_job_status_running(self, mock_urlopen):
+        """get_job_status returns running job status."""
+        mock_response = Mock()
+        mock_response.read.return_value = json.dumps({
+            "status": "running",
+            "backend": "iqm_garnet",
+        }).encode()
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+
+        status = get_job_status("test-job-456")
+
+        assert status["status"] == "running"
+        assert status["backend"] == "iqm_garnet"
+
+    @patch("hal_client.urllib.request.urlopen")
+    def test_get_job_status_failed(self, mock_urlopen):
+        """get_job_status returns failed job status."""
+        mock_response = Mock()
+        mock_response.read.return_value = json.dumps({
+            "status": "failed",
+            "backend": "ibm_torino",
+            "error": "QPU calibration error",
+        }).encode()
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+
+        status = get_job_status("test-job-789")
+
+        assert status["status"] == "failed"
+        assert status["error"] == "QPU calibration error"
+
+    @patch("hal_client.urllib.request.urlopen")
+    def test_get_job_status_not_found(self, mock_urlopen):
+        """get_job_status raises RuntimeError when job not found."""
+        mock_urlopen.side_effect = urllib.error.HTTPError(
+            url="http://test",
+            code=404,
+            msg="Not Found",
+            hdrs={},
+            fp=None,
+        )
+
+        with pytest.raises(RuntimeError, match="Job test-job-999 not found"):
+            get_job_status("test-job-999")
+
+    @patch("hal_client.urllib.request.urlopen")
+    def test_get_job_status_missing_status_field(self, mock_urlopen):
+        """get_job_status raises RuntimeError when response lacks status."""
+        mock_response = Mock()
+        mock_response.read.return_value = json.dumps({}).encode()
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+
+        with pytest.raises(RuntimeError, match="Response missing status field"):
+            get_job_status("test-job-123")


### PR DESCRIPTION
Closes #412

**Solver:** `glm-4.7` (zai-org/GLM-4.7)
**Provider:** huggingface
**License:** MIT
**Origin:** China / Zhipu AI

**Reasoning:** Created HAL Contract client bindings with submit_job and get_job_status functions, along with comprehensive unit tests that validate the JSON schema compliance, and added pytest execution to the CI agent layer.

---
*Autonomous completion — Pauli-Test Leaderboard B*
*Contribution-Agent: glm-4.7*