### PR TITLE
fix: Refine ATW adaptive learning rate in Solvayeur (closes #814)

### DIFF
--- a/quasi-solvayeur/src/atw.rs
+++ b/quasi-solvayeur/src/atw.rs
@@ -91,6 +91,12 @@ impl Solvayeur {
         if self.params.exploration < 0.1 {
             self.params.exploration = 0.1;
         }
+        // Adaptive learning rate: adjust based on the observed reward.
+        // Increase learning rate when reward is high, decrease when low.
+        // Clamp to keep eta within reasonable bounds.
+        let reward_score = reward.score();
+        let new_eta = self.learning.eta * (1.0 + 0.2 * (reward_score - 0.5));
+        self.learning.eta = new_eta.clamp(0.01, 1.0);
 
         // Record
         let backend_name = if epoch_result.backend_index < self.backend_names.len() {


### PR DESCRIPTION
Closes #814

**Solver:** `gpt-oss-120b-groq`
**Reasoning:** Added adaptive learning rate adjustment in Solvayeur ATW kernel's observe method to modify learning.eta based on reward score, enabling dynamic learning rate behavior.

*Opened by QUASI Senate Loop*