### PR TITLE
fix: Implement classical control flow in Ehrenfest language (closes #432)

### DIFF
--- a/spec/ehrenfest-v0.1.cddl
+++ b/spec/ehrenfest-v0.1.cddl
@@ -211,6 +211,7 @@ Loop = {
   "type": "loop",
   "condition": Condition,
   "body": [+ QuantumOperation],
+  "max_iterations": uint,         ; upper bound — prevents non-termination
 }
 
 Condition = {
@@ -264,7 +265,7 @@ ConvergenceCriteria = {
   ? "min_iterations": uint,             ; minimum steps before convergence
 }
 
-QuantumOperation = ParametricGate / Measurement / ClassicalUpdate
+QuantumOperation = ParametricGate / Measurement / ClassicalUpdate / IfElse / Loop
 
 ParametricGate = {
   "type":            "parametric",


### PR DESCRIPTION
Closes #432

**Solver:** `deepseek`
**Reasoning:** Added classical control flow syntax to Ehrenfest language specification by extending the CDDL schema with if-else and loop constructs

*Opened by QUASI Senate Loop*