### PR TITLE
Fix senate PR quality: pre-review cargo check, prompt guardrails

### DIFF
--- a/quasi-senate/src/pipeline.rs
+++ b/quasi-senate/src/pipeline.rs
@@ -658,6 +658,40 @@ pub async fn run_solve_pipeline(ctx: &mut AppContext, issue_number: u32) -> Resu
             }
         };
 
+        // Pre-review compilation gate — check if the solver's edits compile
+        // before wasting a reviewer API call on non-compiling code.
+        let has_rust_edits = solve_result
+            .edits
+            .iter()
+            .any(|e| e.file.ends_with(".rs"))
+            || solve_result
+                .new_files
+                .keys()
+                .any(|p| p.ends_with(".rs"));
+
+        if has_rust_edits && !ctx.dry_run {
+            info!("pipeline: pre-review cargo check for #{issue_number}");
+            match pre_review_cargo_check(&solve_result).await {
+                Ok(()) => {
+                    info!("pipeline: pre-review cargo check passed for #{issue_number}");
+                }
+                Err(compiler_output) => {
+                    warn!(
+                        "pipeline: pre-review cargo check FAILED for #{issue_number} (model={}) — skipping reviewer",
+                        b1_entry.id
+                    );
+                    solver_exclude.push(b1_entry.id.to_string());
+                    retry_feedback = Some(format!(
+                        "Your solution does not compile. Compiler output:\n{compiler_output}\n\n\
+                         Fix the compilation errors. If you create new `.rs` files in `afana/src/`, \
+                         add `pub mod <name>;` to `afana/src/lib.rs`. Do not reference types or \
+                         functions that don't exist."
+                    ));
+                    continue;
+                }
+            }
+        }
+
         // Post solution to Matrix #senate-solutions
         if let Some(bot) = &ctx.matrix {
             let (plain, html) =
@@ -1130,4 +1164,91 @@ async fn apply_and_pr(
         .await?;
 
     Ok((pr.html_url, pr.number))
+}
+
+/// Pre-review compilation gate: clone main, apply solver's edits locally,
+/// run `cargo check`. Returns Ok(()) if it compiles, Err(compiler_output)
+/// otherwise. This runs BEFORE the reviewer to avoid wasting reviewer API
+/// calls on non-compiling solutions.
+async fn pre_review_cargo_check(
+    solve_result: &crate::types::SolveResult,
+) -> std::result::Result<(), String> {
+    use std::process::Command;
+
+    let repo_url = "https://github.com/ehrenfest-quantum/quasi.git";
+    let tmp_dir = format!("/tmp/senate-precheck-{}", &Uuid::new_v4().to_string()[..8]);
+
+    // 1. Shallow clone of main
+    let clone = Command::new("git")
+        .args(["clone", "--depth", "1", repo_url, &tmp_dir])
+        .output();
+
+    let clone_output = clone.map_err(|e| format!("git clone failed: {e}"))?;
+    if !clone_output.status.success() {
+        let stderr = String::from_utf8_lossy(&clone_output.stderr);
+        let _ = std::fs::remove_dir_all(&tmp_dir);
+        return Err(format!("git clone failed: {stderr}"));
+    }
+
+    // 2. Apply edits locally
+    for edit in &solve_result.edits {
+        let file_path = format!("{}/{}", tmp_dir, edit.file);
+        match std::fs::read_to_string(&file_path) {
+            Ok(content) => {
+                if !content.contains(&edit.find) {
+                    let _ = std::fs::remove_dir_all(&tmp_dir);
+                    let snippet: String = edit.find.chars().take(80).collect();
+                    return Err(format!(
+                        "Edit find string not found in '{}': {:?}",
+                        edit.file, snippet
+                    ));
+                }
+                let new_content = content.replacen(&edit.find, &edit.replace, 1);
+                if let Err(e) = std::fs::write(&file_path, new_content) {
+                    let _ = std::fs::remove_dir_all(&tmp_dir);
+                    return Err(format!("Failed to write '{}': {e}", edit.file));
+                }
+            }
+            Err(e) => {
+                let _ = std::fs::remove_dir_all(&tmp_dir);
+                return Err(format!("Failed to read '{}': {e}", edit.file));
+            }
+        }
+    }
+
+    // 3. Create new files locally
+    for (path, content) in &solve_result.new_files {
+        let file_path = format!("{}/{}", tmp_dir, path);
+        if let Some(parent) = std::path::Path::new(&file_path).parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        if let Err(e) = std::fs::write(&file_path, content) {
+            let _ = std::fs::remove_dir_all(&tmp_dir);
+            return Err(format!("Failed to create '{}': {e}", path));
+        }
+    }
+
+    // 4. Run cargo check
+    let check = Command::new("cargo")
+        .args(["check", "--workspace"])
+        .current_dir(&tmp_dir)
+        .env("CARGO_TERM_COLOR", "never")
+        .output();
+
+    let check_output = check.map_err(|e| format!("cargo check failed to run: {e}"))?;
+
+    // 5. Clean up
+    let _ = std::fs::remove_dir_all(&tmp_dir);
+
+    if check_output.status.success() {
+        Ok(())
+    } else {
+        let stderr = String::from_utf8_lossy(&check_output.stderr);
+        let truncated: String = if stderr.len() > 2000 {
+            format!("…{}", &stderr[stderr.len() - 2000..])
+        } else {
+            stderr.to_string()
+        };
+        Err(truncated)
+    }
 }

--- a/quasi-senate/src/prompts.rs
+++ b/quasi-senate/src/prompts.rs
@@ -163,7 +163,18 @@ Output ONLY valid JSON in this exact structure — no prose before or after:
 - The issue must NOT cover a blocked topic from the charter.
 - The issue must be meaningfully different from every already-open issue.
 - Acceptance criteria must be CI-verifiable — not "code is readable" or "docs exist".
-- Do not propose CI workflow changes, README edits, or documentation-only issues."#
+- Do not propose CI workflow changes, README edits, or documentation-only issues.
+
+## Anti-patterns — DO NOT generate these issues
+
+- "Implement X gate synthesis/emission" when GateName::X already exists in ast.rs
+  — the emitter handles ALL gates generically. These issues waste solver time.
+- "Add QASM3 syntax validation test for X gate" — trivial tests that just check
+  `qasm.contains("x q[0];")` add no value. Only propose tests that verify
+  non-trivial behavior (parameter formatting, multi-qubit gates, error cases).
+- "Implement type system for X" when type_check.rs already exists — do not
+  propose parallel type systems.
+- Any issue whose solution is ONLY adding an enum variant — this is too trivial."#
 }
 
 pub fn drafter_user_prompt(
@@ -269,6 +280,10 @@ Your task: decide whether this issue should be opened on GitHub.
 - The acceptance criteria are not CI-verifiable
 - The issue is vague ("improve X", "refactor Y") without a specific deliverable
 - The phase quota for this priority area is already reached
+- The issue asks to "implement X gate synthesis/emission" when the gate already
+  exists in GateName enum — the emitter handles all gates generically
+- The issue's only deliverable is a trivial test (e.g. checking a string contains
+  a gate name) that adds no meaningful coverage beyond what existing tests provide
 
 ## Output
 
@@ -350,15 +365,54 @@ Rules:
 - Do not modify lines unrelated to the issue.
 - Keep changes minimal — only what satisfies the acceptance criteria.
 
-CI / GitHub Actions rules (IMPORTANT — violations break the project for everyone):
-- The project already has a complete CI pipeline at .github/workflows/ci.yml covering all four
-  layers (spec/python, board, mcp, agent). Check it before adding anything CI-related.
-- Do NOT create a new workflow file if the issue can be solved by editing ci.yml.
-- Do NOT create duplicate workflow files — one workflow per concern.
-- If you create a new workflow, ensure all commands actually exist. For Python tests use:
-    pip install pytest pytest-anyio anyio[asyncio]  (pytest is NOT in requirements.txt)
-- Never rename a job ID in ci.yml without updating every "needs:" reference to that job.
-- Prefer editing the existing ci.yml job steps over creating a new .github/workflows/*.yml file."#
+## CRITICAL: Check existing implementation BEFORE writing new code
+
+Before writing new modules or functions, READ the repo context carefully to check
+if the functionality already exists through the existing pipeline:
+
+1. **Gates:** `GateName` enum in `ast.rs` already includes H, X, Y, Z, S, T, Sdg,
+   Tdg, Cx, Cz, Swap, Ccx, Rx, Ry, Rz. The `format_gate()` function in `emit.rs`
+   emits ALL gates generically — if a gate is in the enum, it already emits correctly
+   in both QASM2 and QASM3. Do NOT create parallel emission/synthesis modules.
+2. **Synthesis:** `synthesis.rs` has `synthesize_entangling_gates()` which detects
+   CX, CZ, CCX patterns. Extend THIS function — do not create new modules like
+   `gates.rs`, `qasm3/synthesis.rs`, or `gate_synthesis.rs`.
+3. **Types:** `ast.rs` defines Gate, GateName, EhrenfestAst. `type_check.rs` handles
+   type checking. Do NOT create parallel type systems (`types.rs`, `type_checker.rs`).
+
+If the issue asks to "implement X gate synthesis" and GateName::X already exists
+with working emission, the issue may only need a **test** proving it works.
+
+## Architectural rules — violations get the PR rejected
+
+1. **Afana is a Rust-only compiler.** Never create .py files inside `afana/`.
+   Never create Python test files for Rust code. Afana tests are `#[test]` functions
+   in Rust, either inline `#[cfg(test)] mod tests` or in `afana/tests/*.rs`.
+2. **No Python in afana/.** No `__init__.py`, no `test_*.py`, no `.py` files at all.
+   If the issue is about the Afana compiler, ALL code must be Rust.
+3. **Integration tests** in `afana/tests/*.rs` use `use afana::module_name` (not `use crate::`).
+4. **Do not create CI workflow files** — the project has a complete CI pipeline already.
+5. **Do not create new modules** unless the issue explicitly requires it.
+   Prefer adding functions/variants to existing modules.
+6. **Do not create parallel/duplicate modules.** If `synthesis.rs` exists, do not
+   create `gate_synthesis.rs`. If `emit.rs` exists, do not create `qasm3_emitter.rs`.
+   If `type_check.rs` exists, do not create `type_checker.rs` or `types.rs`.
+
+## Rules for new_files
+
+- Use "new_files" ONLY for files that do not exist yet.
+- For Rust test files, place them in `afana/tests/test_name.rs` and use `use afana::...` imports.
+- NEVER create .py files inside `afana/` — this is an architectural violation.
+- If you create a new `.rs` file inside `afana/src/`, you MUST also add a
+  `pub mod <name>;` line to `afana/src/lib.rs` — otherwise it won't compile.
+
+## General rules
+
+- Keep changes minimal — only what satisfies the acceptance criteria.
+- Do not modify lines unrelated to the issue.
+- If the issue is already satisfied, set "edits" to [] and explain in "reasoning".
+- Your solution MUST compile. Run a mental `cargo check` before emitting.
+  If you reference types or functions, verify they exist in the context provided."#
 }
 
 pub fn solver_user_prompt(issue_title: &str, issue_body: &str, repo_context: &str) -> String {
@@ -398,6 +452,14 @@ and does not introduce architectural violations.
 - The solution modifies CI workflows without clear justification
 - The solution introduces code unrelated to the issue
 - The edits reference strings that don't exist in the target files (broken find/replace)
+- The solution creates new source modules that duplicate existing functionality:
+  e.g. creating `gate_synthesis.rs` when `synthesis.rs` exists, or `types.rs`
+  when `type_check.rs` exists, or `qasm3/synthesis.rs` when `emit.rs` already
+  handles emission. Reject with: "Duplicate module — extend existing code instead."
+- The solution contains only stub/placeholder functions (e.g. `return Vec::new()`,
+  `return 0.0`, `todo!()`) without real implementation logic
+- The solution creates new `.rs` files in `afana/src/` without adding the
+  corresponding `pub mod` declaration in `lib.rs` (won't compile)
 
 ## Output
 

--- a/quasi-senate/tests/test_prompts.rs
+++ b/quasi-senate/tests/test_prompts.rs
@@ -137,6 +137,54 @@ fn test_gate_user_prompt_contains_draft_title() {
 }
 
 #[test]
+fn test_solver_system_prompt_warns_against_duplicate_modules() {
+    let prompt = solver_system_prompt();
+    assert!(
+        prompt.contains("Check existing implementation"),
+        "solver prompt must warn against duplicate modules"
+    );
+    assert!(
+        prompt.contains("Do not create parallel/duplicate modules"),
+        "solver prompt must forbid parallel modules"
+    );
+    assert!(
+        prompt.contains("MUST compile"),
+        "solver prompt must require compilation"
+    );
+}
+
+#[test]
+fn test_reviewer_system_prompt_rejects_stubs() {
+    let prompt = reviewer_system_prompt();
+    assert!(
+        prompt.contains("stub/placeholder"),
+        "reviewer prompt must reject stubs"
+    );
+    assert!(
+        prompt.contains("Duplicate module"),
+        "reviewer prompt must reject duplicate modules"
+    );
+}
+
+#[test]
+fn test_gate_system_prompt_rejects_trivial_gate_issues() {
+    let prompt = gate_system_prompt();
+    assert!(
+        prompt.contains("gate already"),
+        "gate prompt must reject redundant gate issues"
+    );
+}
+
+#[test]
+fn test_drafter_system_prompt_has_anti_patterns() {
+    let prompt = drafter_system_prompt();
+    assert!(
+        prompt.contains("Anti-patterns"),
+        "drafter prompt must list anti-patterns"
+    );
+}
+
+#[test]
 fn test_solver_user_prompt_contains_issue_title() {
     let issue_title = "Add ZX-IR rewrite rules for CX decomposition";
     let result = solver_user_prompt(issue_title, "## Body\nSome body", "## Context\nNone");


### PR DESCRIPTION
## Summary
- **Fix A**: Solver prompt now tells models to check existing implementation before creating new modules (prevents parallel architectures)
- **Fix B**: Pre-review `cargo check` gate — non-compiling solutions skip the reviewer entirely, compiler errors feed back to solver for retry
- **Fix C**: Drafter/gate prompts block redundant gate issues and trivial tests
- **Fix D**: Reviewer rejects duplicate modules, stub implementations, and missing `pub mod` declarations

## Test plan
- [x] 4 new prompt tests verify guardrail text is present
- [x] All 54 quasi-senate tests pass
- [x] Zero clippy warnings
- [x] `pre_review_cargo_check()` compiles and handles: clone failure, edit mismatch, new file creation, cargo check pass/fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)