### PR TITLE
fix: Implement connectivity scoring plugin for quasi-scheduler using real backend calibration data (closes #802)

### DIFF
--- a/quasi-scheduler/src/lib.rs
+++ b/quasi-scheduler/src/lib.rs
@@ -11,3 +11,4 @@ pub mod plugin;
 pub mod profiler;
 pub mod profiles;
 pub mod scheduler;
+pub mod plugins;

--- a/quasi-scheduler/src/plugins/connectivity.rs
+++ b/quasi-scheduler/src/plugins/connectivity.rs
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright 2026 QUASI Contributors
+//! Connectivity scoring plugin for the scheduler.
+//!
+//! Scores backends based on their qubit connectivity. Fully connected backends
+//! receive a perfect score of 1.0. Other backends are scored by the ratio of
+//! actual edges to the maximum possible edges for the given qubit count.
+
+use crate::backend::Backend;
+use crate::plugin::SchedulerPlugin;
+use hal_contract::TopologyKind;
+
+/// Scheduler plugin that scores backends by their connectivity.
+pub struct ConnectivityScorer;
+
+impl SchedulerPlugin for ConnectivityScorer {
+    fn name(&self) -> &str {
+        "connectivity"
+    }
+
+    fn score(&self, _job: &crate::job::QuantumJob, backend: &Backend) -> f64 {
+        let n = backend.qubit_count() as usize;
+        if n <= 1 {
+            return 1.0;
+        }
+        // Maximum possible edges in a fully connected graph.
+        let max_edges = n * (n - 1) / 2;
+        // Determine actual edge count based on topology kind.
+        let edge_count = match backend.capabilities.topology.kind {
+            TopologyKind::FullyConnected => return 1.0,
+            _ => backend.capabilities.topology.edges.len(),
+        };
+        let ratio = edge_count as f64 / max_edges as f64;
+        if ratio > 1.0 { 1.0 } else { ratio }
+    }
+}

--- a/quasi-scheduler/src/plugins/mod.rs
+++ b/quasi-scheduler/src/plugins/mod.rs
@@ -1,0 +1,1 @@
+pub mod connectivity;

--- a/quasi-scheduler/tests/connectivity_plugin.rs
+++ b/quasi-scheduler/tests/connectivity_plugin.rs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright 2026 QUASI Contributors
+//! Integration test for the ConnectivityScorer plugin.
+
+use quasi_scheduler::backend::BackendType;
+use quasi_scheduler::job::{JobRequirements, QuantumJob};
+use quasi_scheduler::plugins::connectivity::ConnectivityScorer;
+use quasi_scheduler::profiles::all_backends;
+
+#[test]
+fn connectivity_plugin_scores_backends() {
+    let plugin = ConnectivityScorer;
+    let backends = all_backends();
+    // Dummy job – requirements are irrelevant for connectivity scoring.
+    let job = QuantumJob {
+        id: "test_job".into(),
+        circuit_hash: [0u8; 32],
+        requirements: JobRequirements {
+            min_qubits: 1,
+            required_gates: vec![],
+            circuit_depth: 0,
+            shot_count: 1,
+            noise_budget: None,
+            prefers_qpu: false,
+            max_cost: None,
+        },
+        priority: 0,
+        submitted_at: 0,
+    };
+
+    let mut positive = 0usize;
+    for backend in &backends {
+        let score = plugin.score(&job, backend);
+        assert!(score >= 0.0 && score <= 1.0, "score out of range for {}", backend.id());
+        if score > 0.0 {
+            positive += 1;
+        }
+    }
+    // Ensure at least five real backends receive a positive score.
+    assert!(positive >= 5, "expected at least 5 backends with positive connectivity score, got {}", positive);
+
+    // The simulator backend is fully connected and should score 1.0.
+    let simulator = backends
+        .iter()
+        .find(|b| b.backend_type == BackendType::Simulator)
+        .expect("simulator backend not found");
+    let sim_score = plugin.score(&job, simulator);
+    assert!((sim_score - 1.0).abs() < f64::EPSILON, "simulator should have perfect connectivity score");
+}


### PR DESCRIPTION
Closes #802

**Solver:** `gpt-oss-120b-groq`
**Reasoning:** Added plugins module with ConnectivityScorer implementing SchedulerPlugin, exposed it in lib.rs, and added integration test to verify scoring across backends

*Opened by QUASI Senate Loop*