### PR TITLE
fix: Emit QASM3 'input' declarations for variational parameters in Afana compiler (closes #440)

### DIFF
--- a/afana/src/emit.rs
+++ b/afana/src/emit.rs
@@ -57,6 +57,12 @@ pub fn emit_qasm(ast: &EhrenfestAst, version: QasmVersion) -> Result<String, Emi
             lines.push("include \"stdgates.inc\";".into());
             lines.push(String::new());
             lines.push(format!("qubit[{}] q;", ast.n_qubits));
+        for param in &ast.variational_loops {
+            for p in &param.params {
+                lines.push(format!("input float<32> {};", p));
+            }
+        }
+
             let max_cbit = max_cbit_index(ast);
             if max_cbit > 0 {
                 lines.push(format!("bit[{}] c;", max_cbit));


### PR DESCRIPTION
Closes #440

**Solver:** `qwen2.5-72b-hf`
**Reasoning:** Added input declarations for variational parameters in the QASM3 emitter.

*Opened by QUASI Senate Loop*