### PR TITLE
fix(quasi-cache): remove undefined CacheMetrics from public re-exports

### DIFF
--- a/quasi-cache/src/lib.rs
+++ b/quasi-cache/src/lib.rs
@@ -4,4 +4,4 @@ pub mod store;
 
 pub use entry::CacheEntry;
 pub use key::CacheKey;
-pub use store::{CacheConfig, CacheMetrics, CacheStats, CacheStore};
+pub use store::{CacheConfig, CacheStats, CacheStore};


### PR DESCRIPTION
## Problem

`main` has been broken since 2026-04-20 14:04 UTC, when PR #869 (closing #809) merged with `Layer 0 · Ehrenfest spec: FAILURE` and `All layers passed: FAILURE`.

The PR added `CacheMetrics` to the public re-export list in `quasi-cache/src/lib.rs`:

```rust
pub use store::{CacheConfig, CacheMetrics, CacheStats, CacheStore};
//                            ^^^^^^^^^^^^ — type never defined in store.rs
```

But the corresponding edits to `store.rs` only added methods on the existing `CacheStats` struct (`hit_rate()`, `avg_lookup_time_us()`, `estimated_memory_bytes()`). No `CacheMetrics` type was created. The compiler should error with `unresolved import store::CacheMetrics`.

## Side effect — senate solver loop

Every Senate solve since 2026-04-20 that fetches `quasi-cache/src/lib.rs` for context (issues with labels `cache`, `scheduler`, `solvayeur`, `os`) sees the broken export. Solvers (deepseek-v4-pro, deepseek-v4-flash, gpt-oss-120b-groq, qwen3.5-397b-a17b) repeatedly try to "fix" it by either re-removing the export or inventing a `CacheMetrics` struct — even when the assigned issue is about ZX-IR. The B.2 reviewer correctly rejects every such attempt as off-target. Issues observed: #868, #870, #877, #879.

Fixing main unblocks the solver from this dead-end.

## Fix

Remove `CacheMetrics,` from the re-export list. The "metrics" intent of the original issue #809 is already realized as methods on `CacheStats`.

## Test plan

- [ ] `cargo check --workspace` passes
- [ ] `cargo test -p quasi-cache` passes
- [ ] Senate next-cycle solver no longer references CacheMetrics in unrelated issues