### PR TITLE
Add Hamiltonian-to-circuit Trotterization pipeline enhancements

### DIFF
--- a/afana/src/main.rs
+++ b/afana/src/main.rs
@@ -33,7 +33,7 @@ struct Cli {
     #[arg(long)]
     reduce_t: bool,
 
-    /// Trotter decomposition order (1 or 2).
+    /// Trotter decomposition order (1, 2, or 4).
     #[arg(long, default_value = "1")]
     trotter_order: u32,
 
@@ -75,12 +75,23 @@ fn main() -> Result<()> {
     // Deserialize CBOR binary program.
     let program = cbor::from_cbor_file(&cli.input).context("CBOR deserialization failed")?;
 
-    // Trotterize: Hamiltonian → gate sequence.
+    // Validate Hamiltonian before Trotterization.
+    trotter::validate_hamiltonian(&program).context("Hamiltonian validation failed")?;
+
+    // Trotterize: Hamiltonian → gate sequence (with statistics).
     let order = match cli.trotter_order {
         2 => TrotterOrder::Second,
+        4 => TrotterOrder::Fourth,
         _ => TrotterOrder::First,
     };
-    let mut ast = trotter::trotterize(&program, order);
+    let (mut ast, trotter_stats) = trotter::trotterize_with_stats(&program, order)
+        .context("Trotterization failed")?;
+
+    // Check noise budget against the Trotterized circuit.
+    let noise_budget = trotter::check_noise_budget(&trotter_stats, &program.noise);
+    for warning in &noise_budget.warnings {
+        eprintln!("warning: {warning}");
+    }
 
     // Substitute variational parameters if --param flags given.
     if !cli.params.is_empty() {
@@ -132,15 +143,15 @@ fn main() -> Result<()> {
     let qasm = emit::emit_qasm(&ast, version).context("QASM emission failed")?;
 
     // Optimize if requested.
-    let (output, stats) = if cli.optimize || cli.reduce_t {
+    let (output, opt_stats) = if cli.optimize || cli.reduce_t {
         optimize::optimize_qasm(&qasm, cli.reduce_t)
     } else {
-        let stats = optimize::OptStats {
+        let s = optimize::OptStats {
             gate_count_before: optimize::count_qasm_gates(&qasm),
             gate_count_after: optimize::count_qasm_gates(&qasm),
             ..Default::default()
         };
-        (qasm, stats)
+        (qasm, s)
     };
 
     // Print output.
@@ -148,14 +159,39 @@ fn main() -> Result<()> {
 
     // Print stats to stderr if requested.
     if cli.stats {
+        eprintln!("--- Trotterization ---");
+        eprintln!("{}", trotter::format_trotter_stats(&trotter_stats));
+        eprintln!("--- Noise budget ---");
+        eprintln!(
+            "  Within T1:          {}",
+            if noise_budget.within_t1 { "yes" } else { "NO" }
+        );
+        eprintln!(
+            "  Within T2:          {}",
+            if noise_budget.within_t2 { "yes" } else { "NO" }
+        );
+        eprintln!(
+            "  Fidelity OK:        {}",
+            if noise_budget.fidelity_ok { "yes" } else { "NO" }
+        );
+        eprintln!(
+            "  Est. fidelity:      {:.6}",
+            noise_budget.estimated_fidelity
+        );
         eprintln!("--- Compilation stats ---");
         eprintln!("  Program: {}", ast.name);
         eprintln!("  Qubits:  {}", ast.n_qubits);
         eprintln!("  ZX-IR spiders: {}", zx.spider_count());
         eprintln!("  ZX-IR edges:   {}", zx.edge_count());
-        eprintln!("  Gates before optimization: {}", stats.gate_count_before);
-        eprintln!("  Gates after optimization:  {}", stats.gate_count_after);
-        if let (Some(tb), Some(ta)) = (stats.t_before, stats.t_after) {
+        eprintln!(
+            "  Gates before optimization: {}",
+            opt_stats.gate_count_before
+        );
+        eprintln!(
+            "  Gates after optimization:  {}",
+            opt_stats.gate_count_after
+        );
+        if let (Some(tb), Some(ta)) = (opt_stats.t_before, opt_stats.t_after) {
             eprintln!("  T-gates before: {tb}");
             eprintln!("  T-gates after:  {ta}");
         }

--- a/afana/src/trotter.rs
+++ b/afana/src/trotter.rs
@@ -12,9 +12,48 @@
 //! Each Pauli term e^{-i·θ·P} is decomposed into a basis-change + Rz + undo
 //! pattern. For example, e^{-iθ·X₀Z₁} decomposes to:
 //!   H q0; Rz(2θ) q1; CNOT q0 q1; Rz(2θ) q1; CNOT q0 q1; H q0;
+//!
+//! Supported orders:
+//! - **First-order**: O(dt²) error per step, O(dt) global error.
+//! - **Second-order**: symmetric Suzuki, O(dt³) error per step, O(dt²) global.
+//! - **Fourth-order**: recursive Suzuki (S₄), O(dt⁵) error per step, O(dt⁴) global.
+
+use thiserror::Error;
 
 use crate::ast::*;
-use crate::cbor::{EhrenfestProgram, PauliOp, PauliOpEntry};
+use crate::cbor::{EhrenfestProgram, NoiseConstraint, PauliOp, PauliOpEntry};
+
+// ── Gate timing constants (same as noise.rs) ────────────────────────────────
+
+const SINGLE_QUBIT_GATE_TIME_US: f64 = 0.05;
+const TWO_QUBIT_GATE_TIME_US: f64 = 0.5;
+
+// ── Errors ──────────────────────────────────────────────────────────────────
+
+/// Errors raised during Hamiltonian validation.
+#[derive(Debug, Error)]
+pub enum TrotterError {
+    #[error("empty Hamiltonian: at least one Pauli term is required")]
+    EmptyHamiltonian,
+
+    #[error("non-finite coefficient {coefficient} in Hamiltonian term {term_index}")]
+    NonFiniteCoefficient { term_index: usize, coefficient: f64 },
+
+    #[error("qubit index {qubit} in Hamiltonian term {term_index} out of range (n_qubits={n_qubits})")]
+    QubitOutOfRange {
+        term_index: usize,
+        qubit: usize,
+        n_qubits: usize,
+    },
+
+    #[error("non-finite evolution parameter: dt_us={dt_us}, total_us={total_us}")]
+    NonFiniteEvolution { dt_us: f64, total_us: f64 },
+
+    #[error("zero Trotter steps")]
+    ZeroSteps,
+}
+
+// ── Public types ────────────────────────────────────────────────────────────
 
 /// Trotter decomposition order.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -22,13 +61,148 @@ pub enum TrotterOrder {
     #[default]
     First,
     Second,
+    Fourth,
 }
+
+/// Statistics from a Trotterization pass.
+#[derive(Debug, Clone)]
+pub struct TrotterStats {
+    /// Trotter order used.
+    pub order: TrotterOrder,
+    /// Number of Trotter time steps.
+    pub steps: u32,
+    /// Time step size in microseconds.
+    pub dt_us: f64,
+    /// Number of Hamiltonian terms.
+    pub hamiltonian_terms: usize,
+    /// Total gates generated.
+    pub total_gates: usize,
+    /// Number of single-qubit gates generated.
+    pub single_qubit_gates: usize,
+    /// Number of two-qubit (CX) gates generated.
+    pub two_qubit_gates: usize,
+    /// Estimated Trotter approximation error bound.
+    pub error_bound: f64,
+    /// Estimated circuit execution time in microseconds.
+    pub estimated_time_us: f64,
+}
+
+/// Result of a noise-budget check against a Trotterized circuit.
+#[derive(Debug, Clone)]
+pub struct NoiseBudgetReport {
+    /// Whether the circuit fits within T1 relaxation time.
+    pub within_t1: bool,
+    /// Whether the circuit fits within T2 coherence time.
+    pub within_t2: bool,
+    /// Whether the estimated fidelity meets the minimum gate fidelity.
+    pub fidelity_ok: bool,
+    /// Estimated circuit execution time in microseconds.
+    pub estimated_time_us: f64,
+    /// Estimated circuit fidelity.
+    pub estimated_fidelity: f64,
+    /// Warnings about noise budget violations.
+    pub warnings: Vec<String>,
+}
+
+// ── Validation ──────────────────────────────────────────────────────────────
+
+/// Validate an Ehrenfest program's Hamiltonian before Trotterization.
+///
+/// Checks:
+/// - Hamiltonian has at least one term
+/// - All coefficients are finite
+/// - All qubit indices are within `n_qubits`
+/// - Evolution parameters are finite and non-zero
+pub fn validate_hamiltonian(program: &EhrenfestProgram) -> Result<(), TrotterError> {
+    if program.hamiltonian.terms.is_empty() {
+        return Err(TrotterError::EmptyHamiltonian);
+    }
+
+    if program.evolution.steps == 0 {
+        return Err(TrotterError::ZeroSteps);
+    }
+
+    if !program.evolution.dt_us.is_finite() || !program.evolution.total_us.is_finite() {
+        return Err(TrotterError::NonFiniteEvolution {
+            dt_us: program.evolution.dt_us,
+            total_us: program.evolution.total_us,
+        });
+    }
+
+    let n_qubits = program.system.n_qubits;
+    for (i, term) in program.hamiltonian.terms.iter().enumerate() {
+        if !term.coefficient.is_finite() {
+            return Err(TrotterError::NonFiniteCoefficient {
+                term_index: i,
+                coefficient: term.coefficient,
+            });
+        }
+        for entry in &term.paulis {
+            if entry.qubit >= n_qubits {
+                return Err(TrotterError::QubitOutOfRange {
+                    term_index: i,
+                    qubit: entry.qubit,
+                    n_qubits,
+                });
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// ── Trotter error estimation ────────────────────────────────────────────────
+
+/// Estimate the Trotter approximation error bound.
+///
+/// For a Hamiltonian H = Σ Hₖ with L terms, the error per step is:
+/// - First-order:  ε ≤ L² · max|[Hⱼ,Hₖ]| · dt² / 2
+/// - Second-order: ε ≤ L³ · max|[[Hⱼ,Hₖ],Hₗ]| · dt³ / 12
+/// - Fourth-order: ε ≤ C · L⁵ · ||H||⁵ · dt⁵
+///
+/// We use the simplified bound based on the sum of absolute coefficients
+/// as a proxy for ||H||, since exact commutator norms are expensive.
+pub fn estimate_trotter_error(program: &EhrenfestProgram, order: TrotterOrder) -> f64 {
+    let n_terms = program.hamiltonian.terms.len() as f64;
+    let dt = program.evolution.dt_us;
+    let steps = program.evolution.steps as f64;
+
+    // Hamiltonian norm proxy: sum of absolute coefficients.
+    let h_norm: f64 = program
+        .hamiltonian
+        .terms
+        .iter()
+        .map(|t| t.coefficient.abs())
+        .sum();
+
+    if h_norm == 0.0 || n_terms == 0.0 {
+        return 0.0;
+    }
+
+    // Error per step, then multiply by number of steps for global bound.
+    let per_step = match order {
+        TrotterOrder::First => n_terms * n_terms * h_norm * h_norm * dt * dt / 2.0,
+        TrotterOrder::Second => {
+            n_terms.powi(3) * h_norm.powi(3) * dt.powi(3) / 12.0
+        }
+        TrotterOrder::Fourth => {
+            // Fourth-order Suzuki: error scales as dt^5.
+            // Prefactor from recursive construction.
+            n_terms.powi(5) * h_norm.powi(5) * dt.powi(5) / 720.0
+        }
+    };
+
+    per_step * steps
+}
+
+// ── Trotterization ──────────────────────────────────────────────────────────
 
 /// Derive a gate-level AST from an Ehrenfest physics program via Trotterization.
 ///
 /// The `order` parameter controls the decomposition:
 /// - First-order: e^{-iH₁dt} · e^{-iH₂dt} · ...
 /// - Second-order: symmetric Suzuki-Trotter (forward half-step + reverse half-step)
+/// - Fourth-order: recursive Suzuki (two time-scales)
 pub fn trotterize(program: &EhrenfestProgram, order: TrotterOrder) -> EhrenfestAst {
     let dt = program.evolution.dt_us;
     let mut gates = Vec::new();
@@ -36,23 +210,13 @@ pub fn trotterize(program: &EhrenfestProgram, order: TrotterOrder) -> EhrenfestA
     for _step in 0..program.evolution.steps {
         match order {
             TrotterOrder::First => {
-                for term in &program.hamiltonian.terms {
-                    let theta = term.coefficient * dt;
-                    gates.extend(pauli_rotation_gates(&term.paulis, theta));
-                }
+                trotter_first_order(&program.hamiltonian.terms, dt, &mut gates);
             }
             TrotterOrder::Second => {
-                let half_dt = dt / 2.0;
-                // Forward half-step
-                for term in &program.hamiltonian.terms {
-                    let theta = term.coefficient * half_dt;
-                    gates.extend(pauli_rotation_gates(&term.paulis, theta));
-                }
-                // Backward half-step (reverse order)
-                for term in program.hamiltonian.terms.iter().rev() {
-                    let theta = term.coefficient * half_dt;
-                    gates.extend(pauli_rotation_gates(&term.paulis, theta));
-                }
+                trotter_second_order(&program.hamiltonian.terms, dt, &mut gates);
+            }
+            TrotterOrder::Fourth => {
+                trotter_fourth_order(&program.hamiltonian.terms, dt, &mut gates);
             }
         }
     }
@@ -73,6 +237,174 @@ pub fn trotterize(program: &EhrenfestProgram, order: TrotterOrder) -> EhrenfestA
         type_decls: Vec::new(),
         variational_loops: Vec::new(),
     }
+}
+
+/// Trotterize with validation and statistics.
+///
+/// Validates the Hamiltonian, performs Trotterization, and returns both
+/// the circuit AST and compilation statistics.
+pub fn trotterize_with_stats(
+    program: &EhrenfestProgram,
+    order: TrotterOrder,
+) -> Result<(EhrenfestAst, TrotterStats), TrotterError> {
+    validate_hamiltonian(program)?;
+
+    let ast = trotterize(program, order);
+
+    let single_qubit_gates = ast.gates.iter().filter(|g| g.name.arity() == 1).count();
+    let two_qubit_gates = ast.gates.iter().filter(|g| g.name.arity() >= 2).count();
+
+    let estimated_time_us = single_qubit_gates as f64 * SINGLE_QUBIT_GATE_TIME_US
+        + two_qubit_gates as f64 * TWO_QUBIT_GATE_TIME_US;
+
+    let stats = TrotterStats {
+        order,
+        steps: program.evolution.steps,
+        dt_us: program.evolution.dt_us,
+        hamiltonian_terms: program.hamiltonian.terms.len(),
+        total_gates: ast.gates.len(),
+        single_qubit_gates,
+        two_qubit_gates,
+        error_bound: estimate_trotter_error(program, order),
+        estimated_time_us,
+    };
+
+    Ok((ast, stats))
+}
+
+// ── Noise budget ────────────────────────────────────────────────────────────
+
+/// Check whether a Trotterized circuit fits within the noise budget.
+///
+/// Compares the estimated circuit execution time and fidelity against the
+/// noise constraints from the Ehrenfest program.
+pub fn check_noise_budget(stats: &TrotterStats, noise: &NoiseConstraint) -> NoiseBudgetReport {
+    let estimated_time_us = stats.estimated_time_us;
+    let mut warnings = Vec::new();
+
+    let within_t1 = estimated_time_us <= noise.t1_us;
+    let within_t2 = estimated_time_us <= noise.t2_us;
+
+    if !within_t2 {
+        warnings.push(format!(
+            "circuit time ({:.2} us) exceeds T2 coherence ({:.2} us) — \
+             consider increasing Trotter steps to reduce dt",
+            estimated_time_us, noise.t2_us,
+        ));
+    }
+
+    if !within_t1 {
+        warnings.push(format!(
+            "circuit time ({:.2} us) exceeds T1 relaxation ({:.2} us)",
+            estimated_time_us, noise.t1_us,
+        ));
+    }
+
+    // Fidelity estimation: (1-ε₁)^n₁ · (1-ε₂)^n₂
+    let single_error = 0.001_f64;
+    let two_error = 0.01_f64;
+    let estimated_fidelity = (1.0 - single_error).powi(stats.single_qubit_gates as i32)
+        * (1.0 - two_error).powi(stats.two_qubit_gates as i32);
+
+    let fidelity_ok = noise
+        .gate_fidelity_min
+        .is_none_or(|threshold| estimated_fidelity >= threshold);
+
+    if !fidelity_ok {
+        if let Some(threshold) = noise.gate_fidelity_min {
+            warnings.push(format!(
+                "estimated fidelity ({:.6}) below threshold ({:.6})",
+                estimated_fidelity, threshold,
+            ));
+        }
+    }
+
+    NoiseBudgetReport {
+        within_t1,
+        within_t2,
+        fidelity_ok,
+        estimated_time_us,
+        estimated_fidelity,
+        warnings,
+    }
+}
+
+/// Format Trotter statistics for human-readable output.
+pub fn format_trotter_stats(stats: &TrotterStats) -> String {
+    let order_str = match stats.order {
+        TrotterOrder::First => "1st",
+        TrotterOrder::Second => "2nd",
+        TrotterOrder::Fourth => "4th",
+    };
+    let mut lines = Vec::new();
+    lines.push(format!("  Trotter order:      {order_str}"));
+    lines.push(format!("  Trotter steps:      {}", stats.steps));
+    lines.push(format!("  dt:                 {:.4} us", stats.dt_us));
+    lines.push(format!("  Hamiltonian terms:  {}", stats.hamiltonian_terms));
+    lines.push(format!("  Total gates:        {}", stats.total_gates));
+    lines.push(format!("  1Q gates:           {}", stats.single_qubit_gates));
+    lines.push(format!("  2Q gates:           {}", stats.two_qubit_gates));
+    lines.push(format!("  Error bound:        {:.2e}", stats.error_bound));
+    lines.push(format!(
+        "  Est. circuit time:  {:.2} us",
+        stats.estimated_time_us
+    ));
+    lines.join("\n")
+}
+
+// ── Trotter step implementations ────────────────────────────────────────────
+
+/// First-order Trotter step: e^{-iH₁dt} · e^{-iH₂dt} · ...
+fn trotter_first_order(
+    terms: &[crate::cbor::PauliTerm],
+    dt: f64,
+    gates: &mut Vec<Gate>,
+) {
+    for term in terms {
+        let theta = term.coefficient * dt;
+        gates.extend(pauli_rotation_gates(&term.paulis, theta));
+    }
+}
+
+/// Second-order Trotter step (symmetric Suzuki):
+///   S₂(dt) = Π_k e^{-iHₖ dt/2} · Π_k' e^{-iHₖ' dt/2}  (reverse order)
+fn trotter_second_order(
+    terms: &[crate::cbor::PauliTerm],
+    dt: f64,
+    gates: &mut Vec<Gate>,
+) {
+    let half_dt = dt / 2.0;
+    // Forward half-step
+    for term in terms {
+        let theta = term.coefficient * half_dt;
+        gates.extend(pauli_rotation_gates(&term.paulis, theta));
+    }
+    // Backward half-step (reverse order)
+    for term in terms.iter().rev() {
+        let theta = term.coefficient * half_dt;
+        gates.extend(pauli_rotation_gates(&term.paulis, theta));
+    }
+}
+
+/// Fourth-order Suzuki-Trotter step:
+///   S₄(dt) = S₂(p·dt) · S₂(p·dt) · S₂((1-4p)·dt) · S₂(p·dt) · S₂(p·dt)
+///
+/// where p = 1 / (4 - 4^{1/3}).
+fn trotter_fourth_order(
+    terms: &[crate::cbor::PauliTerm],
+    dt: f64,
+    gates: &mut Vec<Gate>,
+) {
+    // Suzuki fractal scaling constant.
+    let p = 1.0 / (4.0 - 4.0_f64.cbrt());
+    let p_dt = p * dt;
+    let mid_dt = (1.0 - 4.0 * p) * dt;
+
+    trotter_second_order(terms, p_dt, gates);
+    trotter_second_order(terms, p_dt, gates);
+    trotter_second_order(terms, mid_dt, gates);
+    trotter_second_order(terms, p_dt, gates);
+    trotter_second_order(terms, p_dt, gates);
 }
 
 /// Decompose a Pauli rotation e^{-iθ·P} into native gates.
@@ -222,6 +554,47 @@ mod tests {
         }
     }
 
+    fn two_term_program() -> EhrenfestProgram {
+        EhrenfestProgram {
+            version: 1,
+            system: SystemDef {
+                n_qubits: 2,
+                cooling_profile: None,
+                backend_hint: None,
+            },
+            hamiltonian: Hamiltonian {
+                terms: vec![
+                    PauliTerm {
+                        coefficient: 0.5,
+                        paulis: vec![
+                            PauliOpEntry { qubit: 0, axis: PauliOp::Z },
+                            PauliOpEntry { qubit: 1, axis: PauliOp::Z },
+                        ],
+                    },
+                    PauliTerm {
+                        coefficient: 0.3,
+                        paulis: vec![PauliOpEntry { qubit: 0, axis: PauliOp::X }],
+                    },
+                ],
+                constant_offset: 0.0,
+            },
+            evolution: EvolutionTime {
+                total_us: 1.0,
+                steps: 10,
+                dt_us: 0.1,
+            },
+            observables: vec![Observable::SZ { qubit: 0 }],
+            noise: NoiseConstraint {
+                t1_us: 100.0,
+                t2_us: 50.0,
+                gate_fidelity_min: Some(0.99),
+                readout_fidelity_min: None,
+            },
+        }
+    }
+
+    // ── Basic trotterization tests ───────────────────────────────────────
+
     #[test]
     fn trotterize_zz_produces_gates() {
         let program = simple_zz_program();
@@ -288,5 +661,257 @@ mod tests {
         let ast = trotterize(&program, TrotterOrder::Second);
         // Second-order should produce gates for both terms, twice (forward + backward).
         assert!(!ast.gates.is_empty());
+    }
+
+    // ── Fourth-order Trotter tests ───────────────────────────────────────
+
+    #[test]
+    fn fourth_order_produces_more_gates_than_second() {
+        let program = two_term_program();
+        let ast2 = trotterize(&program, TrotterOrder::Second);
+        let ast4 = trotterize(&program, TrotterOrder::Fourth);
+        // Fourth-order uses 5 second-order sub-steps per Trotter step,
+        // so it should produce roughly 5× the gates.
+        assert!(
+            ast4.gates.len() > ast2.gates.len(),
+            "4th-order ({}) should produce more gates than 2nd-order ({})",
+            ast4.gates.len(),
+            ast2.gates.len(),
+        );
+    }
+
+    #[test]
+    fn fourth_order_gate_count_ratio() {
+        let program = two_term_program();
+        let ast2 = trotterize(&program, TrotterOrder::Second);
+        let ast4 = trotterize(&program, TrotterOrder::Fourth);
+        // S4 = 5 × S2 sub-steps, so gate ratio should be exactly 5.
+        let ratio = ast4.gates.len() as f64 / ast2.gates.len() as f64;
+        assert!(
+            (ratio - 5.0).abs() < 1e-10,
+            "4th/2nd gate ratio should be 5.0, got {ratio}",
+        );
+    }
+
+    #[test]
+    fn fourth_order_single_step_structure() {
+        // Single step, single term: verify S4 = 5 × S2.
+        let program = EhrenfestProgram {
+            version: 1,
+            system: SystemDef {
+                n_qubits: 1,
+                cooling_profile: None,
+                backend_hint: None,
+            },
+            hamiltonian: Hamiltonian {
+                terms: vec![PauliTerm {
+                    coefficient: 1.0,
+                    paulis: vec![PauliOpEntry { qubit: 0, axis: PauliOp::X }],
+                }],
+                constant_offset: 0.0,
+            },
+            evolution: EvolutionTime {
+                total_us: 1.0,
+                steps: 1,
+                dt_us: 1.0,
+            },
+            observables: vec![],
+            noise: NoiseConstraint {
+                t1_us: 100.0,
+                t2_us: 50.0,
+                gate_fidelity_min: None,
+                readout_fidelity_min: None,
+            },
+        };
+        let ast2 = trotterize(&program, TrotterOrder::Second);
+        let ast4 = trotterize(&program, TrotterOrder::Fourth);
+        // X term: S2 produces 2 × (H, Rz, H) = 6 gates.
+        assert_eq!(ast2.gates.len(), 6);
+        // S4 = 5 × S2 = 30 gates.
+        assert_eq!(ast4.gates.len(), 30);
+    }
+
+    // ── Validation tests ─────────────────────────────────────────────────
+
+    #[test]
+    fn validate_good_program() {
+        let program = simple_zz_program();
+        assert!(validate_hamiltonian(&program).is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_empty_hamiltonian() {
+        let mut program = simple_zz_program();
+        program.hamiltonian.terms.clear();
+        let err = validate_hamiltonian(&program).unwrap_err();
+        assert!(matches!(err, TrotterError::EmptyHamiltonian));
+    }
+
+    #[test]
+    fn validate_rejects_nan_coefficient() {
+        let mut program = simple_zz_program();
+        program.hamiltonian.terms[0].coefficient = f64::NAN;
+        let err = validate_hamiltonian(&program).unwrap_err();
+        assert!(matches!(err, TrotterError::NonFiniteCoefficient { .. }));
+    }
+
+    #[test]
+    fn validate_rejects_infinite_coefficient() {
+        let mut program = simple_zz_program();
+        program.hamiltonian.terms[0].coefficient = f64::INFINITY;
+        let err = validate_hamiltonian(&program).unwrap_err();
+        assert!(matches!(err, TrotterError::NonFiniteCoefficient { .. }));
+    }
+
+    #[test]
+    fn validate_rejects_qubit_out_of_range() {
+        let mut program = simple_zz_program();
+        program.hamiltonian.terms[0].paulis[0].qubit = 99;
+        let err = validate_hamiltonian(&program).unwrap_err();
+        assert!(matches!(err, TrotterError::QubitOutOfRange { .. }));
+    }
+
+    #[test]
+    fn validate_rejects_zero_steps() {
+        let mut program = simple_zz_program();
+        program.evolution.steps = 0;
+        let err = validate_hamiltonian(&program).unwrap_err();
+        assert!(matches!(err, TrotterError::ZeroSteps));
+    }
+
+    #[test]
+    fn validate_rejects_nan_evolution() {
+        let mut program = simple_zz_program();
+        program.evolution.dt_us = f64::NAN;
+        let err = validate_hamiltonian(&program).unwrap_err();
+        assert!(matches!(err, TrotterError::NonFiniteEvolution { .. }));
+    }
+
+    // ── Error estimation tests ───────────────────────────────────────────
+
+    #[test]
+    fn error_bound_decreases_with_order() {
+        let program = two_term_program();
+        let e1 = estimate_trotter_error(&program, TrotterOrder::First);
+        let e2 = estimate_trotter_error(&program, TrotterOrder::Second);
+        let e4 = estimate_trotter_error(&program, TrotterOrder::Fourth);
+        // Higher order should have smaller error for small dt.
+        assert!(
+            e2 < e1,
+            "2nd-order error ({e2:.2e}) should be < 1st-order ({e1:.2e})"
+        );
+        assert!(
+            e4 < e2,
+            "4th-order error ({e4:.2e}) should be < 2nd-order ({e2:.2e})"
+        );
+    }
+
+    #[test]
+    fn error_bound_zero_for_zero_hamiltonian() {
+        let mut program = simple_zz_program();
+        program.hamiltonian.terms[0].coefficient = 0.0;
+        assert_eq!(estimate_trotter_error(&program, TrotterOrder::First), 0.0);
+    }
+
+    #[test]
+    fn error_bound_scales_with_steps() {
+        let mut program = two_term_program();
+        let e10 = estimate_trotter_error(&program, TrotterOrder::First);
+        program.evolution.steps = 20;
+        program.evolution.dt_us = program.evolution.total_us / 20.0;
+        let e20 = estimate_trotter_error(&program, TrotterOrder::First);
+        // Doubling steps halves dt, so per-step error ∝ dt² goes to 1/4,
+        // but total error = per-step × steps, so overall goes to 1/2.
+        assert!(
+            e20 < e10,
+            "more steps should reduce error: {e20:.2e} vs {e10:.2e}"
+        );
+    }
+
+    #[test]
+    fn error_bound_positive_for_nonzero_hamiltonian() {
+        let program = two_term_program();
+        let e = estimate_trotter_error(&program, TrotterOrder::First);
+        assert!(e > 0.0, "error bound should be positive, got {e}");
+    }
+
+    // ── Statistics tests ─────────────────────────────────────────────────
+
+    #[test]
+    fn trotterize_with_stats_returns_correct_counts() {
+        let program = two_term_program();
+        let (ast, stats) = trotterize_with_stats(&program, TrotterOrder::First).unwrap();
+        assert_eq!(stats.order, TrotterOrder::First);
+        assert_eq!(stats.steps, 10);
+        assert_eq!(stats.hamiltonian_terms, 2);
+        assert_eq!(stats.total_gates, ast.gates.len());
+        assert_eq!(
+            stats.single_qubit_gates + stats.two_qubit_gates,
+            stats.total_gates
+        );
+        assert!(stats.estimated_time_us > 0.0);
+        assert!(stats.error_bound > 0.0);
+    }
+
+    #[test]
+    fn trotterize_with_stats_rejects_invalid() {
+        let mut program = simple_zz_program();
+        program.hamiltonian.terms.clear();
+        assert!(trotterize_with_stats(&program, TrotterOrder::First).is_err());
+    }
+
+    #[test]
+    fn format_stats_contains_all_fields() {
+        let program = two_term_program();
+        let (_, stats) = trotterize_with_stats(&program, TrotterOrder::Second).unwrap();
+        let formatted = format_trotter_stats(&stats);
+        assert!(formatted.contains("2nd"));
+        assert!(formatted.contains("Trotter steps"));
+        assert!(formatted.contains("Hamiltonian terms"));
+        assert!(formatted.contains("Total gates"));
+        assert!(formatted.contains("Error bound"));
+    }
+
+    // ── Noise budget tests ───────────────────────────────────────────────
+
+    #[test]
+    fn noise_budget_within_limits() {
+        let program = simple_zz_program();
+        let (_, stats) = trotterize_with_stats(&program, TrotterOrder::First).unwrap();
+        let report = check_noise_budget(&stats, &program.noise);
+        assert!(report.within_t1);
+        assert!(report.within_t2);
+        assert!(report.warnings.is_empty());
+    }
+
+    #[test]
+    fn noise_budget_detects_t2_violation() {
+        let program = two_term_program();
+        let (_, stats) = trotterize_with_stats(&program, TrotterOrder::First).unwrap();
+        let tight_noise = NoiseConstraint {
+            t1_us: 100.0,
+            t2_us: 0.01, // Very short T2
+            gate_fidelity_min: None,
+            readout_fidelity_min: None,
+        };
+        let report = check_noise_budget(&stats, &tight_noise);
+        assert!(!report.within_t2);
+        assert!(!report.warnings.is_empty());
+        assert!(report.warnings[0].contains("T2"));
+    }
+
+    #[test]
+    fn noise_budget_detects_fidelity_violation() {
+        let program = two_term_program();
+        let (_, stats) = trotterize_with_stats(&program, TrotterOrder::First).unwrap();
+        let strict_noise = NoiseConstraint {
+            t1_us: 10000.0,
+            t2_us: 10000.0,
+            gate_fidelity_min: Some(0.9999), // Very strict
+            readout_fidelity_min: None,
+        };
+        let report = check_noise_budget(&stats, &strict_noise);
+        assert!(!report.fidelity_ok);
+        assert!(report.warnings.iter().any(|w| w.contains("fidelity")));
     }
 }

--- a/afana/tests/test_trotter_pipeline.rs
+++ b/afana/tests/test_trotter_pipeline.rs
@@ -1,0 +1,404 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright 2026 QUASI Contributors
+//! Integration tests: full Hamiltonian → Trotterization → QASM pipeline.
+//!
+//! Tests the enhanced pipeline end-to-end: validation, Trotterization with
+//! statistics, noise-budget checking, type checking, ZX-IR lowering, and
+//! QASM emission.
+
+use afana::cbor::*;
+use afana::emit::{self, QasmVersion};
+use afana::lower;
+use afana::noise;
+use afana::observable;
+use afana::trotter::{self, TrotterOrder};
+use afana::type_check;
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+fn rabi_program() -> EhrenfestProgram {
+    EhrenfestProgram {
+        version: 1,
+        system: SystemDef {
+            n_qubits: 1,
+            cooling_profile: None,
+            backend_hint: None,
+        },
+        hamiltonian: Hamiltonian {
+            terms: vec![PauliTerm {
+                coefficient: 1.0,
+                paulis: vec![PauliOpEntry {
+                    qubit: 0,
+                    axis: PauliOp::X,
+                }],
+            }],
+            constant_offset: 0.0,
+        },
+        evolution: EvolutionTime {
+            total_us: 1.0,
+            steps: 10,
+            dt_us: 0.1,
+        },
+        observables: vec![Observable::SX { qubit: 0 }],
+        noise: NoiseConstraint {
+            t1_us: 100.0,
+            t2_us: 50.0,
+            gate_fidelity_min: Some(0.90),
+            readout_fidelity_min: None,
+        },
+    }
+}
+
+fn ising_program() -> EhrenfestProgram {
+    EhrenfestProgram {
+        version: 1,
+        system: SystemDef {
+            n_qubits: 2,
+            cooling_profile: None,
+            backend_hint: None,
+        },
+        hamiltonian: Hamiltonian {
+            terms: vec![
+                PauliTerm {
+                    coefficient: 0.5,
+                    paulis: vec![
+                        PauliOpEntry {
+                            qubit: 0,
+                            axis: PauliOp::Z,
+                        },
+                        PauliOpEntry {
+                            qubit: 1,
+                            axis: PauliOp::Z,
+                        },
+                    ],
+                },
+                PauliTerm {
+                    coefficient: 0.3,
+                    paulis: vec![PauliOpEntry {
+                        qubit: 0,
+                        axis: PauliOp::X,
+                    }],
+                },
+                PauliTerm {
+                    coefficient: 0.3,
+                    paulis: vec![PauliOpEntry {
+                        qubit: 1,
+                        axis: PauliOp::X,
+                    }],
+                },
+            ],
+            constant_offset: 0.0,
+        },
+        evolution: EvolutionTime {
+            total_us: 2.0,
+            steps: 20,
+            dt_us: 0.1,
+        },
+        observables: vec![Observable::SZ { qubit: 0 }, Observable::E],
+        noise: NoiseConstraint {
+            t1_us: 100.0,
+            t2_us: 50.0,
+            gate_fidelity_min: Some(0.90),
+            readout_fidelity_min: None,
+        },
+    }
+}
+
+fn heisenberg_program() -> EhrenfestProgram {
+    EhrenfestProgram {
+        version: 1,
+        system: SystemDef {
+            n_qubits: 3,
+            cooling_profile: None,
+            backend_hint: None,
+        },
+        hamiltonian: Hamiltonian {
+            terms: vec![
+                // XX terms
+                PauliTerm {
+                    coefficient: 0.25,
+                    paulis: vec![
+                        PauliOpEntry { qubit: 0, axis: PauliOp::X },
+                        PauliOpEntry { qubit: 1, axis: PauliOp::X },
+                    ],
+                },
+                PauliTerm {
+                    coefficient: 0.25,
+                    paulis: vec![
+                        PauliOpEntry { qubit: 1, axis: PauliOp::X },
+                        PauliOpEntry { qubit: 2, axis: PauliOp::X },
+                    ],
+                },
+                // YY terms
+                PauliTerm {
+                    coefficient: 0.25,
+                    paulis: vec![
+                        PauliOpEntry { qubit: 0, axis: PauliOp::Y },
+                        PauliOpEntry { qubit: 1, axis: PauliOp::Y },
+                    ],
+                },
+                PauliTerm {
+                    coefficient: 0.25,
+                    paulis: vec![
+                        PauliOpEntry { qubit: 1, axis: PauliOp::Y },
+                        PauliOpEntry { qubit: 2, axis: PauliOp::Y },
+                    ],
+                },
+                // ZZ terms
+                PauliTerm {
+                    coefficient: 0.25,
+                    paulis: vec![
+                        PauliOpEntry { qubit: 0, axis: PauliOp::Z },
+                        PauliOpEntry { qubit: 1, axis: PauliOp::Z },
+                    ],
+                },
+                PauliTerm {
+                    coefficient: 0.25,
+                    paulis: vec![
+                        PauliOpEntry { qubit: 1, axis: PauliOp::Z },
+                        PauliOpEntry { qubit: 2, axis: PauliOp::Z },
+                    ],
+                },
+            ],
+            constant_offset: 0.0,
+        },
+        evolution: EvolutionTime {
+            total_us: 1.0,
+            steps: 10,
+            dt_us: 0.1,
+        },
+        observables: vec![Observable::E],
+        noise: NoiseConstraint {
+            t1_us: 200.0,
+            t2_us: 100.0,
+            gate_fidelity_min: Some(0.80),
+            readout_fidelity_min: None,
+        },
+    }
+}
+
+/// Run the full pipeline: validate → trotterize → type check → lower → noise → emit.
+fn full_pipeline(program: &EhrenfestProgram, order: TrotterOrder) -> String {
+    trotter::validate_hamiltonian(program).expect("validation should pass");
+
+    let (mut ast, stats) =
+        trotter::trotterize_with_stats(program, order).expect("trotterize should succeed");
+
+    let _budget = trotter::check_noise_budget(&stats, &program.noise);
+
+    type_check::type_check_ast(&ast).expect("type check should pass");
+
+    let zx = lower::lower_ast_to_zx(&ast).expect("ZX-IR lowering should succeed");
+    zx.validate().expect("ZX-IR should be valid");
+
+    let _noise_report = noise::analyze_noise(&ast, &program.noise, &program.evolution);
+
+    let measurements =
+        observable::synthesize_measurements(&program.observables, program.system.n_qubits);
+    observable::apply_measurement_circuits(&mut ast, &measurements);
+
+    emit::emit_qasm(&ast, QasmVersion::V3).expect("QASM emission should succeed")
+}
+
+// ── End-to-end pipeline tests ───────────────────────────────────────────────
+
+#[test]
+fn pipeline_rabi_first_order() {
+    let qasm = full_pipeline(&rabi_program(), TrotterOrder::First);
+    assert!(qasm.contains("OPENQASM 3.0;"));
+    assert!(qasm.contains("qubit[1] q;"));
+    assert!(qasm.contains("h q[0];"));
+    assert!(qasm.contains("rz("));
+}
+
+#[test]
+fn pipeline_rabi_second_order() {
+    let qasm = full_pipeline(&rabi_program(), TrotterOrder::Second);
+    assert!(qasm.contains("OPENQASM 3.0;"));
+    assert!(qasm.contains("h q[0];"));
+}
+
+#[test]
+fn pipeline_rabi_fourth_order() {
+    let qasm = full_pipeline(&rabi_program(), TrotterOrder::Fourth);
+    assert!(qasm.contains("OPENQASM 3.0;"));
+    assert!(qasm.contains("h q[0];"));
+    // Fourth-order should produce more gates than first-order.
+    let gate_lines: usize = qasm
+        .lines()
+        .filter(|l| {
+            let l = l.trim();
+            !l.is_empty()
+                && !l.starts_with("OPENQASM")
+                && !l.starts_with("include")
+                && !l.starts_with("qubit")
+                && !l.starts_with("bit")
+                && !l.starts_with("//")
+                && !l.contains("measure")
+        })
+        .count();
+    assert!(gate_lines > 30, "4th-order Rabi should produce many gates, got {gate_lines}");
+}
+
+#[test]
+fn pipeline_ising_all_orders() {
+    for order in [TrotterOrder::First, TrotterOrder::Second, TrotterOrder::Fourth] {
+        let qasm = full_pipeline(&ising_program(), order);
+        assert!(qasm.contains("OPENQASM 3.0;"));
+        assert!(qasm.contains("qubit[2] q;"));
+        // ZZ term requires CNOT ladder.
+        assert!(qasm.contains("cx q[0], q[1];"));
+        // Both qubits measured.
+        assert!(qasm.contains("measure q[0]"));
+        assert!(qasm.contains("measure q[1]"));
+    }
+}
+
+#[test]
+fn pipeline_heisenberg_produces_valid_qasm() {
+    let qasm = full_pipeline(&heisenberg_program(), TrotterOrder::Second);
+    assert!(qasm.contains("OPENQASM 3.0;"));
+    assert!(qasm.contains("qubit[3] q;"));
+    // Heisenberg model includes XX, YY, ZZ terms.
+    // XX/YY terms need H and Sdg basis changes; ZZ needs CNOT ladder.
+    assert!(qasm.contains("cx "));
+    assert!(qasm.contains("rz("));
+    // All 3 qubits measured.
+    assert!(qasm.contains("measure q[2]"));
+}
+
+// ── Statistics and error bound tests ────────────────────────────────────────
+
+#[test]
+fn pipeline_stats_consistent_across_orders() {
+    let program = ising_program();
+    let (_, s1) = trotter::trotterize_with_stats(&program, TrotterOrder::First).unwrap();
+    let (_, s2) = trotter::trotterize_with_stats(&program, TrotterOrder::Second).unwrap();
+    let (_, s4) = trotter::trotterize_with_stats(&program, TrotterOrder::Fourth).unwrap();
+
+    // All should report the same Hamiltonian metadata.
+    assert_eq!(s1.hamiltonian_terms, s2.hamiltonian_terms);
+    assert_eq!(s2.hamiltonian_terms, s4.hamiltonian_terms);
+    assert_eq!(s1.steps, s2.steps);
+
+    // Gate counts should increase with order.
+    assert!(s2.total_gates > s1.total_gates);
+    assert!(s4.total_gates > s2.total_gates);
+
+    // Error bounds should decrease with order.
+    assert!(s2.error_bound < s1.error_bound);
+    assert!(s4.error_bound < s2.error_bound);
+}
+
+#[test]
+fn pipeline_error_bound_decreases_with_more_steps() {
+    let mut program = ising_program();
+    let e_20 = trotter::estimate_trotter_error(&program, TrotterOrder::First);
+
+    program.evolution.steps = 40;
+    program.evolution.dt_us = program.evolution.total_us / 40.0;
+    let e_40 = trotter::estimate_trotter_error(&program, TrotterOrder::First);
+
+    assert!(
+        e_40 < e_20,
+        "doubling steps should reduce error: {e_40:.2e} vs {e_20:.2e}"
+    );
+}
+
+// ── Noise budget integration tests ──────────────────────────────────────────
+
+#[test]
+fn pipeline_noise_budget_passes_for_small_circuit() {
+    let program = rabi_program();
+    let (_, stats) = trotter::trotterize_with_stats(&program, TrotterOrder::First).unwrap();
+    let budget = trotter::check_noise_budget(&stats, &program.noise);
+    assert!(budget.within_t1, "small Rabi circuit should fit T1");
+    assert!(budget.within_t2, "small Rabi circuit should fit T2");
+    assert!(budget.fidelity_ok, "small circuit fidelity should be OK");
+    assert!(budget.warnings.is_empty());
+}
+
+#[test]
+fn pipeline_noise_budget_warns_for_deep_circuit() {
+    let program = heisenberg_program();
+    let (_, stats) = trotter::trotterize_with_stats(&program, TrotterOrder::Fourth).unwrap();
+    // Fourth-order Heisenberg produces a deep circuit.
+    let tight_noise = NoiseConstraint {
+        t1_us: 1.0, // Very short T1
+        t2_us: 0.5, // Very short T2
+        gate_fidelity_min: Some(0.9999),
+        readout_fidelity_min: None,
+    };
+    let budget = trotter::check_noise_budget(&stats, &tight_noise);
+    assert!(!budget.within_t1);
+    assert!(!budget.within_t2);
+    assert!(!budget.fidelity_ok);
+    assert!(budget.warnings.len() >= 2, "should have multiple warnings");
+}
+
+// ── Validation rejection tests ──────────────────────────────────────────────
+
+#[test]
+fn pipeline_rejects_empty_hamiltonian() {
+    let mut program = rabi_program();
+    program.hamiltonian.terms.clear();
+    assert!(trotter::validate_hamiltonian(&program).is_err());
+    assert!(trotter::trotterize_with_stats(&program, TrotterOrder::First).is_err());
+}
+
+#[test]
+fn pipeline_rejects_qubit_out_of_range() {
+    let mut program = rabi_program();
+    program.hamiltonian.terms[0].paulis[0].qubit = 10;
+    assert!(trotter::validate_hamiltonian(&program).is_err());
+}
+
+#[test]
+fn pipeline_rejects_nan_coefficient() {
+    let mut program = rabi_program();
+    program.hamiltonian.terms[0].coefficient = f64::NAN;
+    assert!(trotter::validate_hamiltonian(&program).is_err());
+}
+
+// ── Fourth-order correctness tests ──────────────────────────────────────────
+
+#[test]
+fn fourth_order_trotter_produces_5x_second_order_gates() {
+    let program = ising_program();
+    let ast2 = trotter::trotterize(&program, TrotterOrder::Second);
+    let ast4 = trotter::trotterize(&program, TrotterOrder::Fourth);
+    // S4 = 5 × S2 sub-steps, so gate ratio should be exactly 5.
+    let ratio = ast4.gates.len() as f64 / ast2.gates.len() as f64;
+    assert!(
+        (ratio - 5.0).abs() < 1e-10,
+        "4th/2nd gate ratio should be 5.0, got {ratio}",
+    );
+}
+
+#[test]
+fn fourth_order_heisenberg_type_checks_and_lowers() {
+    let program = heisenberg_program();
+    let ast = trotter::trotterize(&program, TrotterOrder::Fourth);
+    type_check::type_check_ast(&ast).expect("4th-order Heisenberg should type check");
+    let zx = lower::lower_ast_to_zx(&ast).expect("should lower to ZX-IR");
+    zx.validate().expect("ZX-IR should validate");
+}
+
+// ── CBOR roundtrip through pipeline ─────────────────────────────────────────
+
+#[test]
+fn cbor_roundtrip_then_pipeline() {
+    let program = ising_program();
+
+    // Serialize to CBOR.
+    let mut buf = Vec::new();
+    ciborium::into_writer(&program, &mut buf).unwrap();
+
+    // Deserialize back.
+    let decoded = afana::cbor::from_cbor(&buf).unwrap();
+
+    // Run full pipeline on deserialized program.
+    let qasm = full_pipeline(&decoded, TrotterOrder::Second);
+    assert!(qasm.contains("OPENQASM 3.0;"));
+    assert!(qasm.contains("cx q[0], q[1];"));
+}


### PR DESCRIPTION
- Add Hamiltonian validation before Trotterization: checks for empty
  Hamiltonians, non-finite coefficients, qubit index bounds, zero
  steps, and non-finite evolution parameters
- Add fourth-order Suzuki-Trotter decomposition (S₄) using the
  recursive construction S₄(dt) = S₂(p·dt)² · S₂((1-4p)·dt) · S₂(p·dt)²
- Add Trotter error bound estimation for all three orders (O(dt²),
  O(dt³), O(dt⁵) per step)
- Add TrotterStats struct tracking gates generated, 1Q/2Q counts,
  error bounds, and estimated circuit time
- Add trotterize_with_stats() combining validation + trotterization +
  statistics in a single call
- Add noise-budget validation (check_noise_budget) comparing circuit
  time/fidelity against T1/T2/gate_fidelity_min constraints
- Wire enhanced pipeline into main.rs: validation runs before
  trotterization, noise-budget warnings emitted to stderr, stats
  section reports Trotter order/steps/error/noise
- Add 15 end-to-end integration tests exercising the full pipeline
  (CBOR → validate → trotterize → type_check → ZX-IR → QASM) across
  Rabi, Ising, and Heisenberg models at all three Trotter orders

https://claude.ai/code/session_01FPcd3h626kf5iYBzMDDZfu