### PR TITLE
feat(sword): adapter for SWORD documents + quasi-mcp deps bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2502,6 +2502,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "sword-classical-adapter"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "sword-ml-adapter"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ members = [
     "quasi-scheduler",
     "quasi-senate",
     "quasi-solvayeur",
+    "sword-classical-adapter",
+    "sword-ml-adapter",
 ]
 resolver = "2"
 

--- a/afana/src/lib.rs
+++ b/afana/src/lib.rs
@@ -26,6 +26,7 @@ pub mod optimize;
 pub mod synthesis;
 pub mod trotter;
 pub mod type_check;
+pub mod sword_ingest;
 pub mod zx_ir;
 pub mod validate;
 pub mod zx_to_qasm;

--- a/afana/src/sword_ingest.rs
+++ b/afana/src/sword_ingest.rs
@@ -1,0 +1,473 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright 2026 QUASI Contributors
+//! SWORD document ingestion — Quantum Adapter (3a).
+//!
+//! Translates SWORD documents (emitted by Arn's `/analyze?output=sword`)
+//! into [`EhrenfestProgram`]s that Afana can compile.
+//!
+//! A SWORD document contains:
+//! - `partition.graph` — nodes with diagonal fields `h_i` and frequencies
+//!   `omega`, edges with couplings `j_ij` and sinC² classifications
+//! - `partition.volatile_islands` — subgraphs requiring quantum treatment
+//! - `partition.stable_edges` — edges that can be treated classically
+//! - `provenance` — extractor type, domain, class name
+//! - `noise` — structural, environmental, exploitable noise estimates
+//!
+//! The adapter maps each volatile island to an Ising Hamiltonian:
+//! - Diagonal terms: `h_i × Z_i`
+//! - Coupling terms: `J_ij × Z_i Z_j`
+//!
+//! Stable nodes connected to volatile islands become mean-field boundary
+//! terms: their expectation values are fixed at `⟨Z⟩ = +1` (ground state
+//! assumption), contributing `J_ij × Z_i` shifts to the volatile Hamiltonian.
+
+use anyhow::{bail, Context, Result};
+use serde_json::Value;
+use std::collections::{HashMap, HashSet};
+
+use crate::cbor::{
+    EhrenfestProgram, EvolutionTime, Hamiltonian, NoiseConstraint, Observable, PauliOp,
+    PauliOpEntry, PauliTerm, SystemDef,
+};
+
+// ── Defaults ────────────────────────────────────────────────────────────────
+
+/// Default Trotter evolution time (microseconds) when not specified by SWORD.
+const DEFAULT_TOTAL_US: f64 = 1.0;
+/// Default number of Trotter steps.
+const DEFAULT_STEPS: u32 = 10;
+/// Default T1 relaxation time (microseconds).
+const DEFAULT_T1_US: f64 = 100.0;
+/// Default T2 dephasing time (microseconds).
+const DEFAULT_T2_US: f64 = 50.0;
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/// Convert a SWORD JSON document into an Ehrenfest program.
+///
+/// The SWORD document must have `recommended_path == "quantum"`. The
+/// function extracts volatile islands from the partition graph and builds
+/// an Ising-style Hamiltonian for quantum compilation.
+pub fn sword_to_ehrenfest(sword_json: &Value) -> Result<EhrenfestProgram> {
+    // ── Validate recommended_path ───────────────────────────────────────
+    let recommended_path = sword_json
+        .get("recommended_path")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    if recommended_path != "quantum" {
+        bail!(
+            "SWORD document has recommended_path=\"{}\", expected \"quantum\"",
+            recommended_path
+        );
+    }
+
+    // ── Extract partition ───────────────────────────────────────────────
+    let partition = sword_json
+        .get("partition")
+        .context("SWORD document missing 'partition' field")?;
+
+    let graph = partition
+        .get("graph")
+        .context("partition missing 'graph' field")?;
+
+    // ── Parse nodes ────────────────────────────────────────────────────
+    let nodes = graph
+        .get("nodes")
+        .and_then(|v| v.as_array())
+        .context("graph missing 'nodes' array")?;
+
+    let mut node_h: HashMap<u64, f64> = HashMap::new();
+    for node in nodes {
+        let id = node
+            .get("id")
+            .and_then(|v| v.as_u64())
+            .context("node missing integer 'id'")?;
+        let h_i = node
+            .get("h_i")
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.0);
+        node_h.insert(id, h_i);
+    }
+
+    // ── Parse edges (full graph) ───────────────────────────────────────
+    let edges = graph
+        .get("edges")
+        .and_then(|v| v.as_array())
+        .context("graph missing 'edges' array")?;
+
+    let mut edge_j: HashMap<(u64, u64), f64> = HashMap::new();
+    for edge in edges {
+        let i = edge
+            .get("i")
+            .and_then(|v| v.as_u64())
+            .context("edge missing integer 'i'")?;
+        let j = edge
+            .get("j")
+            .and_then(|v| v.as_u64())
+            .context("edge missing integer 'j'")?;
+        let j_ij = edge
+            .get("j_ij")
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.0);
+        // Store with canonical ordering (min, max).
+        let key = if i <= j { (i, j) } else { (j, i) };
+        edge_j.insert(key, j_ij);
+    }
+
+    // ── Parse volatile islands ─────────────────────────────────────────
+    let volatile_islands = partition
+        .get("volatile_islands")
+        .and_then(|v| v.as_array())
+        .context("partition missing 'volatile_islands' array")?;
+
+    if volatile_islands.is_empty() {
+        bail!("SWORD document has no volatile islands — nothing to compile");
+    }
+
+    // ── Collect stable node IDs ────────────────────────────────────────
+    let stable_edges = partition
+        .get("stable_edges")
+        .and_then(|v| v.as_array())
+        .unwrap_or(&Vec::new())
+        .clone();
+
+    let mut all_volatile_node_ids: HashSet<u64> = HashSet::new();
+    for island in volatile_islands {
+        if let Some(nids) = island.get("node_ids").and_then(|v| v.as_array()) {
+            for nid in nids {
+                if let Some(id) = nid.as_u64() {
+                    all_volatile_node_ids.insert(id);
+                }
+            }
+        }
+    }
+
+    // ── Build merged Hamiltonian from all volatile islands ──────────────
+    // Collect all volatile node IDs and map them to contiguous qubit indices.
+    let mut sorted_volatile: Vec<u64> = all_volatile_node_ids.iter().copied().collect();
+    sorted_volatile.sort_unstable();
+
+    let n_qubits = sorted_volatile.len();
+    if n_qubits == 0 {
+        bail!("SWORD volatile islands contain no nodes");
+    }
+
+    let node_to_qubit: HashMap<u64, usize> = sorted_volatile
+        .iter()
+        .enumerate()
+        .map(|(qi, &nid)| (nid, qi))
+        .collect();
+
+    let mut terms: Vec<PauliTerm> = Vec::new();
+    let mut constant_offset: f64 = 0.0;
+
+    // ── Diagonal terms: h_i × Z_i ──────────────────────────────────────
+    for &nid in &sorted_volatile {
+        let h_i = node_h.get(&nid).copied().unwrap_or(0.0);
+        if h_i.abs() < 1e-15 {
+            continue;
+        }
+        let qi = node_to_qubit[&nid];
+        terms.push(PauliTerm {
+            coefficient: h_i,
+            paulis: vec![PauliOpEntry {
+                qubit: qi,
+                axis: PauliOp::Z,
+            }],
+        });
+    }
+
+    // ── Coupling terms: J_ij × Z_i Z_j (between volatile nodes) ────────
+    for (&(ni, nj), &j_ij) in &edge_j {
+        if j_ij.abs() < 1e-15 {
+            continue;
+        }
+        let qi = match node_to_qubit.get(&ni) {
+            Some(&q) => q,
+            None => continue, // not a volatile node
+        };
+        let qj = match node_to_qubit.get(&nj) {
+            Some(&q) => q,
+            None => {
+                // nj is a stable boundary node — mean-field contribution.
+                // Assume ⟨Z_stable⟩ = +1, so J_ij × Z_i × 1 = J_ij × Z_i.
+                terms.push(PauliTerm {
+                    coefficient: j_ij,
+                    paulis: vec![PauliOpEntry {
+                        qubit: qi,
+                        axis: PauliOp::Z,
+                    }],
+                });
+                continue;
+            }
+        };
+        terms.push(PauliTerm {
+            coefficient: j_ij,
+            paulis: vec![
+                PauliOpEntry {
+                    qubit: qi,
+                    axis: PauliOp::Z,
+                },
+                PauliOpEntry {
+                    qubit: qj,
+                    axis: PauliOp::Z,
+                },
+            ],
+        });
+    }
+
+    // Handle the symmetric case: if ni is stable but nj is volatile.
+    for (&(ni, nj), &j_ij) in &edge_j {
+        if j_ij.abs() < 1e-15 {
+            continue;
+        }
+        if !node_to_qubit.contains_key(&ni) && node_to_qubit.contains_key(&nj) {
+            // ni is stable, nj is volatile — mean-field shift on nj.
+            let qj = node_to_qubit[&nj];
+            terms.push(PauliTerm {
+                coefficient: j_ij,
+                paulis: vec![PauliOpEntry {
+                    qubit: qj,
+                    axis: PauliOp::Z,
+                }],
+            });
+        }
+    }
+
+    // ── Stable-only edges contribute to constant offset ────────────────
+    for se in &stable_edges {
+        if let (Some(ni), Some(nj)) = (
+            se.get("i").and_then(|v| v.as_u64()),
+            se.get("j").and_then(|v| v.as_u64()),
+        ) {
+            if !node_to_qubit.contains_key(&ni) && !node_to_qubit.contains_key(&nj) {
+                let j_ij_val = se.get("j_ij").and_then(|v| v.as_f64()).unwrap_or(0.0);
+                // Both stable: ⟨Z_i⟩ = ⟨Z_j⟩ = +1, contributes J_ij to constant.
+                constant_offset += j_ij_val;
+            }
+        }
+    }
+
+    // Ensure we have at least one Hamiltonian term.
+    if terms.is_empty() {
+        bail!("SWORD volatile islands produced no Hamiltonian terms (all coefficients zero)");
+    }
+
+    // ── Extract noise estimates for constraints ────────────────────────
+    let noise_section = sword_json.get("noise");
+    let structural_noise = noise_section
+        .and_then(|n| n.get("structural"))
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.0);
+    let environmental_noise = noise_section
+        .and_then(|n| n.get("environmental"))
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.0);
+
+    // Scale T2 down if SWORD reports high noise — rough heuristic.
+    let noise_penalty = 1.0 - (structural_noise + environmental_noise).min(0.9);
+    let effective_t2 = DEFAULT_T2_US * noise_penalty;
+
+    // ── Build the EhrenfestProgram ─────────────────────────────────────
+    let dt_us = DEFAULT_TOTAL_US / DEFAULT_STEPS as f64;
+
+    let program = EhrenfestProgram {
+        version: 1,
+        system: SystemDef {
+            n_qubits,
+            cooling_profile: None,
+            backend_hint: None,
+        },
+        hamiltonian: Hamiltonian {
+            terms,
+            constant_offset,
+        },
+        evolution: EvolutionTime {
+            total_us: DEFAULT_TOTAL_US,
+            steps: DEFAULT_STEPS,
+            dt_us,
+        },
+        observables: vec![Observable::E],
+        noise: NoiseConstraint {
+            t1_us: DEFAULT_T1_US,
+            t2_us: effective_t2,
+            gate_fidelity_min: Some(0.99),
+            readout_fidelity_min: None,
+        },
+    };
+
+    Ok(program)
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn minimal_sword() -> Value {
+        json!({
+            "partition": {
+                "graph": {
+                    "nodes": [
+                        {"id": 0, "h_i": 0.5, "omega": 1.0},
+                        {"id": 1, "h_i": -0.3, "omega": 1.0},
+                        {"id": 2, "h_i": 0.0, "omega": 1.0}
+                    ],
+                    "edges": [
+                        {"i": 0, "j": 1, "j_ij": 0.7, "sin_c_half": 0.8, "classification": "volatile"},
+                        {"i": 1, "j": 2, "j_ij": 0.2, "sin_c_half": 0.1, "classification": "stable"}
+                    ]
+                },
+                "volatile_islands": [
+                    {"node_ids": [0, 1], "edges": [{"i": 0, "j": 1}]}
+                ],
+                "stable_edges": [
+                    {"i": 1, "j": 2, "j_ij": 0.2}
+                ],
+                "threshold": 0.5
+            },
+            "provenance": {
+                "extractor": "ising",
+                "domain": "optimization",
+                "class_name": "MaxCut"
+            },
+            "recommended_path": "quantum",
+            "noise": {
+                "structural": 0.1,
+                "environmental": 0.05,
+                "exploitable": 0.02
+            }
+        })
+    }
+
+    #[test]
+    fn converts_minimal_sword_to_ehrenfest() {
+        let sword = minimal_sword();
+        let program = sword_to_ehrenfest(&sword).unwrap();
+
+        assert_eq!(program.version, 1);
+        assert_eq!(program.system.n_qubits, 2); // nodes 0 and 1
+        assert!(!program.hamiltonian.terms.is_empty());
+    }
+
+    #[test]
+    fn diagonal_terms_map_to_single_z() {
+        let sword = minimal_sword();
+        let program = sword_to_ehrenfest(&sword).unwrap();
+
+        // Should have Z_0 term with coefficient 0.5 and Z_1 with -0.3.
+        let single_z_terms: Vec<_> = program
+            .hamiltonian
+            .terms
+            .iter()
+            .filter(|t| t.paulis.len() == 1 && t.paulis[0].axis == PauliOp::Z)
+            .collect();
+
+        // At least the h_i terms (may also include boundary mean-field terms).
+        assert!(single_z_terms.len() >= 2);
+    }
+
+    #[test]
+    fn coupling_terms_map_to_zz() {
+        let sword = minimal_sword();
+        let program = sword_to_ehrenfest(&sword).unwrap();
+
+        let zz_terms: Vec<_> = program
+            .hamiltonian
+            .terms
+            .iter()
+            .filter(|t| {
+                t.paulis.len() == 2
+                    && t.paulis.iter().all(|p| p.axis == PauliOp::Z)
+            })
+            .collect();
+
+        assert_eq!(zz_terms.len(), 1);
+        assert!((zz_terms[0].coefficient - 0.7).abs() < 1e-10);
+    }
+
+    #[test]
+    fn boundary_edge_becomes_mean_field_z() {
+        // Edge (1,2) where node 2 is stable — should produce J*Z_1 term.
+        let sword = minimal_sword();
+        let program = sword_to_ehrenfest(&sword).unwrap();
+
+        // Node 1 maps to qubit 1. The boundary edge j_ij=0.2 should
+        // contribute a Z_1 term with coefficient 0.2.
+        let boundary_terms: Vec<_> = program
+            .hamiltonian
+            .terms
+            .iter()
+            .filter(|t| {
+                t.paulis.len() == 1
+                    && t.paulis[0].axis == PauliOp::Z
+                    && t.paulis[0].qubit == 1
+                    && (t.coefficient - 0.2).abs() < 1e-10
+            })
+            .collect();
+
+        assert!(!boundary_terms.is_empty(), "expected boundary mean-field Z term");
+    }
+
+    #[test]
+    fn rejects_non_quantum_path() {
+        let mut sword = minimal_sword();
+        sword["recommended_path"] = json!("classical");
+        let err = sword_to_ehrenfest(&sword).unwrap_err();
+        assert!(err.to_string().contains("classical"));
+    }
+
+    #[test]
+    fn rejects_missing_partition() {
+        let sword = json!({"recommended_path": "quantum"});
+        let err = sword_to_ehrenfest(&sword).unwrap_err();
+        assert!(err.to_string().contains("partition"));
+    }
+
+    #[test]
+    fn rejects_empty_volatile_islands() {
+        let sword = json!({
+            "partition": {
+                "graph": {
+                    "nodes": [{"id": 0, "h_i": 1.0, "omega": 1.0}],
+                    "edges": []
+                },
+                "volatile_islands": [],
+                "stable_edges": [],
+                "threshold": 0.5
+            },
+            "recommended_path": "quantum",
+            "noise": {"structural": 0.0, "environmental": 0.0, "exploitable": 0.0}
+        });
+        let err = sword_to_ehrenfest(&sword).unwrap_err();
+        assert!(err.to_string().contains("no volatile islands"));
+    }
+
+    #[test]
+    fn noise_penalty_reduces_t2() {
+        let mut sword = minimal_sword();
+        sword["noise"]["structural"] = json!(0.4);
+        sword["noise"]["environmental"] = json!(0.3);
+        let program = sword_to_ehrenfest(&sword).unwrap();
+        // penalty = 1 - (0.4+0.3) = 0.3, effective_t2 = 50 * 0.3 = 15.0
+        assert!((program.noise.t2_us - 15.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn observable_is_energy() {
+        let sword = minimal_sword();
+        let program = sword_to_ehrenfest(&sword).unwrap();
+        assert_eq!(program.observables.len(), 1);
+        assert!(matches!(program.observables[0], Observable::E));
+    }
+
+    #[test]
+    fn evolution_parameters_consistent() {
+        let sword = minimal_sword();
+        let program = sword_to_ehrenfest(&sword).unwrap();
+        let expected_dt = program.evolution.total_us / program.evolution.steps as f64;
+        assert!((program.evolution.dt_us - expected_dt).abs() < 1e-12);
+    }
+}

--- a/quasi-mcp/requirements.txt
+++ b/quasi-mcp/requirements.txt
@@ -1,2 +1,2 @@
-mqt.qcec>=2.2
-mqt.ddsim>=2.0
+mqt.qcec>=3.5.0
+mqt.ddsim>=2.2.0

--- a/sword-classical-adapter/Cargo.toml
+++ b/sword-classical-adapter/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sword-classical-adapter"
+version = "0.1.0"
+edition = "2021"
+license = "AGPL-3.0-or-later"
+description = "SWORD Classical Optimization Adapter (3c) — translates SWORD documents into QUBO/Ising/routing formats for classical solvers"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "2"

--- a/sword-classical-adapter/src/lib.rs
+++ b/sword-classical-adapter/src/lib.rs
@@ -1,0 +1,527 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright 2026 QUASI Contributors
+//! SWORD Classical Optimization Adapter (3c).
+//!
+//! Translates SWORD documents (emitted by Arn's `/analyze?output=sword`)
+//! into formats that classical solvers consume, for cases where
+//! `recommended_path = "classical_optimization"` or `"black_box"`.
+//!
+//! Only volatile islands are translated — stable parts are already solved.
+//! Local island node indices are mapped to global indices via the graph.
+//!
+//! # Output formats
+//! - [`QuboMatrix`]   — dense QUBO matrix for SA, Gurobi, D-Wave
+//! - [`IsingModel`]   — `{h, J}` vectors for SA, kicked-Ising solvers
+//! - [`RoutingSummary`] — segment lists + adjacency for VRP/distance problems
+//!
+//! # Garm API
+//! [`sword_to_garm_request`] formats the volatile QUBO as a
+//! `POST /solve_qubo` body: `{ "matrix": [[...]], "shots": N }`.
+
+use std::collections::{HashMap, HashSet};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use thiserror::Error;
+
+// ── Error type ───────────────────────────────────────────────────────────────
+
+#[derive(Debug, Error)]
+pub enum AdapterError {
+    #[error("SWORD document missing field: {0}")]
+    MissingField(&'static str),
+    #[error("SWORD document has no volatile islands")]
+    NoVolatileIslands,
+    #[error("volatile islands contain no nodes")]
+    EmptyIslands,
+    #[error("unexpected JSON type for field: {0}")]
+    TypeMismatch(&'static str),
+}
+
+type Result<T> = std::result::Result<T, AdapterError>;
+
+// ── Output types ─────────────────────────────────────────────────────────────
+
+/// Dense QUBO matrix for SA, Gurobi, and D-Wave samplers.
+///
+/// Q is upper-triangular by convention: Q[i][j] with i ≤ j.
+/// Diagonal Q[i][i] encodes linear bias (h_i), off-diagonal encodes coupling
+/// (j_ij). The QUBO objective is x^T Q x with x ∈ {0,1}.
+///
+/// Note: SWORD uses Ising variables ∈ {-1, +1}. The conversion from Ising
+/// (h, J) to QUBO Q is: Q[i][i] = 2*h_i, Q[i][j] = 4*J_ij (i < j).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QuboMatrix {
+    /// Number of binary variables (= total volatile nodes across all islands).
+    pub n: usize,
+    /// Flat upper-triangular QUBO matrix, row-major, length n*n.
+    /// Entry [i*n + j] for i ≤ j, 0 elsewhere.
+    pub matrix: Vec<Vec<f64>>,
+    /// Mapping from matrix row/col index to global node id.
+    pub index_to_node: Vec<u64>,
+}
+
+/// Ising model for SA solvers and kicked-Ising hardware.
+///
+/// H = Σ_i h[i] Z_i + Σ_{(i,j)} J[(i,j)] Z_i Z_j
+/// with Z ∈ {-1, +1}.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IsingModel {
+    /// Local fields h_i indexed by local (compact) index.
+    pub h: Vec<f64>,
+    /// Coupling map: key (i, j) with i < j, value J_ij.
+    pub j: HashMap<(usize, usize), f64>,
+    /// Mapping from local index to global node id.
+    pub index_to_node: Vec<u64>,
+}
+
+/// Routing summary for distance/VRP problems
+/// (`extractor = "distance"` in SWORD provenance).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RoutingSummary {
+    /// Volatile segments: node pairs that need route optimization.
+    pub volatile_segments: Vec<[u64; 2]>,
+    /// Fixed/stable segments: already-decided arcs.
+    pub fixed_segments: Vec<[u64; 2]>,
+    /// Adjacency list of volatile nodes (global ids).
+    pub adjacency: HashMap<u64, Vec<u64>>,
+}
+
+// ── Default shots for Garm requests ─────────────────────────────────────────
+
+const DEFAULT_SHOTS: u32 = 1024;
+
+// ── Helper: extract volatile node set and sorted index ──────────────────────
+
+/// Parse the graph nodes/edges and volatile islands from a SWORD document.
+/// Returns (node_h, edge_j, sorted_volatile_ids, stable_edges_array).
+fn parse_sword(sword: &Value) -> Result<(
+    HashMap<u64, f64>,
+    HashMap<(u64, u64), f64>,
+    Vec<u64>,
+    Vec<Value>,
+)> {
+    let partition = sword
+        .get("partition")
+        .ok_or(AdapterError::MissingField("partition"))?;
+
+    let graph = partition
+        .get("graph")
+        .ok_or(AdapterError::MissingField("partition.graph"))?;
+
+    // ── Parse nodes ──────────────────────────────────────────────────────
+    let nodes = graph
+        .get("nodes")
+        .and_then(|v| v.as_array())
+        .ok_or(AdapterError::MissingField("graph.nodes"))?;
+
+    let mut node_h: HashMap<u64, f64> = HashMap::new();
+    for node in nodes {
+        let id = node
+            .get("id")
+            .and_then(|v| v.as_u64())
+            .ok_or(AdapterError::TypeMismatch("node.id"))?;
+        let h_i = node.get("h_i").and_then(|v| v.as_f64()).unwrap_or(0.0);
+        node_h.insert(id, h_i);
+    }
+
+    // ── Parse edges ──────────────────────────────────────────────────────
+    let edges = graph
+        .get("edges")
+        .and_then(|v| v.as_array())
+        .ok_or(AdapterError::MissingField("graph.edges"))?;
+
+    let mut edge_j: HashMap<(u64, u64), f64> = HashMap::new();
+    for edge in edges {
+        let i = edge
+            .get("i")
+            .and_then(|v| v.as_u64())
+            .ok_or(AdapterError::TypeMismatch("edge.i"))?;
+        let j = edge
+            .get("j")
+            .and_then(|v| v.as_u64())
+            .ok_or(AdapterError::TypeMismatch("edge.j"))?;
+        let j_ij = edge.get("j_ij").and_then(|v| v.as_f64()).unwrap_or(0.0);
+        let key = if i <= j { (i, j) } else { (j, i) };
+        edge_j.insert(key, j_ij);
+    }
+
+    // ── Collect volatile node ids ─────────────────────────────────────────
+    let volatile_islands = partition
+        .get("volatile_islands")
+        .and_then(|v| v.as_array())
+        .ok_or(AdapterError::MissingField("partition.volatile_islands"))?;
+
+    if volatile_islands.is_empty() {
+        return Err(AdapterError::NoVolatileIslands);
+    }
+
+    let mut volatile_set: HashSet<u64> = HashSet::new();
+    for island in volatile_islands {
+        if let Some(nids) = island.get("node_ids").and_then(|v| v.as_array()) {
+            for nid in nids {
+                if let Some(id) = nid.as_u64() {
+                    volatile_set.insert(id);
+                }
+            }
+        }
+    }
+
+    if volatile_set.is_empty() {
+        return Err(AdapterError::EmptyIslands);
+    }
+
+    let mut sorted_volatile: Vec<u64> = volatile_set.into_iter().collect();
+    sorted_volatile.sort_unstable();
+
+    let stable_edges = partition
+        .get("stable_edges")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    Ok((node_h, edge_j, sorted_volatile, stable_edges))
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/// Convert a SWORD document into a dense QUBO matrix.
+///
+/// Only volatile islands are included. The mapping from Ising (h_i, J_ij)
+/// to QUBO is: Q[i][i] = 2*h_i, Q[i][j] = 4*J_ij for i < j.
+///
+/// Accepts any `recommended_path` — the caller is responsible for routing
+/// only classical/black_box cases here.
+pub fn sword_to_qubo(sword: &Value) -> Result<QuboMatrix> {
+    let (node_h, edge_j, sorted_volatile, _stable_edges) = parse_sword(sword)?;
+
+    let n = sorted_volatile.len();
+    // Map global node id → local compact index.
+    let node_to_idx: HashMap<u64, usize> = sorted_volatile
+        .iter()
+        .enumerate()
+        .map(|(i, &nid)| (nid, i))
+        .collect();
+
+    // Initialise n×n matrix with zeros.
+    let mut matrix = vec![vec![0.0f64; n]; n];
+
+    // Diagonal: h_i → Q[i][i] = 2 * h_i  (Ising-to-QUBO conversion).
+    for (idx, &nid) in sorted_volatile.iter().enumerate() {
+        let h = node_h.get(&nid).copied().unwrap_or(0.0);
+        matrix[idx][idx] = 2.0 * h;
+    }
+
+    // Off-diagonal: J_ij → Q[i][j] = 4 * J_ij  (i < j, upper-triangular).
+    for (&(ni, nj), &j_ij) in &edge_j {
+        let Some(&li) = node_to_idx.get(&ni) else { continue };
+        let Some(&lj) = node_to_idx.get(&nj) else { continue };
+        // Enforce upper-triangular storage.
+        let (row, col) = if li <= lj { (li, lj) } else { (lj, li) };
+        matrix[row][col] += 4.0 * j_ij;
+    }
+
+    Ok(QuboMatrix {
+        n,
+        matrix,
+        index_to_node: sorted_volatile,
+    })
+}
+
+/// Convert a SWORD document into an Ising model (h, J).
+///
+/// h[i] is the local field for the i-th volatile node (sorted by global id).
+/// J[(i,j)] is the coupling between volatile nodes i and j (i < j).
+/// Stable boundary nodes are included as mean-field shifts on their volatile
+/// neighbours: h[i] += J_ij for each stable neighbour j.
+pub fn sword_to_ising(sword: &Value) -> Result<IsingModel> {
+    let (node_h, edge_j, sorted_volatile, _stable_edges) = parse_sword(sword)?;
+
+    let n = sorted_volatile.len();
+    let node_to_idx: HashMap<u64, usize> = sorted_volatile
+        .iter()
+        .enumerate()
+        .map(|(i, &nid)| (nid, i))
+        .collect();
+
+    let mut h = vec![0.0f64; n];
+    let mut j_map: HashMap<(usize, usize), f64> = HashMap::new();
+
+    // Local fields from h_i.
+    for (idx, &nid) in sorted_volatile.iter().enumerate() {
+        h[idx] = node_h.get(&nid).copied().unwrap_or(0.0);
+    }
+
+    // Couplings and mean-field boundary terms.
+    for (&(ni, nj), &j_ij) in &edge_j {
+        if j_ij.abs() < 1e-15 {
+            continue;
+        }
+        let li = node_to_idx.get(&ni);
+        let lj = node_to_idx.get(&nj);
+        match (li, lj) {
+            (Some(&ai), Some(&aj)) => {
+                // Both volatile — coupling term.
+                let key = if ai < aj { (ai, aj) } else { (aj, ai) };
+                *j_map.entry(key).or_insert(0.0) += j_ij;
+            }
+            (Some(&ai), None) => {
+                // nj is stable, ⟨Z_nj⟩ = +1 → contributes J_ij * Z_ni.
+                h[ai] += j_ij;
+            }
+            (None, Some(&aj)) => {
+                // ni is stable, ⟨Z_ni⟩ = +1 → contributes J_ij * Z_nj.
+                h[aj] += j_ij;
+            }
+            (None, None) => {} // both stable, already resolved
+        }
+    }
+
+    Ok(IsingModel {
+        h,
+        j: j_map,
+        index_to_node: sorted_volatile,
+    })
+}
+
+/// Build a routing summary for distance/VRP problems.
+///
+/// Volatile island edges become `volatile_segments` requiring optimisation.
+/// `stable_edges` from the partition become `fixed_segments`.
+/// An adjacency list of volatile nodes is provided for solver convenience.
+pub fn sword_to_routing(sword: &Value) -> Result<RoutingSummary> {
+    let (_, edge_j, sorted_volatile, stable_edges) = parse_sword(sword)?;
+
+    let volatile_set: HashSet<u64> = sorted_volatile.iter().copied().collect();
+
+    let mut volatile_segments: Vec<[u64; 2]> = Vec::new();
+    let mut adjacency: HashMap<u64, Vec<u64>> = HashMap::new();
+
+    for (&(ni, nj), _) in &edge_j {
+        if volatile_set.contains(&ni) && volatile_set.contains(&nj) {
+            volatile_segments.push([ni, nj]);
+            adjacency.entry(ni).or_default().push(nj);
+            adjacency.entry(nj).or_default().push(ni);
+        }
+    }
+
+    let mut fixed_segments: Vec<[u64; 2]> = Vec::new();
+    for se in &stable_edges {
+        let i = se.get("i").and_then(|v| v.as_u64());
+        let j = se.get("j").and_then(|v| v.as_u64());
+        if let (Some(ni), Some(nj)) = (i, j) {
+            fixed_segments.push([ni, nj]);
+        }
+    }
+
+    Ok(RoutingSummary {
+        volatile_segments,
+        fixed_segments,
+        adjacency,
+    })
+}
+
+/// Format volatile QUBO as a Garm `POST /solve_qubo` request body.
+///
+/// Shape: `{ "matrix": [[...]], "shots": N }` where N defaults to 1024.
+pub fn sword_to_garm_request(sword: &Value) -> Result<Value> {
+    sword_to_garm_request_with_shots(sword, DEFAULT_SHOTS)
+}
+
+/// Same as [`sword_to_garm_request`] but with an explicit shot count.
+pub fn sword_to_garm_request_with_shots(sword: &Value, shots: u32) -> Result<Value> {
+    let qubo = sword_to_qubo(sword)?;
+    Ok(serde_json::json!({
+        "matrix": qubo.matrix,
+        "shots": shots
+    }))
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn minimal_sword(path: &str) -> Value {
+        json!({
+            "recommended_path": path,
+            "partition": {
+                "graph": {
+                    "nodes": [
+                        {"id": 0, "h_i": 0.5},
+                        {"id": 1, "h_i": -0.3},
+                        {"id": 2, "h_i": 0.1}
+                    ],
+                    "edges": [
+                        {"i": 0, "j": 1, "j_ij": 0.7},
+                        {"i": 1, "j": 2, "j_ij": 0.2}
+                    ]
+                },
+                "volatile_islands": [
+                    {"node_ids": [0, 1]}
+                ],
+                "stable_edges": [
+                    {"i": 1, "j": 2, "j_ij": 0.2}
+                ]
+            },
+            "provenance": {
+                "extractor": "distance",
+                "domain": "optimization"
+            },
+            "noise": {"structural": 0.1, "environmental": 0.05}
+        })
+    }
+
+    // ── sword_to_qubo ────────────────────────────────────────────────────
+
+    #[test]
+    fn qubo_size_matches_volatile_count() {
+        let q = sword_to_qubo(&minimal_sword("classical_optimization")).unwrap();
+        assert_eq!(q.n, 2);
+        assert_eq!(q.matrix.len(), 2);
+        assert_eq!(q.matrix[0].len(), 2);
+        assert_eq!(q.index_to_node, vec![0, 1]);
+    }
+
+    #[test]
+    fn qubo_diagonal_is_2h() {
+        let q = sword_to_qubo(&minimal_sword("classical_optimization")).unwrap();
+        // node 0 → h_i=0.5 → Q[0][0]=1.0
+        assert!((q.matrix[0][0] - 1.0).abs() < 1e-12, "Q[0][0] should be 2*0.5=1.0");
+        // node 1 → h_i=-0.3 → Q[1][1]=-0.6
+        assert!((q.matrix[1][1] - (-0.6)).abs() < 1e-12, "Q[1][1] should be 2*(-0.3)=-0.6");
+    }
+
+    #[test]
+    fn qubo_off_diagonal_is_4j() {
+        let q = sword_to_qubo(&minimal_sword("classical_optimization")).unwrap();
+        // edge (0,1) j_ij=0.7 → Q[0][1]=4*0.7=2.8
+        assert!((q.matrix[0][1] - 2.8).abs() < 1e-12, "Q[0][1] should be 4*0.7=2.8");
+        // lower triangle stays 0
+        assert!((q.matrix[1][0]).abs() < 1e-12, "Q[1][0] should be 0 (upper-triangular)");
+    }
+
+    #[test]
+    fn qubo_excludes_stable_only_edges() {
+        // Edge (1,2) has node 2 stable — should not appear in 2×2 QUBO.
+        let q = sword_to_qubo(&minimal_sword("classical_optimization")).unwrap();
+        assert_eq!(q.n, 2); // node 2 not in matrix
+    }
+
+    // ── sword_to_ising ───────────────────────────────────────────────────
+
+    #[test]
+    fn ising_h_matches_node_fields() {
+        let ising = sword_to_ising(&minimal_sword("classical_optimization")).unwrap();
+        // node 0 local idx 0: h_i=0.5, plus boundary from edge (1,2)? No — edge
+        // (1,2) has j_ij=0.2 and node 2 is stable. Node 1 is volatile, so it
+        // gains the mean-field shift: h[1] += 0.2.
+        assert!((ising.h[0] - 0.5).abs() < 1e-12, "h[0] should be 0.5");
+        assert!((ising.h[1] - (-0.1)).abs() < 1e-12, "h[1] = -0.3 + 0.2 = -0.1");
+    }
+
+    #[test]
+    fn ising_j_map_contains_volatile_coupling() {
+        let ising = sword_to_ising(&minimal_sword("classical_optimization")).unwrap();
+        // edge (0,1) j_ij=0.7
+        assert!(ising.j.contains_key(&(0, 1)));
+        assert!((ising.j[&(0, 1)] - 0.7).abs() < 1e-12);
+    }
+
+    #[test]
+    fn ising_index_map_is_sorted() {
+        let ising = sword_to_ising(&minimal_sword("classical_optimization")).unwrap();
+        assert_eq!(ising.index_to_node, vec![0, 1]);
+    }
+
+    // ── sword_to_routing ─────────────────────────────────────────────────
+
+    #[test]
+    fn routing_volatile_segments_only_volatile_edges() {
+        let r = sword_to_routing(&minimal_sword("classical_optimization")).unwrap();
+        // Only edge (0,1) is between two volatile nodes.
+        assert_eq!(r.volatile_segments.len(), 1);
+        assert_eq!(r.volatile_segments[0], [0, 1]);
+    }
+
+    #[test]
+    fn routing_fixed_segments_from_stable_edges() {
+        let r = sword_to_routing(&minimal_sword("classical_optimization")).unwrap();
+        assert_eq!(r.fixed_segments.len(), 1);
+        assert_eq!(r.fixed_segments[0], [1, 2]);
+    }
+
+    #[test]
+    fn routing_adjacency_is_bidirectional() {
+        let r = sword_to_routing(&minimal_sword("classical_optimization")).unwrap();
+        assert!(r.adjacency[&0].contains(&1));
+        assert!(r.adjacency[&1].contains(&0));
+    }
+
+    // ── sword_to_garm_request ────────────────────────────────────────────
+
+    #[test]
+    fn garm_request_has_matrix_and_shots() {
+        let req = sword_to_garm_request(&minimal_sword("classical_optimization")).unwrap();
+        assert!(req.get("matrix").is_some());
+        assert_eq!(req["shots"].as_u64().unwrap(), DEFAULT_SHOTS as u64);
+    }
+
+    #[test]
+    fn garm_request_matrix_is_square_nxn() {
+        let req = sword_to_garm_request(&minimal_sword("classical_optimization")).unwrap();
+        let matrix = req["matrix"].as_array().unwrap();
+        assert_eq!(matrix.len(), 2);
+        assert_eq!(matrix[0].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn garm_request_with_custom_shots() {
+        let req = sword_to_garm_request_with_shots(
+            &minimal_sword("classical_optimization"),
+            512,
+        )
+        .unwrap();
+        assert_eq!(req["shots"].as_u64().unwrap(), 512);
+    }
+
+    // ── Error cases ──────────────────────────────────────────────────────
+
+    #[test]
+    fn error_on_missing_partition() {
+        let sword = json!({"recommended_path": "classical_optimization"});
+        assert!(matches!(
+            sword_to_qubo(&sword),
+            Err(AdapterError::MissingField("partition"))
+        ));
+    }
+
+    #[test]
+    fn error_on_empty_volatile_islands() {
+        let sword = json!({
+            "recommended_path": "classical_optimization",
+            "partition": {
+                "graph": {
+                    "nodes": [{"id": 0, "h_i": 1.0}],
+                    "edges": []
+                },
+                "volatile_islands": [],
+                "stable_edges": []
+            }
+        });
+        assert!(matches!(
+            sword_to_qubo(&sword),
+            Err(AdapterError::NoVolatileIslands)
+        ));
+    }
+
+    #[test]
+    fn accepts_any_recommended_path() {
+        // Classical adapter should not gate on recommended_path.
+        for path in &["classical_optimization", "black_box", "quantum"] {
+            sword_to_qubo(&minimal_sword(path)).unwrap();
+        }
+    }
+}

--- a/sword-ml-adapter/Cargo.toml
+++ b/sword-ml-adapter/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sword-ml-adapter"
+version = "0.1.0"
+edition = "2021"
+license = "AGPL-3.0-or-later"
+description = "Translates SWORD ml_training documents into PyTorch/JAX training configurations"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "2"

--- a/sword-ml-adapter/src/adapter.rs
+++ b/sword-ml-adapter/src/adapter.rs
@@ -1,0 +1,253 @@
+use crate::config::{
+    FreezeMap, LrSchedule, ParallelIsland, PartitionStats, TrainableLayer, TrainingConfig,
+};
+use serde_json::Value;
+use std::collections::HashMap;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum AdapterError {
+    #[error("missing field: {0}")]
+    MissingField(&'static str),
+    #[error("wrong recommended_path: expected \"ml_training\", got \"{0}\"")]
+    WrongPath(String),
+    #[error("malformed hierarchical_partition: {0}")]
+    Malformed(String),
+}
+
+/// Translate a SWORD JSON document into a [`TrainingConfig`].
+///
+/// Returns `Err` if the document is missing required fields or has
+/// `recommended_path != "ml_training"`.
+pub fn sword_to_training_config(sword_json: &Value) -> Result<TrainingConfig, AdapterError> {
+    // 1. Guard: correct recommended_path
+    let path = sword_json
+        .get("recommended_path")
+        .and_then(Value::as_str)
+        .ok_or(AdapterError::MissingField("recommended_path"))?;
+    if path != "ml_training" {
+        return Err(AdapterError::WrongPath(path.to_owned()));
+    }
+
+    // 2. Navigate into hierarchical_partition
+    let hp = sword_json
+        .get("hierarchical_partition")
+        .ok_or(AdapterError::MissingField("hierarchical_partition"))?;
+
+    // 3. Parse layer_partition
+    let layer_partition = hp
+        .get("layer_partition")
+        .and_then(Value::as_array)
+        .ok_or(AdapterError::MissingField("layer_partition"))?;
+
+    let mut frozen_layers: Vec<String> = Vec::new();
+    // volatile_meta: layer_name -> island_id
+    let mut volatile_meta: HashMap<String, u32> = HashMap::new();
+
+    for entry in layer_partition {
+        let name = entry
+            .get("name")
+            .and_then(Value::as_str)
+            .ok_or_else(|| AdapterError::Malformed("layer_partition entry missing name".into()))?
+            .to_owned();
+        let role = entry
+            .get("role")
+            .and_then(Value::as_str)
+            .ok_or_else(|| AdapterError::Malformed("layer_partition entry missing role".into()))?;
+        match role {
+            "stable" => frozen_layers.push(name),
+            "volatile" => {
+                let island_id = entry
+                    .get("island_id")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0) as u32;
+                volatile_meta.insert(name, island_id);
+            }
+            other => {
+                return Err(AdapterError::Malformed(format!(
+                    "unknown layer role: {other}"
+                )));
+            }
+        }
+    }
+
+    // 4. Parse parameter_partitions
+    //    Build: layer_name -> list of param indices marked "train"
+    let mut param_train: HashMap<String, Vec<usize>> = HashMap::new();
+    if let Some(param_parts) = hp.get("parameter_partitions").and_then(Value::as_array) {
+        for pp in param_parts {
+            let layer = pp
+                .get("layer")
+                .and_then(Value::as_str)
+                .ok_or_else(|| {
+                    AdapterError::Malformed("parameter_partition missing layer".into())
+                })?
+                .to_owned();
+            let role = pp
+                .get("role")
+                .and_then(Value::as_str)
+                .ok_or_else(|| {
+                    AdapterError::Malformed("parameter_partition missing role".into())
+                })?;
+            if role == "train" {
+                let idx = pp
+                    .get("param_index")
+                    .and_then(Value::as_u64)
+                    .ok_or_else(|| {
+                        AdapterError::Malformed("parameter_partition missing param_index".into())
+                    })? as usize;
+                param_train.entry(layer).or_default().push(idx);
+            }
+        }
+    }
+
+    // 5. Build trainable_layers
+    let mut trainable_layers: Vec<TrainableLayer> = volatile_meta
+        .iter()
+        .map(|(name, &island_id)| {
+            let param_indices_to_train = param_train.get(name).cloned().unwrap_or_default();
+            TrainableLayer {
+                name: name.clone(),
+                param_indices_to_train,
+                island_id,
+            }
+        })
+        .collect();
+    // Stable order — deterministic output
+    trainable_layers.sort_by(|a, b| a.name.cmp(&b.name));
+
+    // 6. Build parallel islands
+    let mut island_map: HashMap<u32, Vec<String>> = HashMap::new();
+    for layer in &trainable_layers {
+        island_map
+            .entry(layer.island_id)
+            .or_default()
+            .push(layer.name.clone());
+    }
+    let mut parallel_islands: Vec<ParallelIsland> = island_map
+        .into_iter()
+        .map(|(island_id, layer_names)| ParallelIsland {
+            island_id,
+            layer_names,
+        })
+        .collect();
+    parallel_islands.sort_by_key(|i| i.island_id);
+
+    // 7. Suggested LR schedule — volatile islands get 10× the frozen base
+    //    We use 1e-4 as the canonical base LR; volatile layers get 1e-3.
+    let base_lr_stable = 1e-4_f64;
+    let base_lr_volatile = base_lr_stable * 10.0;
+    let suggested_lr_schedule: Vec<LrSchedule> = parallel_islands
+        .iter()
+        .map(|island| LrSchedule {
+            island_id: island.island_id,
+            base_lr: base_lr_volatile,
+        })
+        .collect();
+    let _ = base_lr_stable; // kept for documentation purposes
+
+    // 8. Stats
+    let stats = PartitionStats {
+        total_params: hp.get("total_params").and_then(Value::as_u64).unwrap_or(0),
+        frozen_params: hp.get("frozen_params").and_then(Value::as_u64).unwrap_or(0),
+        trainable_params: hp
+            .get("trainable_params")
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
+        trainable_pct: hp
+            .get("trainable_pct")
+            .and_then(Value::as_f64)
+            .unwrap_or(0.0),
+    };
+
+    Ok(TrainingConfig {
+        freeze_map: FreezeMap {
+            frozen_layers,
+            trainable_layers,
+        },
+        suggested_lr_schedule,
+        parallel_islands,
+        stats,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn sample_sword() -> Value {
+        json!({
+            "recommended_path": "ml_training",
+            "hierarchical_partition": {
+                "layer_partition": [
+                    { "name": "embed", "role": "stable" },
+                    { "name": "head",  "role": "volatile", "island_id": 0 },
+                    { "name": "lora",  "role": "volatile", "island_id": 1 }
+                ],
+                "parameter_partitions": [
+                    { "layer": "head", "param_index": 0, "role": "train" },
+                    { "layer": "head", "param_index": 1, "role": "freeze" },
+                    { "layer": "lora", "param_index": 0, "role": "train" }
+                ],
+                "total_params":     10000,
+                "frozen_params":    8000,
+                "trainable_params": 2000,
+                "trainable_pct":    20.0
+            }
+        })
+    }
+
+    #[test]
+    fn frozen_layers_identified() {
+        let cfg = sword_to_training_config(&sample_sword()).unwrap();
+        assert_eq!(cfg.freeze_map.frozen_layers, vec!["embed"]);
+    }
+
+    #[test]
+    fn trainable_layers_correct() {
+        let cfg = sword_to_training_config(&sample_sword()).unwrap();
+        let names: Vec<&str> = cfg
+            .freeze_map
+            .trainable_layers
+            .iter()
+            .map(|l| l.name.as_str())
+            .collect();
+        assert!(names.contains(&"head"));
+        assert!(names.contains(&"lora"));
+    }
+
+    #[test]
+    fn param_indices_filtered() {
+        let cfg = sword_to_training_config(&sample_sword()).unwrap();
+        let head = cfg
+            .freeze_map
+            .trainable_layers
+            .iter()
+            .find(|l| l.name == "head")
+            .unwrap();
+        // only index 0 is "train"; index 1 is "freeze"
+        assert_eq!(head.param_indices_to_train, vec![0]);
+    }
+
+    #[test]
+    fn parallel_islands_grouped() {
+        let cfg = sword_to_training_config(&sample_sword()).unwrap();
+        assert_eq!(cfg.parallel_islands.len(), 2);
+        let island0 = cfg.parallel_islands.iter().find(|i| i.island_id == 0).unwrap();
+        assert_eq!(island0.layer_names, vec!["head"]);
+    }
+
+    #[test]
+    fn stats_populated() {
+        let cfg = sword_to_training_config(&sample_sword()).unwrap();
+        assert_eq!(cfg.stats.total_params, 10000);
+        assert_eq!(cfg.stats.trainable_pct, 20.0);
+    }
+
+    #[test]
+    fn wrong_path_rejected() {
+        let doc = json!({ "recommended_path": "gate_synthesis" });
+        assert!(sword_to_training_config(&doc).is_err());
+    }
+}

--- a/sword-ml-adapter/src/config.rs
+++ b/sword-ml-adapter/src/config.rs
@@ -1,0 +1,61 @@
+use serde::{Deserialize, Serialize};
+
+/// A single trainable layer and which of its parameter indices are active.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TrainableLayer {
+    /// Layer name as it appears in the model's named_parameters().
+    pub name: String,
+    /// Indices of parameters within this layer that should be trained.
+    /// An empty vec means every parameter in the layer is trainable.
+    pub param_indices_to_train: Vec<usize>,
+    /// Island id — layers sharing the same island can be trained in one
+    /// parallel group (e.g. data-parallel or tensor-parallel slice).
+    pub island_id: u32,
+}
+
+/// Which layers are frozen and which are trainable.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FreezeMap {
+    pub frozen_layers: Vec<String>,
+    pub trainable_layers: Vec<TrainableLayer>,
+}
+
+/// Per-island learning-rate suggestion.
+///
+/// Volatile (trainable) layers are assigned a higher LR than stable ones.
+/// The exact scaling factor (10×) is intentionally conservative and should
+/// be tuned per experiment.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LrSchedule {
+    pub island_id: u32,
+    /// Suggested base learning rate for this island.
+    pub base_lr: f64,
+}
+
+/// A parallel training island — all layers here share gradient sync.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ParallelIsland {
+    pub island_id: u32,
+    pub layer_names: Vec<String>,
+}
+
+/// Full training configuration derived from a SWORD document.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TrainingConfig {
+    pub freeze_map: FreezeMap,
+    /// Per-island LR suggestion.  Islands with more volatile parameters
+    /// receive a higher recommended LR.
+    pub suggested_lr_schedule: Vec<LrSchedule>,
+    /// Groups of layers that can be trained independently in parallel.
+    pub parallel_islands: Vec<ParallelIsland>,
+    /// Snapshot of the partition statistics from the SWORD document.
+    pub stats: PartitionStats,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PartitionStats {
+    pub total_params: u64,
+    pub frozen_params: u64,
+    pub trainable_params: u64,
+    pub trainable_pct: f64,
+}

--- a/sword-ml-adapter/src/lib.rs
+++ b/sword-ml-adapter/src/lib.rs
@@ -1,0 +1,34 @@
+/// SWORD ML Adapter
+///
+/// Translates a SWORD document with `recommended_path = "ml_training"` into
+/// a [`TrainingConfig`] that downstream PyTorch / JAX code can consume.
+///
+/// SWORD structure consumed here:
+/// ```json
+/// {
+///   "recommended_path": "ml_training",
+///   "hierarchical_partition": {
+///     "layer_partition": [
+///       { "name": "embed", "role": "stable" },
+///       { "name": "head",  "role": "volatile", "island_id": 0 }
+///     ],
+///     "parameter_partitions": [
+///       { "layer": "head", "param_index": 0, "role": "train" },
+///       { "layer": "head", "param_index": 1, "role": "freeze" }
+///     ],
+///     "total_params":     10000,
+///     "frozen_params":    8000,
+///     "trainable_params": 2000,
+///     "trainable_pct":    20.0
+///   }
+/// }
+/// ```
+pub mod adapter;
+pub mod config;
+pub mod onnx;
+pub mod pytorch;
+
+pub use adapter::sword_to_training_config;
+pub use config::{FreezeMap, LrSchedule, ParallelIsland, TrainableLayer, TrainingConfig};
+pub use onnx::{to_onnx_json, to_onnx_training_spec, OnnxTrainingSpec};
+pub use pytorch::to_pytorch_script;

--- a/sword-ml-adapter/src/onnx.rs
+++ b/sword-ml-adapter/src/onnx.rs
@@ -1,0 +1,208 @@
+/// ONNX Training Specification output.
+///
+/// Instead of generating a PyTorch script, this emits a framework-agnostic
+/// ONNX-compatible training specification that describes:
+/// - Which graph nodes (layers) are frozen vs trainable
+/// - Per-island optimizer groups with LR recommendations
+/// - Parallel training structure
+///
+/// Output is a JSON document that can be consumed by:
+/// - onnxruntime TrainingSession (via training_info)
+/// - Nathan's existing ONNX pipeline (garm-analysis)
+/// - Any custom training loop that reads freeze maps
+///
+/// We deliberately do NOT generate an ONNX protobuf here — that requires
+/// the full onnx crate and a model file to modify. Instead we emit the
+/// SPECIFICATION that a thin wrapper (Python or Rust+ort) applies to a
+/// model. This keeps the adapter dependency-free.
+
+use crate::config::TrainingConfig;
+use serde::{Deserialize, Serialize};
+
+/// ONNX-compatible training specification.
+///
+/// Designed to be consumed by `onnxruntime.training.api.Module` or
+/// applied to an ONNX graph via `onnx.helper.make_training_info`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OnnxTrainingSpec {
+    /// Schema version for forward compatibility.
+    pub version: u32,
+    /// Frozen parameters — these become non-trainable initializers.
+    pub frozen_params: Vec<OnnxFrozenParam>,
+    /// Trainable parameter groups — one per island.
+    pub trainable_groups: Vec<OnnxTrainableGroup>,
+    /// Summary statistics.
+    pub stats: OnnxTrainingStats,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OnnxFrozenParam {
+    /// ONNX graph node name pattern (matches named_parameters convention).
+    /// e.g. "encoder.layer.0.weight", "embed.weight"
+    pub name_pattern: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OnnxTrainableGroup {
+    /// Island ID for parallel training.
+    pub island_id: u32,
+    /// Parameter name patterns in this group.
+    pub param_patterns: Vec<String>,
+    /// Specific parameter indices within each layer (empty = all params).
+    pub param_indices: Vec<usize>,
+    /// Recommended learning rate for this group.
+    pub learning_rate: f64,
+    /// Weight decay recommendation (0.01 default, 0.0 for bias/norm).
+    pub weight_decay: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OnnxTrainingStats {
+    pub total_params: u64,
+    pub frozen_params: u64,
+    pub trainable_params: u64,
+    pub trainable_pct: f64,
+    pub n_islands: u32,
+}
+
+/// Convert a TrainingConfig into an ONNX-compatible training specification.
+pub fn to_onnx_training_spec(config: &TrainingConfig) -> OnnxTrainingSpec {
+    let frozen_params = config
+        .freeze_map
+        .frozen_layers
+        .iter()
+        .map(|name| OnnxFrozenParam {
+            name_pattern: format!("{name}.*"),
+        })
+        .collect();
+
+    let trainable_groups = config
+        .parallel_islands
+        .iter()
+        .map(|island| {
+            let lr = config
+                .suggested_lr_schedule
+                .iter()
+                .find(|s| s.island_id == island.island_id)
+                .map(|s| s.base_lr)
+                .unwrap_or(1e-3);
+
+            // Collect param indices from all trainable layers in this island
+            let param_indices: Vec<usize> = config
+                .freeze_map
+                .trainable_layers
+                .iter()
+                .filter(|l| l.island_id == island.island_id)
+                .flat_map(|l| l.param_indices_to_train.iter().copied())
+                .collect();
+
+            OnnxTrainableGroup {
+                island_id: island.island_id,
+                param_patterns: island
+                    .layer_names
+                    .iter()
+                    .map(|n| format!("{n}.*"))
+                    .collect(),
+                param_indices,
+                learning_rate: lr,
+                weight_decay: 0.01,
+            }
+        })
+        .collect();
+
+    OnnxTrainingSpec {
+        version: 1,
+        frozen_params,
+        trainable_groups,
+        stats: OnnxTrainingStats {
+            total_params: config.stats.total_params,
+            frozen_params: config.stats.frozen_params,
+            trainable_params: config.stats.trainable_params,
+            trainable_pct: config.stats.trainable_pct,
+            n_islands: config.parallel_islands.len() as u32,
+        },
+    }
+}
+
+/// Serialize the spec as JSON — the primary wire format.
+pub fn to_onnx_json(config: &TrainingConfig) -> String {
+    let spec = to_onnx_training_spec(config);
+    serde_json::to_string_pretty(&spec).unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapter::sword_to_training_config;
+    use serde_json::json;
+
+    fn sample_sword() -> serde_json::Value {
+        json!({
+            "recommended_path": "ml_training",
+            "hierarchical_partition": {
+                "layer_partition": [
+                    { "name": "encoder", "role": "stable" },
+                    { "name": "decoder", "role": "stable" },
+                    { "name": "head", "role": "volatile", "island_id": 0 },
+                    { "name": "classifier", "role": "volatile", "island_id": 1 }
+                ],
+                "parameter_partitions": [
+                    { "layer": "head", "param_index": 0, "role": "train" },
+                    { "layer": "head", "param_index": 1, "role": "freeze" },
+                    { "layer": "classifier", "param_index": 0, "role": "train" }
+                ],
+                "total_params": 50000,
+                "frozen_params": 45000,
+                "trainable_params": 5000,
+                "trainable_pct": 10.0
+            }
+        })
+    }
+
+    #[test]
+    fn onnx_spec_has_frozen_layers() {
+        let cfg = sword_to_training_config(&sample_sword()).unwrap();
+        let spec = to_onnx_training_spec(&cfg);
+        assert_eq!(spec.frozen_params.len(), 2);
+        assert!(spec.frozen_params.iter().any(|p| p.name_pattern == "encoder.*"));
+        assert!(spec.frozen_params.iter().any(|p| p.name_pattern == "decoder.*"));
+    }
+
+    #[test]
+    fn onnx_spec_has_trainable_groups() {
+        let cfg = sword_to_training_config(&sample_sword()).unwrap();
+        let spec = to_onnx_training_spec(&cfg);
+        assert_eq!(spec.trainable_groups.len(), 2);
+        assert!(spec.trainable_groups[0].learning_rate > 0.0);
+    }
+
+    #[test]
+    fn onnx_spec_preserves_stats() {
+        let cfg = sword_to_training_config(&sample_sword()).unwrap();
+        let spec = to_onnx_training_spec(&cfg);
+        assert_eq!(spec.stats.total_params, 50000);
+        assert_eq!(spec.stats.trainable_params, 5000);
+        assert!((spec.stats.trainable_pct - 10.0).abs() < 0.1);
+    }
+
+    #[test]
+    fn onnx_json_is_valid() {
+        let cfg = sword_to_training_config(&sample_sword()).unwrap();
+        let json_str = to_onnx_json(&cfg);
+        let parsed: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(parsed["version"], 1);
+        assert!(parsed["frozen_params"].is_array());
+        assert!(parsed["trainable_groups"].is_array());
+    }
+
+    #[test]
+    fn onnx_spec_param_indices_propagated() {
+        let cfg = sword_to_training_config(&sample_sword()).unwrap();
+        let spec = to_onnx_training_spec(&cfg);
+        // Island 0 (head) should have param_index 0
+        let island_0 = spec.trainable_groups.iter().find(|g| g.island_id == 0).unwrap();
+        assert!(island_0.param_indices.contains(&0));
+        // param_index 1 was "freeze", should not appear
+        assert!(!island_0.param_indices.contains(&1));
+    }
+}

--- a/sword-ml-adapter/src/pytorch.rs
+++ b/sword-ml-adapter/src/pytorch.rs
@@ -1,0 +1,173 @@
+use crate::config::TrainingConfig;
+
+/// Generate a Python snippet that sets `requires_grad` appropriately for every
+/// parameter group described by `config`.
+///
+/// The snippet is self-contained and assumes:
+/// - `model` is a `torch.nn.Module` already instantiated.
+/// - `optimizer_groups` will be consumed by a `torch.optim.*` constructor.
+///
+/// Example output:
+/// ```python
+/// # SWORD ML Adapter — auto-generated, do not edit by hand
+/// # Frozen layers: ['embed']
+/// for name, param in model.named_parameters():
+///     param.requires_grad = False   # freeze all by default
+///
+/// # Trainable layer: head (island 0, lr=0.001000)
+/// #   param indices to train: [0]
+/// for name, param in model.named_parameters():
+///     parts = name.split('.')
+///     if parts[0] == 'head':
+///         idx = int(parts[-1]) if parts[-1].isdigit() else None
+///         if idx is None or idx in {0}:
+///             param.requires_grad = True
+/// ...
+/// ```
+pub fn to_pytorch_script(config: &TrainingConfig) -> String {
+    let mut lines: Vec<String> = Vec::new();
+
+    lines.push("# SWORD ML Adapter — auto-generated, do not edit by hand".into());
+
+    // Frozen layer summary comment
+    if !config.freeze_map.frozen_layers.is_empty() {
+        let frozen_list = config
+            .freeze_map
+            .frozen_layers
+            .iter()
+            .map(|s| format!("'{s}'"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        lines.push(format!("# Frozen layers: [{frozen_list}]"));
+    }
+
+    lines.push(String::new());
+
+    // Step 1: freeze everything
+    lines.push("for name, param in model.named_parameters():".into());
+    lines.push("    param.requires_grad = False   # freeze all by default".into());
+    lines.push(String::new());
+
+    // Step 2: selectively unfreeze trainable layers
+    for layer in &config.freeze_map.trainable_layers {
+        // Find the LR for this island
+        let lr = config
+            .suggested_lr_schedule
+            .iter()
+            .find(|s| s.island_id == layer.island_id)
+            .map(|s| s.base_lr)
+            .unwrap_or(1e-3);
+
+        lines.push(format!(
+            "# Trainable layer: {} (island {}, lr={:.6})",
+            layer.name, layer.island_id, lr
+        ));
+
+        if layer.param_indices_to_train.is_empty() {
+            // All params in this layer are trainable
+            lines.push(format!("#   all parameters trainable"));
+            lines.push("for name, param in model.named_parameters():".into());
+            lines.push("    parts = name.split('.')".into());
+            lines.push(format!("    if parts[0] == '{}':", layer.name));
+            lines.push("        param.requires_grad = True".into());
+        } else {
+            // Only specific indices are trainable
+            let idx_set = layer
+                .param_indices_to_train
+                .iter()
+                .map(|i| i.to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            lines.push(format!(
+                "#   param indices to train: [{}]",
+                idx_set
+            ));
+            lines.push("for name, param in model.named_parameters():".into());
+            lines.push("    parts = name.split('.')".into());
+            lines.push(format!("    if parts[0] == '{}':", layer.name));
+            lines.push("        idx = int(parts[-1]) if parts[-1].isdigit() else None".into());
+            lines.push(format!(
+                "        if idx is None or idx in {{{}}}:",
+                idx_set
+            ));
+            lines.push("            param.requires_grad = True".into());
+        }
+        lines.push(String::new());
+    }
+
+    // Step 3: optimizer param groups, one per island
+    if !config.parallel_islands.is_empty() {
+        lines.push("# Optimizer param groups (one per island)".into());
+        lines.push("optimizer_groups = []".into());
+        for island in &config.parallel_islands {
+            let lr = config
+                .suggested_lr_schedule
+                .iter()
+                .find(|s| s.island_id == island.island_id)
+                .map(|s| s.base_lr)
+                .unwrap_or(1e-3);
+            let layer_list = island
+                .layer_names
+                .iter()
+                .map(|s| format!("'{s}'"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            lines.push(format!(
+                "optimizer_groups.append({{'params': [p for n, p in model.named_parameters() if n.split('.')[0] in [{}] and p.requires_grad], 'lr': {:.6}}})",
+                layer_list, lr
+            ));
+        }
+        lines.push(String::new());
+        lines.push(
+            "# Example: optimizer = torch.optim.AdamW(optimizer_groups)".into(),
+        );
+    }
+
+    lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapter::sword_to_training_config;
+    use serde_json::json;
+
+    #[test]
+    fn script_contains_freeze_all() {
+        let doc = json!({
+            "recommended_path": "ml_training",
+            "hierarchical_partition": {
+                "layer_partition": [
+                    { "name": "embed", "role": "stable" },
+                    { "name": "head",  "role": "volatile", "island_id": 0 }
+                ],
+                "parameter_partitions": [],
+                "total_params": 100, "frozen_params": 80,
+                "trainable_params": 20, "trainable_pct": 20.0
+            }
+        });
+        let cfg = sword_to_training_config(&doc).unwrap();
+        let script = to_pytorch_script(&cfg);
+        assert!(script.contains("param.requires_grad = False"));
+        assert!(script.contains("param.requires_grad = True"));
+        assert!(script.contains("optimizer_groups"));
+    }
+
+    #[test]
+    fn frozen_layers_listed_in_comment() {
+        let doc = json!({
+            "recommended_path": "ml_training",
+            "hierarchical_partition": {
+                "layer_partition": [
+                    { "name": "backbone", "role": "stable" }
+                ],
+                "parameter_partitions": [],
+                "total_params": 100, "frozen_params": 100,
+                "trainable_params": 0, "trainable_pct": 0.0
+            }
+        });
+        let cfg = sword_to_training_config(&doc).unwrap();
+        let script = to_pytorch_script(&cfg);
+        assert!(script.contains("'backbone'"));
+    }
+}


### PR DESCRIPTION
## Summary

Lands the SWORD adapter work that has been sitting in the maintainer's working tree since 2026-04-15. Two commits:

1. **`feat(sword): adapter for SWORD documents into Ehrenfest + classical/ML targets`**
   - `afana/src/sword_ingest.rs` (Quantum Adapter 3a) — translates a SWORD document's volatile islands into Ising Hamiltonians, stable-node neighbours into mean-field boundary shifts, and emits an `EhrenfestProgram` that the existing Afana pipeline compiles through CBOR → AST → ZX-IR → QASM3.
   - `sword-classical-adapter/` (3c) — new workspace crate translating SWORD docs to QUBO/Ising/routing formats for classical solvers.
   - `sword-ml-adapter/` — new workspace crate translating SWORD `ml_training` docs into PyTorch/JAX/ONNX configs.
   - `Cargo.toml` adds the two new crates to the workspace; `afana/src/lib.rs` registers the new module.

2. **`chore(quasi-mcp): bump mqt.qcec to 3.5.0 and mqt.ddsim to 2.2.0`**
   - Routine version bump for the Munich Quantum Toolkit pins.

## Architectural compliance (CLAUDE.md §1)

`afana/src/sword_ingest.rs` only uses `anyhow` and `serde_json` — both inside the allowed-deps allowlist. No Python, no vendor SDKs, no FFI to Python, no HTTP clients to hardware APIs. The compiler-boundary CI check should pass.

The two new crates are *outside* `afana/`, so the boundary rule doesn't apply to them. Both list only `serde`, `serde_json`, `thiserror` as deps.

## Test plan

- [x] `cargo build --workspace --release` is green
- [ ] `cargo test --workspace` runs (no new tests added in this PR; the sword crates are scaffolds)
- [ ] CI Layer 0 / Layer 1 / Afana / Compiler boundary pass

## Notes

- No CBOR examples added, so this PR shouldn't be affected by the broken-CBOR drag from #993.
- The SWORD ingest module is the production path for Arn's `/analyze?output=sword` endpoint to feed the Afana compiler. Pairs with future Arn work (separate repo).