### PR TITLE
Feed recently closed issues + merged PRs to drafter and gate

### DIFF
--- a/quasi-senate/src/drafter.rs
+++ b/quasi-senate/src/drafter.rs
@@ -42,6 +42,24 @@ pub async fn draft_issue(
         .map(|i| format!("  #{}: {}\n", i.number, i.title))
         .collect();
 
+    // 2b. Fetch recently closed issues + merged PRs to avoid re-proposing completed work
+    let closed_issues = github.list_recently_closed_issues(14).await.unwrap_or_default();
+    let closed_issues_str: String = closed_issues
+        .iter()
+        .take(40)
+        .map(|i| format!("  #{}: {}\n", i.number, i.title))
+        .collect();
+
+    let since_14d = (chrono::Utc::now() - chrono::Duration::days(14))
+        .format("%Y-%m-%dT00:00:00Z")
+        .to_string();
+    let merged_prs = github.list_merged_prs_since(&since_14d).await.unwrap_or_default();
+    let merged_prs_str: String = merged_prs
+        .iter()
+        .take(20)
+        .map(|pr| format!("  PR #{}: {}\n", pr.number, pr.title))
+        .collect();
+
     // 3. Fetch ARCHITECTURE.md for file tree context
     let file_tree = github
         .get_file("ARCHITECTURE.md", "main")
@@ -49,8 +67,16 @@ pub async fn draft_issue(
         .map(|fc| fc.content)
         .unwrap_or_else(|_| "(ARCHITECTURE.md unavailable)".to_string());
 
-    // 4. Recent commits placeholder (unavailable in daemon mode)
-    let recent_commits = "(recent commits unavailable in daemon mode)";
+    // 4. Recent completed work (closed issues + merged PRs)
+    let recent_commits = if closed_issues_str.is_empty() && merged_prs_str.is_empty() {
+        "(no recently completed work)".to_string()
+    } else {
+        format!(
+            "Recently closed issues (last 14 days):\n{}\nRecently merged PRs:\n{}",
+            if closed_issues_str.is_empty() { "  (none)\n".to_string() } else { closed_issues_str },
+            if merged_prs_str.is_empty() { "  (none)\n".to_string() } else { merged_prs_str },
+        )
+    };
 
     // 5. Parse charter from JSON
     let charter: Charter = serde_json::from_str(charter_json)?;

--- a/quasi-senate/src/gate.rs
+++ b/quasi-senate/src/gate.rs
@@ -22,6 +22,7 @@ pub async fn gate_review(
     charter: &Charter,
     draft: &IssueDraft,
     open_issues: &str,
+    recently_closed: &str,
     exclude: &[&str],
     counts: &HashMap<String, u32>,
     last_provider: Option<&str>,
@@ -32,7 +33,7 @@ pub async fn gate_review(
 
     // 2. Build prompts
     let system = crate::prompts::gate_system_prompt();
-    let user = crate::prompts::gate_user_prompt(charter, draft, open_issues);
+    let user = crate::prompts::gate_user_prompt(charter, draft, open_issues, recently_closed);
 
     // 3. Dry-run path — return an approving verdict
     if dry_run {

--- a/quasi-senate/src/github.rs
+++ b/quasi-senate/src/github.rs
@@ -125,6 +125,37 @@ impl GitHubClient {
         Ok(collected)
     }
 
+    /// List issues closed in the last `days` days (for dedup context).
+    pub async fn list_recently_closed_issues(&self, days: u32) -> Result<Vec<Issue>> {
+        let since = chrono::Utc::now() - chrono::Duration::days(days as i64);
+        let since_str = since.format("%Y-%m-%dT%H:%M:%SZ").to_string();
+        let url = format!(
+            "{}/issues?state=closed&since={}&per_page=100&sort=updated&direction=desc",
+            self.base_url(),
+            since_str,
+        );
+
+        let resp = self
+            .client
+            .get(&url)
+            .headers(self.default_headers())
+            .send()
+            .await
+            .context("list_recently_closed_issues: network error")?;
+
+        if !resp.status().is_success() {
+            return Err(self.github_error(resp).await);
+        }
+
+        let issues: Vec<Issue> = resp
+            .json()
+            .await
+            .context("list_recently_closed_issues: deserialise")?;
+
+        info!("list_recently_closed_issues: {} issues closed in last {} days", issues.len(), days);
+        Ok(issues)
+    }
+
     pub async fn create_issue(
         &self,
         title: &str,

--- a/quasi-senate/src/pipeline.rs
+++ b/quasi-senate/src/pipeline.rs
@@ -175,6 +175,26 @@ pub async fn run_draft_pipeline(ctx: &mut AppContext) -> Result<u32> {
         .map(|i| format!("  #{}: {}\n", i.number, i.title))
         .collect();
 
+    // 3b. List recently closed issues + merged PRs to prevent re-proposing completed work
+    let closed_issues = ctx.github.list_recently_closed_issues(14).await.unwrap_or_default();
+    let since_14d = (chrono::Utc::now() - chrono::Duration::days(14))
+        .format("%Y-%m-%dT00:00:00Z")
+        .to_string();
+    let merged_prs = ctx.github.list_merged_prs_since(&since_14d).await.unwrap_or_default();
+    let recently_closed_str: String = {
+        let closed: String = closed_issues
+            .iter()
+            .take(40)
+            .map(|i| format!("  #{}: {} [CLOSED]\n", i.number, i.title))
+            .collect();
+        let merged: String = merged_prs
+            .iter()
+            .take(20)
+            .map(|pr| format!("  PR #{}: {} [MERGED]\n", pr.number, pr.title))
+            .collect();
+        format!("{}{}", closed, merged)
+    };
+
     // 4. Determine level from charter
     let level = charter.frontier_level;
 
@@ -273,6 +293,7 @@ pub async fn run_draft_pipeline(ctx: &mut AppContext) -> Result<u32> {
             &charter,
             &draft,
             &open_issues_str,
+            &recently_closed_str,
             &gate_exclude,
             &counts,
             last_provider,

--- a/quasi-senate/src/prompts.rs
+++ b/quasi-senate/src/prompts.rs
@@ -225,7 +225,11 @@ task distribution system.
 
 {file_tree}
 
-## Recent Commits
+## Recently Completed Work — DO NOT re-propose these
+
+The following issues were recently closed and PRs merged. These features are
+ALREADY IMPLEMENTED. Do not propose issues that duplicate, re-state, or
+trivially extend this completed work.
 
 {commits}
 
@@ -298,6 +302,8 @@ Your task: decide whether this issue should be opened on GitHub.
 - **Trivial tests**: Issues whose only deliverable is checking a QASM string
   contains a gate name (e.g. `qasm.contains("h q[0];")`)
 - **CBOR serialization for AST**: cbor.rs already handles CBOR deserialization
+- **Duplicates recently closed work**: If the draft substantially overlaps an issue
+  or PR listed in the "Recently Closed" section, reject it — that work is done
 
 ## Output
 
@@ -310,7 +316,7 @@ Your task: decide whether this issue should be opened on GitHub.
 Emit ONLY the JSON."#
 }
 
-pub fn gate_user_prompt(charter: &Charter, draft: &IssueDraft, open_issues: &str) -> String {
+pub fn gate_user_prompt(charter: &Charter, draft: &IssueDraft, open_issues: &str, recently_closed: &str) -> String {
     let charter_json = serde_json::to_string_pretty(charter)
         .unwrap_or_else(|_| "(charter serialization error)".to_string());
 
@@ -333,6 +339,13 @@ pub fn gate_user_prompt(charter: &Charter, draft: &IssueDraft, open_issues: &str
 ## Already-open GitHub Issues
 
 {open_issues}
+
+## Recently Closed Issues & Merged PRs (last 14 days) — ALREADY DONE
+
+Reject the draft if it duplicates, re-states, or trivially extends any of
+these completed items. The work below is already merged into the codebase.
+
+{recently_closed}
 
 ## Your task
 

--- a/quasi-senate/tests/test_prompts.rs
+++ b/quasi-senate/tests/test_prompts.rs
@@ -129,7 +129,7 @@ fn test_drafter_user_prompt_contains_charter() {
 fn test_gate_user_prompt_contains_draft_title() {
     let charter = dummy_charter();
     let draft = dummy_draft();
-    let result = gate_user_prompt(&charter, &draft, "No open issues");
+    let result = gate_user_prompt(&charter, &draft, "No open issues", "  PR #701: Implement parameter substitution [MERGED]");
     assert!(
         result.contains("Implement ZX-IR gate fusion pass"),
         "gate_user_prompt() does not contain the draft title"


### PR DESCRIPTION
## Summary
- Drafter now sees recently closed issues (14d) + merged PRs as "Recently Completed Work"
- Gate now sees same context with explicit reject criterion for duplicating completed work
- New `list_recently_closed_issues(days)` method in github.rs

Prevents re-proposing work already merged (e.g. param substitution PR #701 was re-proposed 3x as #702, #704, #709).

## Test plan
- [x] All 54 tests pass, zero clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)