### PR TITLE
Unstick drafter: 7-day lookback, 4 attempts

### DIFF
--- a/quasi-senate/src/drafter.rs
+++ b/quasi-senate/src/drafter.rs
@@ -43,17 +43,17 @@ pub async fn draft_issue(
         .collect();
 
     // 2b. Fetch recently closed issues + merged PRs to avoid re-proposing completed work
-    let closed_issues = github.list_recently_closed_issues(14).await.unwrap_or_default();
+    let closed_issues = github.list_recently_closed_issues(7).await.unwrap_or_default();
     let closed_issues_str: String = closed_issues
         .iter()
         .take(40)
         .map(|i| format!("  #{}: {}\n", i.number, i.title))
         .collect();
 
-    let since_14d = (chrono::Utc::now() - chrono::Duration::days(14))
+    let since_7d = (chrono::Utc::now() - chrono::Duration::days(7))
         .format("%Y-%m-%dT00:00:00Z")
         .to_string();
-    let merged_prs = github.list_merged_prs_since(&since_14d).await.unwrap_or_default();
+    let merged_prs = github.list_merged_prs_since(&since_7d).await.unwrap_or_default();
     let merged_prs_str: String = merged_prs
         .iter()
         .take(20)
@@ -72,7 +72,7 @@ pub async fn draft_issue(
         "(no recently completed work)".to_string()
     } else {
         format!(
-            "Recently closed issues (last 14 days):\n{}\nRecently merged PRs:\n{}",
+            "Recently closed issues (last 7 days):\n{}\nRecently merged PRs:\n{}",
             if closed_issues_str.is_empty() { "  (none)\n".to_string() } else { closed_issues_str },
             if merged_prs_str.is_empty() { "  (none)\n".to_string() } else { merged_prs_str },
         )

--- a/quasi-senate/src/pipeline.rs
+++ b/quasi-senate/src/pipeline.rs
@@ -176,11 +176,11 @@ pub async fn run_draft_pipeline(ctx: &mut AppContext) -> Result<u32> {
         .collect();
 
     // 3b. List recently closed issues + merged PRs to prevent re-proposing completed work
-    let closed_issues = ctx.github.list_recently_closed_issues(14).await.unwrap_or_default();
-    let since_14d = (chrono::Utc::now() - chrono::Duration::days(14))
+    let closed_issues = ctx.github.list_recently_closed_issues(7).await.unwrap_or_default();
+    let since_7d = (chrono::Utc::now() - chrono::Duration::days(7))
         .format("%Y-%m-%dT00:00:00Z")
         .to_string();
-    let merged_prs = ctx.github.list_merged_prs_since(&since_14d).await.unwrap_or_default();
+    let merged_prs = ctx.github.list_merged_prs_since(&since_7d).await.unwrap_or_default();
     let recently_closed_str: String = {
         let closed: String = closed_issues
             .iter()
@@ -204,8 +204,8 @@ pub async fn run_draft_pipeline(ctx: &mut AppContext) -> Result<u32> {
     let mut drafter_exclude: Vec<String> = Vec::new();
     let mut retry_feedback: Option<String> = None;
 
-    // 5. Retry loop — up to 2 attempts
-    for retry in 0..2u32 {
+    // 5. Retry loop — up to 4 attempts
+    for retry in 0..4u32 {
         info!("pipeline: A.2 draft attempt {}", retry + 1);
 
         let exclude_refs: Vec<&str> = drafter_exclude.iter().map(|s| s.as_str()).collect();
@@ -567,8 +567,8 @@ pub async fn run_draft_pipeline(ctx: &mut AppContext) -> Result<u32> {
 
     // All retries exhausted
     if let Some(bot) = &ctx.matrix {
-        let plain = "⚠️ Draft shelved after 2 rejected attempts — moving on.".to_string();
-        let html = "<p>⚠️ <b>Draft shelved</b> after 2 rejected attempts — moving on.</p>"
+        let plain = "⚠️ Draft shelved after 4 rejected attempts — moving on.".to_string();
+        let html = "<p>⚠️ <b>Draft shelved</b> after 4 rejected attempts — moving on.</p>"
             .to_string();
         match bot.join_room("#senate-drafts:paulsboutique.hal-contract.org").await {
             Ok(room_id) => {
@@ -580,7 +580,7 @@ pub async fn run_draft_pipeline(ctx: &mut AppContext) -> Result<u32> {
         }
     }
 
-    Err(anyhow!("Draft rejected after 2 attempts"))
+    Err(anyhow!("Draft rejected after 4 attempts"))
 }
 
 // ── B-track ───────────────────────────────────────────────────────────────────

--- a/quasi-senate/src/prompts.rs
+++ b/quasi-senate/src/prompts.rs
@@ -340,7 +340,7 @@ pub fn gate_user_prompt(charter: &Charter, draft: &IssueDraft, open_issues: &str
 
 {open_issues}
 
-## Recently Closed Issues & Merged PRs (last 14 days) — ALREADY DONE
+## Recently Closed Issues & Merged PRs (last 7 days) — ALREADY DONE
 
 Reject the draft if it duplicates, re-states, or trivially extends any of
 these completed items. The work below is already merged into the codebase.


### PR DESCRIPTION
## Summary
- Reduce closed-issue/merged-PR lookback from 14 to 7 days — the 100-issue dedup window was so large every new draft looked like a rehash
- Increase draft retry attempts from 2 to 4

## Test plan
- [x] `cargo build -p quasi-senate --release` passes
- [ ] Deploy to Camelot and trigger manual draft run
- [ ] Verify new issue gets created

🤖 Generated with [Claude Code](https://claude.com/claude-code)