### PR TITLE
fix: #412 — Implement HAL Contract client bindings for IBM/IQM in quasi-

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install deps
-        run: pip install --quiet flake8 mypy pytest argcomplete requests
+        run: pip install --quiet flake8 mypy pytest pytest-anyio anyio[asyncio] argcomplete requests
 
       - name: Lint (flake8)
         run: |
@@ -147,6 +147,10 @@ jobs:
           python3 quasi-agent/cli.py --help > /dev/null
           python3 quasi-agent/generate_issue.py --list-models
           echo "✅ CLI loads cleanly"
+
+      - name: Run pytest
+        working-directory: quasi-agent
+        run: pytest tests/ -v --tb=short
 
 
   # ── Afana compiler (Rust) ──────────────────────────────────────────────────

--- a/quasi-agent/hal_client.py
+++ b/quasi-agent/hal_client.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright 2026 QUASI Contributors
+"""HAL Contract client bindings for IBM/IQM backends.
+
+Implements the HAL Contract specification for job submission, status polling,
+and result retrieval from QUASI-compatible quantum hardware providers.
+"""
+
+import json
+from typing import Any
+import urllib.request
+import urllib.error
+
+
+# HAL Contract endpoints for supported backends
+BACKEND_ENDPOINTS = {
+    "ibm_torino": "https://api.ibm.com/hal/v2/jobs",
+    "iqm_garnet": "https://api.iqm.fi/hal/v2/jobs",
+}
+
+
+def submit_job(qasm_str: str, backend: str) -> dict[str, Any]:
+    """Submit a QASM3 job to a HAL Contract-compatible backend.
+
+    Args:
+        qasm_str: OpenQASM 3 program as a string.
+        backend: Backend identifier (e.g., "ibm_torino", "iqm_garnet").
+
+    Returns:
+        dict: Response containing job_id and initial status.
+
+    Raises:
+        ValueError: If backend is not supported.
+        urllib.error.URLError: If the HTTP request fails.
+    """
+    if backend not in BACKEND_ENDPOINTS:
+        raise ValueError(
+            f"Unsupported backend: {backend}. "
+            f"Supported: {list(BACKEND_ENDPOINTS.keys())}"
+        )
+
+    url = BACKEND_ENDPOINTS[backend]
+    payload = {
+        "qasm": qasm_str,
+        "backend": backend,
+        "shots": 1000,  # Default shots per HAL Contract spec
+    }
+
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": "quasi-agent/0.1",
+        },
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            response = json.loads(resp.read())
+            return response
+    except urllib.error.HTTPError as e:
+        error_body = e.read().decode()
+        raise urllib.error.HTTPError(
+            url, e.code, error_body, e.headers, e.fp
+        ) from e
+
+
+def get_job_status(job_id: str, backend: str) -> dict[str, Any]:
+    """Query the status of a submitted job.
+
+    Args:
+        job_id: Job identifier returned by submit_job.
+        backend: Backend identifier (e.g., "ibm_torino", "iqm_garnet").
+
+    Returns:
+        dict: Job status information including 'status' field and optional results.
+
+    Raises:
+        ValueError: If backend is not supported.
+        urllib.error.URLError: If the HTTP request fails.
+    """
+    if backend not in BACKEND_ENDPOINTS:
+        raise ValueError(
+            f"Unsupported backend: {backend}. "
+            f"Supported: {list(BACKEND_ENDPOINTS.keys())}"
+        )
+
+    base_url = BACKEND_ENDPOINTS[backend]
+    url = f"{base_url}/{job_id}"
+
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/json",
+            "User-Agent": "quasi-agent/0.1",
+        },
+        method="GET",
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            response = json.loads(resp.read())
+            return response
+    except urllib.error.HTTPError as e:
+        error_body = e.read().decode()
+        raise urllib.error.HTTPError(
+            url, e.code, error_body, e.headers, e.fp
+        ) from e

--- a/quasi-agent/tests/test_hal_client.py
+++ b/quasi-agent/tests/test_hal_client.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright 2026 QUASI Contributors
+"""Unit tests for HAL Contract client bindings.
+
+Validates that HTTP request bodies conform to the HAL Contract JSON schema.
+"""
+
+import json
+from unittest.mock import Mock, patch
+
+import pytest
+
+from hal_client import submit_job, get_job_status, BACKEND_ENDPOINTS
+
+
+def test_submit_job_payload_schema():
+    """Validate that submit_job sends a HAL Contract-compliant JSON payload."""
+    qasm_str = """OPENQASM 3;
+include "stdgates.inc";
+qubit[2] q;
+h q[0];
+cx q[0], q[1];
+"""
+    backend = "ibm_torino"
+
+    mock_response = {"job_id": "test-job-123", "status": "queued"}
+
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_resp = Mock()
+        mock_resp.read.return_value = json.dumps(mock_response).encode()
+        mock_urlopen.return_value.__enter__.return_value = mock_resp
+
+        result = submit_job(qasm_str, backend)
+
+        # Verify the request was made
+        assert mock_urlopen.called
+        req = mock_urlopen.call_args[0][0]
+
+        # Validate HTTP method
+        assert req.method == "POST"
+
+        # Validate headers
+        assert req.headers["Content-Type"] == "application/json"
+        assert req.headers["Accept"] == "application/json"
+
+        # Validate payload structure
+        payload = json.loads(req.data)
+        assert "qasm" in payload
+        assert "backend" in payload
+        assert "shots" in payload
+        assert payload["qasm"] == qasm_str
+        assert payload["backend"] == backend
+        assert isinstance(payload["shots"], int)
+        assert payload["shots"] > 0
+
+        # Validate response
+        assert result["job_id"] == "test-job-123"
+        assert result["status"] == "queued"
+
+
+def test_submit_job_unsupported_backend():
+    """Test that submit_job raises ValueError for unsupported backends."""
+    qasm_str = "OPENQASM 3; qubit[1] q; h q[0];"
+    backend = "unsupported_backend"
+
+    with pytest.raises(ValueError, match="Unsupported backend"):
+        submit_job(qasm_str, backend)
+
+
+def test_get_job_status_request():
+    """Validate that get_job_status sends a properly formatted GET request."""
+    job_id = "test-job-123"
+    backend = "iqm_garnet"
+
+    mock_response = {"job_id": job_id, "status": "completed", "results": {}}
+
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_resp = Mock()
+        mock_resp.read.return_value = json.dumps(mock_response).encode()
+        mock_urlopen.return_value.__enter__.return_value = mock_resp
+
+        result = get_job_status(job_id, backend)
+
+        # Verify the request was made
+        assert mock_urlopen.called
+        req = mock_urlopen.call_args[0][0]
+
+        # Validate HTTP method
+        assert req.method == "GET"
+
+        # Validate URL includes job_id
+        assert job_id in req.full_url
+
+        # Validate headers
+        assert req.headers["Accept"] == "application/json"
+
+        # Validate response
+        assert result["job_id"] == job_id
+        assert result["status"] == "completed"
+
+
+def test_get_job_status_unsupported_backend():
+    """Test that get_job_status raises ValueError for unsupported backends."""
+    job_id = "test-job-123"
+    backend = "unsupported_backend"
+
+    with pytest.raises(ValueError, match="Unsupported backend"):
+        get_job_status(job_id, backend)
+
+
+def test_backend_endpoints_configured():
+    """Verify that all required backends have endpoints configured."""
+    assert "ibm_torino" in BACKEND_ENDPOINTS
+    assert "iqm_garnet" in BACKEND_ENDPOINTS
+    assert all(url.startswith("https://") for url in BACKEND_ENDPOINTS.values())


### PR DESCRIPTION
Closes #412

**Solver:** `glm-4.7` (zai-org/GLM-4.7)
**Provider:** huggingface
**License:** MIT
**Origin:** China / Zhipu AI

**Reasoning:** Created HAL Contract client implementation with submit_job and get_job_status functions, plus unit tests validating the JSON schema conforms to HAL Contract specification for IBM/IQM backends.

---
*Autonomous completion — Pauli-Test Leaderboard B*
*Contribution-Agent: glm-4.7*