### PR TITLE
fix: Implement ZX-IR validation for Pauli-term coefficient sign consistency (closes #800)

### DIFF
--- a/afana/src/zx_ir/validate.rs
+++ b/afana/src/zx_ir/validate.rs
@@ -1,0 +1,121 @@
+//! ZX-IR validation for Pauli-term coefficient sign consistency.
+//!
+//! Ensures that Pauli-term coefficients maintain consistent sign conventions
+//! across Trotter steps to prevent phase errors in time-evolution simulations.
+
+use crate::zx_ir::{ZxGraph, ZxValidationError};
+
+/// Validate that all Pauli-term coefficients in a ZX-IR graph have consistent sign conventions.
+///
+/// This prevents phase errors in time-evolution simulations by ensuring that
+/// Hamiltonian terms with negative coefficients are properly tracked through
+/// ZX-graph transformations before QASM3 emission.
+///
+/// Returns `Ok(())` if all coefficients have consistent signs, or an error
+/// if mixed signs are detected.
+pub fn validate_sign_consistency(graph: &ZxGraph) -> Result<(), Vec<ZxValidationError>> {
+    let mut errors = Vec::new();
+    
+    // Track the sign of the first non-zero coefficient encountered
+    let mut expected_sign: Option<f64> = None;
+    
+    for (i, spider) in graph.spiders.iter().enumerate() {
+        // Only consider Z-spiders with non-zero phase (representing Pauli terms)
+        if spider.color == crate::zx_ir::SpiderColor::Z && spider.phase != 0.0 {
+            let current_sign = spider.phase.signum();
+            
+            match expected_sign {
+                None => {
+                    expected_sign = Some(current_sign);
+                }
+                Some(sign) => {
+                    if sign != current_sign {
+                        errors.push(ZxValidationError::StructuralError(
+                            format!("mixed coefficient signs detected: expected {}, found {} at node {}", 
+                                   if sign > 0.0 { "positive" } else { "negative" },
+                                   if current_sign > 0.0 { "positive" } else { "negative" },
+                                   i)
+                        ));
+                    }
+                }
+            }
+        }
+    }
+    
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::zx_ir::{SpiderColor, ZxGraph};
+    
+    #[test]
+    fn test_consistent_positive_signs() {
+        let mut graph = ZxGraph::new();
+        // Add Z-spiders with positive phases
+        graph.add_spider(SpiderColor::Z, 0.5, Some(0));
+        graph.add_spider(SpiderColor::Z, 1.0, Some(1));
+        graph.add_spider(SpiderColor::Z, 0.25, Some(2));
+        
+        assert!(validate_sign_consistency(&graph).is_ok());
+    }
+    
+    #[test]
+    fn test_consistent_negative_signs() {
+        let mut graph = ZxGraph::new();
+        // Add Z-spiders with negative phases
+        graph.add_spider(SpiderColor::Z, -0.5, Some(0));
+        graph.add_spider(SpiderColor::Z, -1.0, Some(1));
+        graph.add_spider(SpiderColor::Z, -0.25, Some(2));
+        
+        assert!(validate_sign_consistency(&graph).is_ok());
+    }
+    
+    #[test]
+    fn test_mixed_signs_rejected() {
+        let mut graph = ZxGraph::new();
+        // Add Z-spiders with mixed signs
+        graph.add_spider(SpiderColor::Z, 0.5, Some(0));
+        graph.add_spider(SpiderColor::Z, -1.0, Some(1)); // Mixed sign
+        
+        let result = validate_sign_consistency(&graph);
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(!errors.is_empty());
+        assert!(errors[0].to_string().contains("mixed coefficient signs"));
+    }
+    
+    #[test]
+    fn test_zero_phase_ignored() {
+        let mut graph = ZxGraph::new();
+        // Zero phase should be ignored in sign consistency check
+        graph.add_spider(SpiderColor::Z, 0.0, Some(0));
+        graph.add_spider(SpiderColor::Z, 0.5, Some(1));
+        graph.add_spider(SpiderColor::Z, 1.0, Some(2));
+        
+        assert!(validate_sign_consistency(&graph).is_ok());
+    }
+    
+    #[test]
+    fn test_x_spiders_ignored() {
+        let mut graph = ZxGraph::new();
+        // X-spiders should be ignored in sign consistency check
+        graph.add_spider(SpiderColor::X, 0.5, Some(0));
+        graph.add_spider(SpiderColor::Z, 0.5, Some(1));
+        graph.add_spider(SpiderColor::Z, 1.0, Some(2));
+        
+        assert!(validate_sign_consistency(&graph).is_ok());
+    }
+    
+    #[test]
+    fn test_empty_graph() {
+        let graph = ZxGraph::new();
+        // Empty graph should pass (no signs to be inconsistent)
+        assert!(validate_sign_consistency(&graph).is_ok());
+    }
+}

--- a/afana/tests/zx_ir/validation.rs
+++ b/afana/tests/zx_ir/validation.rs
@@ -1,0 +1,111 @@
+//! CI tests for ZX-IR validation.
+
+use afana::zx_ir::{ZxGraph, SpiderColor};
+use afana::zx_ir::validate::validate_sign_consistency;
+
+#[test]
+fn test_rejects_mixed_sign_pauli_terms() {
+    let mut graph = ZxGraph::new();
+    
+    // Add Pauli terms with mixed signs (+0.5X and -0.5X)
+    // First term: +0.5X represented as Z(0) - X(0.5) - Z(0) pattern
+    let z1 = graph.add_spider(SpiderColor::Z, 0.0, Some(0));
+    let x1 = graph.add_spider(SpiderColor::X, 0.5, Some(0)); // +0.5 coefficient
+    let z2 = graph.add_spider(SpiderColor::Z, 0.0, Some(0));
+    graph.add_edge(z1, x1);
+    graph.add_edge(x1, z2);
+    
+    // Second term: -0.5X represented as Z(0) - X(-0.5) - Z(0) pattern
+    let z3 = graph.add_spider(SpiderColor::Z, 0.0, Some(1));
+    let x2 = graph.add_spider(SpiderColor::X, -0.5, Some(1)); // -0.5 coefficient
+    let z4 = graph.add_spider(SpiderColor::Z, 0.0, Some(1));
+    graph.add_edge(z3, x2);
+    graph.add_edge(x2, z4);
+    
+    // Validation should reject mixed signs
+    let result = validate_sign_consistency(&graph);
+    assert!(result.is_err(), "Graph with mixed-sign Pauli terms should be rejected");
+    
+    let errors = result.unwrap_err();
+    assert!(!errors.is_empty(), "Should report validation errors");
+    assert!(errors[0].to_string().contains("mixed coefficient signs"), 
+            "Error message should indicate mixed signs");
+}
+
+#[test]
+fn test_accepts_consistent_sign_pauli_terms() {
+    let mut graph = ZxGraph::new();
+    
+    // Add Pauli terms with consistent signs (+0.5X and +0.3X)
+    // First term: +0.5X
+    let z1 = graph.add_spider(SpiderColor::Z, 0.0, Some(0));
+    let x1 = graph.add_spider(SpiderColor::X, 0.5, Some(0));
+    let z2 = graph.add_spider(SpiderColor::Z, 0.0, Some(0));
+    graph.add_edge(z1, x1);
+    graph.add_edge(x1, z2);
+    
+    // Second term: +0.3X
+    let z3 = graph.add_spider(SpiderColor::Z, 0.0, Some(1));
+    let x2 = graph.add_spider(SpiderColor::X, 0.3, Some(1));
+    let z4 = graph.add_spider(SpiderColor::Z, 0.0, Some(1));
+    graph.add_edge(z3, x2);
+    graph.add_edge(x2, z4);
+    
+    // Validation should accept consistent signs
+    let result = validate_sign_consistency(&graph);
+    assert!(result.is_ok(), "Graph with consistent-sign Pauli terms should be accepted");
+}
+
+#[test]
+fn test_ignores_non_pauli_elements() {
+    let mut graph = ZxGraph::new();
+    
+    // Add some non-Pauli elements that shouldn't affect sign consistency
+    // H gate decomposition (Z-X-Z)
+    let h_z1 = graph.add_spider(SpiderColor::Z, 0.0, Some(0));
+    let h_x = graph.add_spider(SpiderColor::X, 0.0, Some(0));
+    let h_z2 = graph.add_spider(SpiderColor::Z, 0.0, Some(0));
+    graph.add_edge(h_z1, h_x);
+    graph.add_edge(h_x, h_z2);
+    
+    // CX gate (Z-X connection)
+    let cx_z = graph.add_spider(SpiderColor::Z, 0.0, Some(1));
+    let cx_x = graph.add_spider(SpiderColor::X, 0.0, Some(2));
+    graph.add_edge(cx_z, cx_x);
+    
+    // Now add a Pauli term with positive coefficient
+    let z1 = graph.add_spider(SpiderColor::Z, 0.0, Some(3));
+    let x1 = graph.add_spider(SpiderColor::X, 0.5, Some(3));
+    let z2 = graph.add_spider(SpiderColor::Z, 0.0, Some(3));
+    graph.add_edge(z1, x1);
+    graph.add_edge(x1, z2);
+    
+    // Validation should still accept since the single Pauli term has consistent sign
+    let result = validate_sign_consistency(&graph);
+    assert!(result.is_ok(), "Graph with non-Pauli elements and consistent Pauli signs should be accepted");
+}
+
+#[test]
+fn test_empty_pauli_terms() {
+    let graph = ZxGraph::new();
+    
+    // Empty graph should pass validation (no Pauli terms to be inconsistent)
+    let result = validate_sign_consistency(&graph);
+    assert!(result.is_ok(), "Empty graph should be valid");
+}
+
+#[test]
+fn test_single_pauli_term() {
+    let mut graph = ZxGraph::new();
+    
+    // Add a single Pauli term with negative coefficient
+    let z1 = graph.add_spider(SpiderColor::Z, 0.0, Some(0));
+    let x1 = graph.add_spider(SpiderColor::X, -0.5, Some(0));
+    let z2 = graph.add_spider(SpiderColor::Z, 0.0, Some(0));
+    graph.add_edge(z1, x1);
+    graph.add_edge(x1, z2);
+    
+    // Single term should pass regardless of sign
+    let result = validate_sign_consistency(&graph);
+    assert!(result.is_ok(), "Single Pauli term should be valid");
+}


### PR DESCRIPTION
Closes #800

**Solver:** `qwen3-235b-a22b-2507`
**Reasoning:** Added a new validation pass in `zx_ir/validate.rs` to check Pauli-term coefficient sign consistency and a CI test in `tests/zx_ir/validation.rs` to verify it rejects mixed-sign Pauli terms.

*Opened by QUASI Senate Loop*