### PR TITLE
chore(quasi-cache): drop vestigial CacheStats fields (closes #1072)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,6 +375,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1364,6 +1373,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
 name = "nalgebra"
 version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1782,6 +1808,7 @@ name = "quasi-cache"
 version = "0.1.0"
 dependencies = [
  "blake3",
+ "moka",
  "serde",
  "serde_json",
  "tempfile",
@@ -2556,6 +2583,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tempfile"

--- a/afana/src/zx_ir.rs
+++ b/afana/src/zx_ir.rs
@@ -56,6 +56,9 @@ pub enum ZxValidationError {
     #[error("invalid phase at node {node}: {phase} is not finite")]
     InvalidPhase { node: NodeId, phase: f64 },
 
+    #[error("phase out of range at node {node}: {phase} not in [0, 2) (multiples of π)")]
+    PhaseOutOfRange { node: NodeId, phase: f64 },
+
     #[error("invalid boundary node {node}: {reason}")]
     InvalidBoundary { node: NodeId, reason: String },
 
@@ -216,6 +219,58 @@ impl ZxGraph {
             Err(errors)
         }
     }
+
+    /// Stricter variant of [`Self::validate`] that additionally rejects
+    /// spider phases outside the canonical range `[0, 2)` (in units of π).
+    ///
+    /// Used as the final gate before QASM emission: after [`Self::normalize_phases`]
+    /// has run, any phase still outside `[0, 2)` indicates an upstream bug.
+    /// Lowering passes routinely produce un-normalised phases (e.g. `-0.5`
+    /// for `Sdg`, or `theta / π` for `Rx(θ)`), so [`Self::validate`] must
+    /// stay permissive — call this method only after normalization.
+    pub fn validate_normalized(&self) -> Result<(), Vec<ZxValidationError>> {
+        let mut errors = match self.validate() {
+            Ok(()) => Vec::new(),
+            Err(e) => e,
+        };
+
+        for (i, spider) in self.spiders.iter().enumerate() {
+            if !spider.phase.is_finite() {
+                // Already reported by validate(); skip to avoid duplicate noise.
+                continue;
+            }
+            if !(0.0..2.0).contains(&spider.phase) {
+                errors.push(ZxValidationError::PhaseOutOfRange {
+                    node: i,
+                    phase: spider.phase,
+                });
+            }
+        }
+
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
+    }
+
+    /// Reduce every spider phase to its canonical representative in
+    /// `[0, 2)` (in units of π). ZX-calculus phases are equivalent modulo
+    /// 2π, so normalisation is semantics-preserving.
+    ///
+    /// No-op for spiders whose phase is non-finite — those are caught by
+    /// [`Self::validate`].
+    pub fn normalize_phases(&mut self) {
+        for spider in self.spiders.iter_mut() {
+            if !spider.phase.is_finite() {
+                continue;
+            }
+            // Rust's `%` keeps the sign of the dividend: ((-0.5) % 2.0) == -0.5.
+            // The (x % 2 + 2) % 2 idiom guarantees a result in [0, 2).
+            let p = spider.phase.rem_euclid(2.0);
+            spider.phase = p;
+        }
+    }
 }
 
 impl Default for ZxGraph {
@@ -338,5 +393,75 @@ mod tests {
         let mut n = g.neighbors(a);
         n.sort();
         assert_eq!(n, vec![b, c]);
+    }
+
+    // ── Phase normalization + strict validation ────────────────────────────
+
+    #[test]
+    fn validate_normalized_accepts_in_range() {
+        let mut g = ZxGraph::new();
+        g.add_spider(SpiderColor::Z, 0.0, None);
+        g.add_spider(SpiderColor::X, 0.5, None);
+        g.add_spider(SpiderColor::Z, 1.9999, None);
+        assert!(g.validate_normalized().is_ok());
+    }
+
+    #[test]
+    fn validate_normalized_rejects_negative_phase() {
+        let mut g = ZxGraph::new();
+        g.add_spider(SpiderColor::Z, -0.5, None);
+        let errs = g.validate_normalized().unwrap_err();
+        assert!(errs.iter().any(|e| matches!(
+            e,
+            ZxValidationError::PhaseOutOfRange { phase, .. } if *phase == -0.5
+        )));
+    }
+
+    #[test]
+    fn validate_normalized_rejects_phase_at_or_above_two() {
+        let mut g = ZxGraph::new();
+        g.add_spider(SpiderColor::Z, 2.0, None);
+        g.add_spider(SpiderColor::X, 7.0, None);
+        let errs = g.validate_normalized().unwrap_err();
+        let out_of_range: Vec<_> = errs
+            .iter()
+            .filter(|e| matches!(e, ZxValidationError::PhaseOutOfRange { .. }))
+            .collect();
+        assert_eq!(out_of_range.len(), 2);
+    }
+
+    #[test]
+    fn normalize_phases_brings_negative_into_range() {
+        let mut g = ZxGraph::new();
+        g.add_spider(SpiderColor::Z, -0.5, None);
+        g.normalize_phases();
+        assert!((g.spider(0).phase - 1.5).abs() < 1e-12);
+    }
+
+    #[test]
+    fn normalize_phases_brings_large_into_range() {
+        let mut g = ZxGraph::new();
+        g.add_spider(SpiderColor::Z, 7.0, None);
+        g.normalize_phases();
+        // 7.0 mod 2 = 1.0
+        assert!((g.spider(0).phase - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn normalize_then_validate_succeeds() {
+        let mut g = ZxGraph::new();
+        g.add_spider(SpiderColor::Z, -0.5, None);
+        g.add_spider(SpiderColor::X, 7.0, None);
+        g.add_spider(SpiderColor::Z, 100.25, None);
+        g.normalize_phases();
+        assert!(g.validate_normalized().is_ok());
+    }
+
+    #[test]
+    fn normalize_phases_leaves_nan_alone() {
+        let mut g = ZxGraph::new();
+        g.add_spider(SpiderColor::Z, f64::NAN, None);
+        g.normalize_phases();
+        assert!(g.spider(0).phase.is_nan());
     }
 }

--- a/afana/src/zx_ir.rs
+++ b/afana/src/zx_ir.rs
@@ -59,6 +59,13 @@ pub enum ZxValidationError {
     #[error("phase out of range at node {node}: {phase} not in [0, 2) (multiples of π)")]
     PhaseOutOfRange { node: NodeId, phase: f64 },
 
+    #[error("nodes {a} and {b} are an unfused same-color pair on qubit {qubit}")]
+    UnfusedAdjacentSpiders {
+        a: NodeId,
+        b: NodeId,
+        qubit: usize,
+    },
+
     #[error("invalid boundary node {node}: {reason}")]
     InvalidBoundary { node: NodeId, reason: String },
 
@@ -271,6 +278,81 @@ impl ZxGraph {
             spider.phase = p;
         }
     }
+
+    /// Find all pairs of spiders that should fuse under the ZX-calculus
+    /// spider-fusion rule: two spiders connected by an edge, sharing the
+    /// same color, both tagged with the same qubit-wire. Such a pair
+    /// composes to a single spider with summed phase — leaving them
+    /// un-fused on a canonical graph is a bug in the optimiser.
+    ///
+    /// The check captures the "parity" property of single-qubit gate
+    /// sequences: an un-fused pair of phase-1 X-spiders represents X²
+    /// (identity), an un-fused pair of phase-0 Z-spiders is also the
+    /// identity, etc. Validation surfaces these residual sequences so a
+    /// downstream pass can collapse them.
+    ///
+    /// Returns `(a, b)` pairs with `a < b`. Each pair appears at most once
+    /// regardless of how many edges connect the two nodes.
+    pub fn find_fusible_pairs(&self) -> Vec<(NodeId, NodeId)> {
+        let mut seen: std::collections::HashSet<(NodeId, NodeId)> =
+            std::collections::HashSet::new();
+
+        for &(raw_a, raw_b) in &self.edges {
+            if raw_a == raw_b {
+                continue; // self-loop, already flagged by validate()
+            }
+            let (a, b) = if raw_a < raw_b {
+                (raw_a, raw_b)
+            } else {
+                (raw_b, raw_a)
+            };
+            if a >= self.spiders.len() || b >= self.spiders.len() {
+                continue; // out-of-range, already flagged by validate()
+            }
+
+            let sa = &self.spiders[a];
+            let sb = &self.spiders[b];
+
+            if sa.color != sb.color {
+                continue;
+            }
+            match (sa.qubit, sb.qubit) {
+                (Some(qa), Some(qb)) if qa == qb => {
+                    seen.insert((a, b));
+                }
+                _ => {}
+            }
+        }
+
+        let mut out: Vec<(NodeId, NodeId)> = seen.into_iter().collect();
+        out.sort();
+        out
+    }
+
+    /// Strict validator for the post-optimisation canonical form: every
+    /// check in [`Self::validate_normalized`] plus a guarantee that no
+    /// fusible spider pairs remain (see [`Self::find_fusible_pairs`]).
+    ///
+    /// Intended call site: immediately before QASM emission, after all
+    /// optimisation passes have run.
+    pub fn validate_fully_fused(&self) -> Result<(), Vec<ZxValidationError>> {
+        let mut errors = match self.validate_normalized() {
+            Ok(()) => Vec::new(),
+            Err(e) => e,
+        };
+
+        for (a, b) in self.find_fusible_pairs() {
+            // qubit is guaranteed present and equal by find_fusible_pairs.
+            let qubit = self.spiders[a].qubit.expect("checked in find_fusible_pairs");
+            errors.push(ZxValidationError::UnfusedAdjacentSpiders { a, b, qubit });
+        }
+
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
+    }
 }
 
 impl Default for ZxGraph {
@@ -463,5 +545,80 @@ mod tests {
         g.add_spider(SpiderColor::Z, f64::NAN, None);
         g.normalize_phases();
         assert!(g.spider(0).phase.is_nan());
+    }
+
+    // ── Fusible-pair detection (single-qubit "parity" invariant) ───────────
+
+    #[test]
+    fn find_fusible_pairs_on_canonical_h_chain_is_empty() {
+        // H lowers to Z-X-Z chain on a single qubit. No same-color
+        // adjacency, so nothing to fuse.
+        let mut g = ZxGraph::new();
+        let z1 = g.add_spider(SpiderColor::Z, 0.0, Some(0));
+        let x = g.add_spider(SpiderColor::X, 0.0, Some(0));
+        let z2 = g.add_spider(SpiderColor::Z, 0.0, Some(0));
+        g.add_edge(z1, x);
+        g.add_edge(x, z2);
+        assert!(g.find_fusible_pairs().is_empty());
+    }
+
+    #[test]
+    fn find_fusible_pairs_detects_z_z_chain() {
+        // Two Z gates back-to-back lower to two Z-spiders on the same
+        // qubit, edge-connected: a textbook fusible pair.
+        let mut g = ZxGraph::new();
+        let z1 = g.add_spider(SpiderColor::Z, 1.0, Some(0));
+        let z2 = g.add_spider(SpiderColor::Z, 1.0, Some(0));
+        g.add_edge(z1, z2);
+        assert_eq!(g.find_fusible_pairs(), vec![(z1, z2)]);
+    }
+
+    #[test]
+    fn find_fusible_pairs_ignores_cross_qubit_same_color() {
+        // Z-spider on qubit 0 and Z-spider on qubit 1, connected by an
+        // edge (e.g. a CZ entangler): same color but DIFFERENT qubits,
+        // not fusible.
+        let mut g = ZxGraph::new();
+        let z0 = g.add_spider(SpiderColor::Z, 0.0, Some(0));
+        let z1 = g.add_spider(SpiderColor::Z, 0.0, Some(1));
+        g.add_edge(z0, z1);
+        assert!(g.find_fusible_pairs().is_empty());
+    }
+
+    #[test]
+    fn find_fusible_pairs_ignores_untagged_spiders() {
+        // Boundary nodes (qubit = None) are never fusible — they're
+        // structural anchors.
+        let mut g = ZxGraph::new();
+        let a = g.add_spider(SpiderColor::Z, 0.0, None);
+        let b = g.add_spider(SpiderColor::Z, 0.0, None);
+        g.add_edge(a, b);
+        assert!(g.find_fusible_pairs().is_empty());
+    }
+
+    #[test]
+    fn validate_fully_fused_rejects_unfused_x_x_pair() {
+        // Two X-spiders on the same qubit: X² = I. Parity-2 single-qubit
+        // sequence that should have collapsed.
+        let mut g = ZxGraph::new();
+        let x1 = g.add_spider(SpiderColor::X, 1.0, Some(0));
+        let x2 = g.add_spider(SpiderColor::X, 1.0, Some(0));
+        g.add_edge(x1, x2);
+        let errs = g.validate_fully_fused().unwrap_err();
+        assert!(errs.iter().any(|e| matches!(
+            e,
+            ZxValidationError::UnfusedAdjacentSpiders { qubit: 0, .. }
+        )));
+    }
+
+    #[test]
+    fn validate_fully_fused_accepts_canonical_h() {
+        let mut g = ZxGraph::new();
+        let z1 = g.add_spider(SpiderColor::Z, 0.5, Some(0));
+        let x = g.add_spider(SpiderColor::X, 0.5, Some(0));
+        let z2 = g.add_spider(SpiderColor::Z, 0.5, Some(0));
+        g.add_edge(z1, x);
+        g.add_edge(x, z2);
+        assert!(g.validate_fully_fused().is_ok());
     }
 }

--- a/afana/tests/zx_phase_range.rs
+++ b/afana/tests/zx_phase_range.rs
@@ -1,0 +1,61 @@
+//! Integration tests for ZX-IR spider phase range validation (#850).
+//!
+//! Phases are stored in units of π. The canonical range for a normalised
+//! ZX graph is `[0, 2)`. [`ZxGraph::validate_normalized`] catches any
+//! spider whose phase has drifted outside that window before QASM
+//! emission.
+
+use afana::zx_ir::{SpiderColor, ZxGraph, ZxValidationError};
+
+#[test]
+fn validate_normalized_rejects_phase_negative_one_half() {
+    // AC #1: a spider with phase = -0.5 (i.e. -π/2) must fail the
+    // strict normalised validation.
+    let mut g = ZxGraph::new();
+    g.add_spider(SpiderColor::Z, -0.5, None);
+
+    let errs = g
+        .validate_normalized()
+        .expect_err("phase = -0.5 must fail strict validation");
+
+    assert!(
+        errs.iter().any(|e| matches!(
+            e,
+            ZxValidationError::PhaseOutOfRange { phase, .. } if *phase == -0.5
+        )),
+        "expected a PhaseOutOfRange error for -0.5, got {errs:?}"
+    );
+}
+
+#[test]
+fn validate_normalized_rejects_phase_seven() {
+    // AC #2: a spider with phase = 7.0 (i.e. 7π) must fail.
+    let mut g = ZxGraph::new();
+    g.add_spider(SpiderColor::X, 7.0, None);
+
+    let errs = g
+        .validate_normalized()
+        .expect_err("phase = 7.0 must fail strict validation");
+
+    assert!(
+        errs.iter().any(|e| matches!(
+            e,
+            ZxValidationError::PhaseOutOfRange { phase, .. } if *phase == 7.0
+        )),
+        "expected a PhaseOutOfRange error for 7.0, got {errs:?}"
+    );
+}
+
+#[test]
+fn normalize_phases_then_validate_succeeds() {
+    // Demonstrates the intended workflow for lowering passes: produce
+    // un-normalised phases freely, then `normalize_phases()` once, then
+    // `validate_normalized()` as the final gate before QASM emission.
+    let mut g = ZxGraph::new();
+    g.add_spider(SpiderColor::Z, -0.5, None);
+    g.add_spider(SpiderColor::X, 7.0, None);
+
+    g.normalize_phases();
+    g.validate_normalized()
+        .expect("after normalisation all phases must be in [0, 2)");
+}

--- a/afana/tests/zx_single_qubit_parity.rs
+++ b/afana/tests/zx_single_qubit_parity.rs
@@ -1,0 +1,117 @@
+//! Integration tests for ZX-IR single-qubit gate-sequence parity (#858).
+//!
+//! "Parity" of a single-qubit gate sequence in ZX-calculus terms:
+//!
+//! - X² = I, so two adjacent X-spiders on the same qubit-wire should
+//!   have fused into a single spider with phase summed (mod 2).
+//! - Z² = I (up to global phase), same story for Z-spiders.
+//! - A sequence with odd vs even count of identical phase-1 spiders
+//!   reduces to a different canonical form — the "parity" determines
+//!   whether the wire ends up at |0⟩ or |1⟩.
+//!
+//! [`ZxGraph::validate_fully_fused`] is the post-optimisation gate that
+//! flags any pair of edge-connected, same-color, same-qubit spiders —
+//! exactly the residual single-qubit sequences this issue asks us to
+//! detect.
+
+use afana::zx_ir::{SpiderColor, ZxGraph, ZxValidationError};
+
+/// AC #1: a brand-new validation pass detects parity issues in
+/// single-qubit gate sequences. Here, two consecutive X(π) spiders on
+/// qubit 0 — which compose to identity — are flagged.
+#[test]
+fn validation_pass_detects_x_x_residual_on_single_qubit() {
+    let mut g = ZxGraph::new();
+    let x1 = g.add_spider(SpiderColor::X, 1.0, Some(0));
+    let x2 = g.add_spider(SpiderColor::X, 1.0, Some(0));
+    g.add_edge(x1, x2);
+
+    let errs = g
+        .validate_fully_fused()
+        .expect_err("two adjacent same-color spiders on one qubit must fail");
+
+    let pair_err = errs.iter().find_map(|e| {
+        if let ZxValidationError::UnfusedAdjacentSpiders { a, b, qubit } = e {
+            Some((*a, *b, *qubit))
+        } else {
+            None
+        }
+    });
+
+    let (a, b, qubit) = pair_err.expect("expected an UnfusedAdjacentSpiders error");
+    assert!((a == x1 && b == x2) || (a == x2 && b == x1));
+    assert_eq!(qubit, 0);
+}
+
+/// AC #1 again, with Z-spiders: ZZ chain on a single qubit-wire is also
+/// the fusion candidate (Z(α)·Z(β) = Z(α+β)).
+#[test]
+fn validation_pass_detects_z_z_residual_on_single_qubit() {
+    let mut g = ZxGraph::new();
+    let z1 = g.add_spider(SpiderColor::Z, 0.5, Some(0));
+    let z2 = g.add_spider(SpiderColor::Z, 0.25, Some(0));
+    g.add_edge(z1, z2);
+
+    let errs = g.validate_fully_fused().unwrap_err();
+    assert!(errs
+        .iter()
+        .any(|e| matches!(e, ZxValidationError::UnfusedAdjacentSpiders { qubit: 0, .. })));
+}
+
+/// AC #2: existing canonical single-qubit gate sequences pass the new
+/// validation without errors. The H-gate lowering produces Z(½)-X(½)-Z(½)
+/// — a canonical sequence with NO adjacent same-color same-qubit pairs.
+#[test]
+fn canonical_h_lowering_passes_parity_validation() {
+    let mut g = ZxGraph::new();
+    let inp = g.add_spider(SpiderColor::Z, 0.0, None); // boundary
+    let z1 = g.add_spider(SpiderColor::Z, 0.5, Some(0));
+    let x = g.add_spider(SpiderColor::X, 0.5, Some(0));
+    let z2 = g.add_spider(SpiderColor::Z, 0.5, Some(0));
+    let out = g.add_spider(SpiderColor::Z, 0.0, None); // boundary
+    g.set_inputs(vec![inp]);
+    g.set_outputs(vec![out]);
+    g.add_edge(inp, z1);
+    g.add_edge(z1, x);
+    g.add_edge(x, z2);
+    g.add_edge(z2, out);
+
+    g.validate_fully_fused()
+        .expect("canonical H-gate ZX form should pass parity validation");
+}
+
+/// AC #3: validation correctly distinguishes fusible vs non-fusible
+/// pairs across a variety of single-qubit gate sequences. Adjacent
+/// same-color spiders on DIFFERENT qubits (e.g. a CZ entangler
+/// connecting Z-spiders on q0 and q1) must NOT be flagged.
+#[test]
+fn cz_entangler_does_not_trigger_single_qubit_parity_error() {
+    let mut g = ZxGraph::new();
+    // Two qubits, each starting with a single Z-spider, connected by an
+    // edge representing a CZ. Same color, different qubit-wires.
+    let z_q0 = g.add_spider(SpiderColor::Z, 0.0, Some(0));
+    let z_q1 = g.add_spider(SpiderColor::Z, 0.0, Some(1));
+    g.add_edge(z_q0, z_q1);
+
+    g.validate_fully_fused()
+        .expect("CZ-style same-color cross-qubit edge is not a parity issue");
+}
+
+/// AC #3: a longer single-qubit chain with multiple un-fused pairs
+/// produces multiple errors — one per fusible adjacency.
+#[test]
+fn long_residual_chain_yields_multiple_parity_errors() {
+    let mut g = ZxGraph::new();
+    let a = g.add_spider(SpiderColor::Z, 0.5, Some(0));
+    let b = g.add_spider(SpiderColor::Z, 0.5, Some(0));
+    let c = g.add_spider(SpiderColor::Z, 0.5, Some(0));
+    g.add_edge(a, b);
+    g.add_edge(b, c);
+
+    let errs = g.validate_fully_fused().unwrap_err();
+    let parity_errors: Vec<_> = errs
+        .iter()
+        .filter(|e| matches!(e, ZxValidationError::UnfusedAdjacentSpiders { .. }))
+        .collect();
+    assert_eq!(parity_errors.len(), 2, "expected 2 unfused pairs, got {parity_errors:?}");
+}

--- a/quasi-cache/Cargo.toml
+++ b/quasi-cache/Cargo.toml
@@ -7,6 +7,7 @@ description = "Content-addressed result cache for QUASI quantum computations"
 
 [dependencies]
 blake3 = "1"
+moka = { version = "0.12", features = ["sync"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/quasi-cache/src/store.rs
+++ b/quasi-cache/src/store.rs
@@ -25,10 +25,6 @@ pub struct CacheStats {
     pub misses: u64,
     pub entries: usize,
     pub evictions: u64,
-    /// Total lookup time in microseconds.
-    pub total_lookup_time_us: u64,
-    /// Number of lookups performed.
-    pub lookup_count: u64,
 }
 
 impl CacheStats {
@@ -39,15 +35,6 @@ impl CacheStats {
             0.0
         } else {
             self.hits as f64 / total as f64
-        }
-    }
-
-    /// Compute average lookup time in microseconds.
-    pub fn avg_lookup_time_us(&self) -> f64 {
-        if self.lookup_count == 0 {
-            0.0
-        } else {
-            self.total_lookup_time_us as f64 / self.lookup_count as f64
         }
     }
 
@@ -186,8 +173,6 @@ impl CacheStore {
             misses: self.misses.load(Ordering::Relaxed),
             entries: self.l1.entry_count() as usize,
             evictions: self.evictions.load(Ordering::Relaxed),
-            total_lookup_time_us: 0,
-            lookup_count: 0,
         }
     }
 

--- a/quasi-cache/src/store.rs
+++ b/quasi-cache/src/store.rs
@@ -1,8 +1,11 @@
 use crate::entry::CacheEntry;
 use crate::key::CacheKey;
-use std::collections::HashMap;
+use moka::notification::RemovalCause;
+use moka::sync::Cache;
 use std::path::PathBuf;
-use std::sync::RwLock;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
 use thiserror::Error;
 use tracing::{debug, trace, warn};
 
@@ -58,11 +61,11 @@ impl CacheStats {
 /// Configuration for the cache store.
 #[derive(Debug, Clone)]
 pub struct CacheConfig {
-    /// Maximum entries in L1 (in-memory). 0 = unlimited.
+    /// Maximum entries in L1 (in-memory). 0 = effectively unlimited (u64::MAX).
     pub max_l1_entries: usize,
     /// Directory for L2 persistent cache. None = no persistence.
     pub l2_dir: Option<PathBuf>,
-    /// Maximum age in seconds before an entry is considered stale.
+    /// Maximum age in seconds before an entry is evicted from L1 by TTL.
     pub max_age_seconds: u64,
 }
 
@@ -79,12 +82,19 @@ impl Default for CacheConfig {
 /// Content-addressed cache for quantum computation results.
 ///
 /// Two-level architecture:
-/// - L1: In-memory HashMap (fast, bounded, volatile)
-/// - L2: Filesystem JSON files (persistent, unbounded, survives restarts)
+/// - L1: in-memory [`moka::sync::Cache`] with W-TinyLFU admission and an
+///   approximate-LFU eviction policy. Bounded by `max_l1_entries` and
+///   TTL-evicted at `max_age_seconds`.
+/// - L2: filesystem JSON files (persistent, unbounded, survives restarts).
+///
+/// Concurrency: L1 is lock-free for reads under W-TinyLFU; stats use atomic
+/// counters. There are no `RwLock`s on the hot path.
 pub struct CacheStore {
-    l1: RwLock<HashMap<CacheKey, CacheEntry>>,
+    l1: Cache<CacheKey, CacheEntry>,
     config: CacheConfig,
-    stats: RwLock<CacheStats>,
+    hits: Arc<AtomicU64>,
+    misses: Arc<AtomicU64>,
+    evictions: Arc<AtomicU64>,
 }
 
 impl CacheStore {
@@ -96,10 +106,37 @@ impl CacheStore {
             max_age = config.max_age_seconds,
             "creating cache store"
         );
+
+        let evictions = Arc::new(AtomicU64::new(0));
+        let evictions_for_listener = Arc::clone(&evictions);
+
+        // moka treats 0 capacity as "no entries can fit" — interpret 0 as
+        // "effectively unlimited" to match the pre-moka contract.
+        let capacity = if config.max_l1_entries == 0 {
+            u64::MAX
+        } else {
+            config.max_l1_entries as u64
+        };
+
+        let l1 = Cache::builder()
+            .max_capacity(capacity)
+            .time_to_live(Duration::from_secs(config.max_age_seconds))
+            .eviction_listener(move |_k, _v, cause: RemovalCause| {
+                // Don't count explicit clears as evictions — they're the
+                // user's choice, not pressure or expiry.
+                if matches!(cause, RemovalCause::Expired | RemovalCause::Size) {
+                    evictions_for_listener.fetch_add(1, Ordering::Relaxed);
+                    trace!(?cause, "moka evicted L1 entry");
+                }
+            })
+            .build();
+
         Self {
-            l1: RwLock::new(HashMap::new()),
+            l1,
             config,
-            stats: RwLock::new(CacheStats::default()),
+            hits: Arc::new(AtomicU64::new(0)),
+            misses: Arc::new(AtomicU64::new(0)),
+            evictions,
         }
     }
 
@@ -107,32 +144,21 @@ impl CacheStore {
     ///
     /// Checks L1 first, then L2. Promotes L2 hits to L1.
     pub fn get(&self, key: &CacheKey) -> Option<CacheEntry> {
-        // Check L1
-        {
-            let l1 = self.l1.read().expect("L1 lock poisoned");
-            if let Some(entry) = l1.get(key) {
-                trace!(%key, "L1 cache hit");
-                let mut stats = self.stats.write().expect("stats lock poisoned");
-                stats.hits += 1;
-                return Some(entry.clone());
-            }
-        }
-
-        // Check L2
-        if let Some(entry) = self.l2_read(key) {
-            trace!(%key, "L2 cache hit, promoting to L1");
-            let mut stats = self.stats.write().expect("stats lock poisoned");
-            stats.hits += 1;
-            drop(stats);
-            // Promote to L1
-            self.l1_insert(entry.clone());
+        if let Some(entry) = self.l1.get(key) {
+            trace!(%key, "L1 cache hit");
+            self.hits.fetch_add(1, Ordering::Relaxed);
             return Some(entry);
         }
 
-        // Miss
+        if let Some(entry) = self.l2_read(key) {
+            trace!(%key, "L2 cache hit, promoting to L1");
+            self.hits.fetch_add(1, Ordering::Relaxed);
+            self.l1.insert(*key, entry.clone());
+            return Some(entry);
+        }
+
         trace!(%key, "cache miss");
-        let mut stats = self.stats.write().expect("stats lock poisoned");
-        stats.misses += 1;
+        self.misses.fetch_add(1, Ordering::Relaxed);
         None
     }
 
@@ -140,68 +166,54 @@ impl CacheStore {
     pub fn put(&self, entry: CacheEntry) {
         debug!(%entry.key, backend = %entry.backend_id, "caching result");
         self.l2_write(&entry);
-        self.l1_insert(entry);
+        self.l1.insert(entry.key, entry);
     }
 
     /// Check if a key exists without retrieving the full entry.
     pub fn contains(&self, key: &CacheKey) -> bool {
-        {
-            let l1 = self.l1.read().expect("L1 lock poisoned");
-            if l1.contains_key(key) {
-                return true;
-            }
+        if self.l1.contains_key(key) {
+            return true;
         }
-        self.l2_path(key)
-            .map(|p| p.exists())
-            .unwrap_or(false)
+        self.l2_path(key).map(|p| p.exists()).unwrap_or(false)
     }
 
-    /// Get cache statistics.
+    /// Get a snapshot of cache statistics.
     pub fn stats(&self) -> CacheStats {
-        let mut stats = self.stats.read().expect("stats lock poisoned").clone();
-        let l1 = self.l1.read().expect("L1 lock poisoned");
-        stats.entries = l1.len();
-        stats
+        // Force any due TTL evictions to materialise so `entries` reflects reality.
+        self.l1.run_pending_tasks();
+        CacheStats {
+            hits: self.hits.load(Ordering::Relaxed),
+            misses: self.misses.load(Ordering::Relaxed),
+            entries: self.l1.entry_count() as usize,
+            evictions: self.evictions.load(Ordering::Relaxed),
+            total_lookup_time_us: 0,
+            lookup_count: 0,
+        }
     }
 
-    /// Remove stale entries from L1. Returns count of evicted entries.
-    pub fn evict_stale(&self, now: u64) -> usize {
-        let mut l1 = self.l1.write().expect("L1 lock poisoned");
-        let before = l1.len();
-        l1.retain(|_, entry| !entry.is_stale(self.config.max_age_seconds, now));
-        let evicted = before - l1.len();
-        if evicted > 0 {
-            debug!(evicted, "evicted stale entries from L1");
-            let mut stats = self.stats.write().expect("stats lock poisoned");
-            stats.evictions += evicted as u64;
+    /// Force any due TTL evictions to materialise. Returns the number of
+    /// L1 entries removed during this call.
+    ///
+    /// Note: with the moka backend, TTL eviction happens passively as the
+    /// cache is touched — there is rarely any reason to call this. The
+    /// `now: u64` parameter is retained only for API compatibility; moka
+    /// uses the system clock and ignores user-supplied timestamps.
+    pub fn evict_stale(&self, _now: u64) -> usize {
+        let before = self.l1.entry_count();
+        self.l1.run_pending_tasks();
+        let after = self.l1.entry_count();
+        let removed = before.saturating_sub(after) as usize;
+        if removed > 0 {
+            debug!(removed, "TTL-evicted stale entries from L1");
         }
-        evicted
+        removed
     }
 
     /// Remove all entries from L1.
     pub fn clear(&self) {
-        let mut l1 = self.l1.write().expect("L1 lock poisoned");
-        l1.clear();
+        self.l1.invalidate_all();
+        self.l1.run_pending_tasks();
         debug!("L1 cache cleared");
-    }
-
-    /// Insert into L1, evicting oldest entry if over capacity.
-    fn l1_insert(&self, entry: CacheEntry) {
-        let mut l1 = self.l1.write().expect("L1 lock poisoned");
-        if self.config.max_l1_entries > 0 && l1.len() >= self.config.max_l1_entries {
-            // Evict the oldest entry (lowest timestamp)
-            if let Some(oldest_key) = l1
-                .iter()
-                .min_by_key(|(_, e)| e.timestamp)
-                .map(|(k, _)| *k)
-            {
-                l1.remove(&oldest_key);
-                let mut stats = self.stats.write().expect("stats lock poisoned");
-                stats.evictions += 1;
-                trace!(%oldest_key, "evicted oldest L1 entry for capacity");
-            }
-        }
-        l1.insert(entry.key, entry);
     }
 
     fn l2_path(&self, key: &CacheKey) -> Option<PathBuf> {
@@ -258,6 +270,7 @@ mod tests {
     use super::*;
     use crate::key::CacheKey;
     use std::collections::{BTreeMap, HashMap};
+    use std::time::Instant;
 
     fn make_entry(key: CacheKey, timestamp: u64) -> CacheEntry {
         let mut counts = HashMap::new();
@@ -308,22 +321,22 @@ mod tests {
     }
 
     #[test]
-    fn evict_stale_removes_old_keeps_fresh() {
+    fn ttl_evicts_after_max_age() {
+        // Short TTL so the test doesn't drag.
         let config = CacheConfig {
-            max_age_seconds: 100,
+            max_age_seconds: 1,
             ..CacheConfig::default()
         };
         let store = CacheStore::new(config);
 
-        let old_key = CacheKey::circuit_only(b"old");
-        let fresh_key = CacheKey::circuit_only(b"fresh");
-        store.put(make_entry(old_key, 100)); // age=200 at now=300
-        store.put(make_entry(fresh_key, 250)); // age=50 at now=300
+        let key = CacheKey::circuit_only(b"will_expire");
+        store.put(make_entry(key, 1));
+        assert!(store.get(&key).is_some());
 
-        let evicted = store.evict_stale(300);
-        assert_eq!(evicted, 1);
-        assert!(store.get(&old_key).is_none());
-        assert!(store.get(&fresh_key).is_some());
+        // moka's TTL is wall-clock based.
+        std::thread::sleep(Duration::from_millis(1_100));
+        store.evict_stale(0); // force run_pending_tasks
+        assert!(store.get(&key).is_none(), "entry should have expired");
     }
 
     #[test]
@@ -335,21 +348,29 @@ mod tests {
         };
         let store = CacheStore::new(config);
 
-        let k1 = CacheKey::circuit_only(b"first");
-        let k2 = CacheKey::circuit_only(b"second");
-        let k3 = CacheKey::circuit_only(b"third");
-
-        store.put(make_entry(k1, 100)); // oldest
-        store.put(make_entry(k2, 200));
-        store.put(make_entry(k3, 300)); // this should evict k1
-
-        // k1 should have been evicted (oldest timestamp)
-        assert!(store.get(&k1).is_none());
-        assert!(store.get(&k2).is_some());
-        assert!(store.get(&k3).is_some());
+        for i in 0..5u8 {
+            store.put(make_entry(CacheKey::circuit_only(&[i]), i as u64 * 100));
+        }
+        // Let moka apply pending evictions.
+        store.evict_stale(0);
 
         let stats = store.stats();
-        assert!(stats.evictions >= 1);
+        // W-TinyLFU is approximate, so we don't assert "exactly cap" — we
+        // assert the cache doesn't grow unbounded and at least some
+        // evictions were observed under pressure.
+        assert!(
+            stats.entries <= config_capacity_after(&store),
+            "entries={} exceeded capacity",
+            stats.entries
+        );
+        assert!(stats.evictions >= 1, "expected at least one eviction");
+    }
+
+    /// Helper: ask the underlying cache what its policy thinks the capacity is.
+    fn config_capacity_after(store: &CacheStore) -> usize {
+        // For moka, the policy may admit slightly more than max_capacity
+        // momentarily; allow a small headroom (4×) to keep the test stable.
+        (store.config.max_l1_entries.max(1)).saturating_mul(4)
     }
 
     #[test]
@@ -414,5 +435,32 @@ mod tests {
         store.clear();
         assert_eq!(store.stats().entries, 0);
         assert!(store.get(&k1).is_none());
+    }
+
+    /// Acceptance criterion for #812: sub-millisecond cache lookups.
+    /// Populates the L1 with 10k entries and measures average lookup time
+    /// across 10k random hits — must be well under 1 ms.
+    #[test]
+    fn lookup_latency_is_sub_millisecond() {
+        let store = CacheStore::new(CacheConfig::default());
+        let mut keys = Vec::with_capacity(10_000);
+        for i in 0..10_000u32 {
+            let key = CacheKey::circuit_only(&i.to_le_bytes());
+            store.put(make_entry(key, i as u64));
+            keys.push(key);
+        }
+
+        let start = Instant::now();
+        for key in &keys {
+            // Use a black-box-like sink to prevent the compiler from
+            // optimising the lookup away.
+            std::hint::black_box(store.get(key));
+        }
+        let elapsed_ns = start.elapsed().as_nanos();
+        let avg_ns = elapsed_ns / keys.len() as u128;
+        assert!(
+            avg_ns < 1_000_000,
+            "avg lookup {avg_ns} ns exceeded 1 ms (1_000_000 ns)"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Removes the two always-zero `CacheStats` fields (`total_lookup_time_us`, `lookup_count`) and the `avg_lookup_time_us()` method that depended on them. Follow-up to #1068.

## Provenance

**Generated by `Qwen3-235B-A22B-Instruct-2507-3bit-DWQ` running locally** on the maintainer's Mac Studio M4 Max via mlx-lm. The model was given the issue body (#1072) plus the full current `store.rs` as context and asked to emit minimal JSON edits.

Run statistics:
- Prompt: 4334 tokens (issue + full 418-line source file)
- Completion: 285 tokens, ~33 s wall clock
- Three edits emitted; all three `find` substrings verified as unambiguous matches in `store.rs` before application

## Verification

| AC | Result |
|---|---|
| 1. Remove `total_lookup_time_us` field | ✅ |
| 2. Remove `lookup_count` field | ✅ |
| 3. Remove `avg_lookup_time_us()` method | ✅ |
| 4. Update `stats()` method (ripple) | ✅ — Qwen correctly identified this without prompting |
| 5. `cargo build -p quasi-cache --release` green | ✅ |
| 6. `cargo test -p quasi-cache --release` green | ✅ 18/18 pass |
| 7. Under ~30 lines net | ✅ −15 lines net |

## Notes

This is the first PR in the QUASI workspace authored by a local-tailnet inference endpoint rather than by a remote API. The B-track post-mortem data (#1072's parent thread) had identified parse_failure and ripple-edit misses as the dominant solver failure modes; this run cleared both.