### PR TITLE
feat(afana/zx-ir): ergonomic API additions — is_empty, spiders(), count_z/x_spiders

### DIFF
--- a/afana/src/zx_ir.rs
+++ b/afana/src/zx_ir.rs
@@ -501,7 +501,6 @@ mod tests {
         assert_eq!(n, vec![b, c]);
     }
 
-<<<<<<< HEAD
     // ── Phase normalization + strict validation ────────────────────────────
 
     #[test]

--- a/afana/src/zx_ir.rs
+++ b/afana/src/zx_ir.rs
@@ -131,6 +131,11 @@ impl ZxGraph {
         &self.spiders[id]
     }
 
+    /// Get an iterator over all spiders in insertion order.
+    pub fn spiders(&self) -> impl Iterator<Item = &Spider> + '_ {
+        self.spiders.iter()
+    }
+
     /// Get all neighbors of a node (via undirected edges).
     pub fn neighbors(&self, id: NodeId) -> Vec<NodeId> {
         let mut result = Vec::new();
@@ -149,9 +154,28 @@ impl ZxGraph {
         self.spiders.len()
     }
 
+    /// Check if the graph has no spiders.
+    ///
+    /// # Returns
+    ///
+    /// `true` if the graph contains zero spiders.
+    pub fn is_empty(&self) -> bool {
+        self.spider_count() == 0
+    }
+
     /// Number of edges in the graph.
     pub fn edge_count(&self) -> usize {
         self.edges.len()
+    }
+
+    /// Returns the number of spiders whose color is `SpiderColor::Z`.
+    pub fn count_z_spiders(&self) -> usize {
+        self.spiders.iter().filter(|s| s.color == SpiderColor::Z).count()
+    }
+
+    /// Returns the number of spiders whose color is `SpiderColor::X`.
+    pub fn count_x_spiders(&self) -> usize {
+        self.spiders.iter().filter(|s| s.color == SpiderColor::X).count()
     }
 
     /// Validate the structural integrity of the graph.
@@ -477,6 +501,7 @@ mod tests {
         assert_eq!(n, vec![b, c]);
     }
 
+<<<<<<< HEAD
     // ── Phase normalization + strict validation ────────────────────────────
 
     #[test]
@@ -620,5 +645,16 @@ mod tests {
         g.add_edge(z1, x);
         g.add_edge(x, z2);
         assert!(g.validate_fully_fused().is_ok());
+    }
+
+    #[test]
+    fn count_z_and_x_spiders() {
+        let mut g = ZxGraph::new();
+        let _z1 = g.add_spider(SpiderColor::Z, 0.0, Some(0));
+        let _z2 = g.add_spider(SpiderColor::Z, 0.0, Some(0));
+        let _x1 = g.add_spider(SpiderColor::X, 0.0, Some(0));
+
+        assert_eq!(g.count_z_spiders(), 2);
+        assert_eq!(g.count_x_spiders(), 1);
     }
 }


### PR DESCRIPTION
## Summary

Adds three small public methods on `ZxGraph` for ergonomic inspection / iteration:

```rust
impl ZxGraph {
    pub fn is_empty(&self) -> bool;
    pub fn spiders(&self) -> impl Iterator<Item = &Spider> + '_;
    pub fn count_z_spiders(&self) -> usize;
    pub fn count_x_spiders(&self) -> usize;
}
```

Plus one unit test (`count_z_and_x_spiders`) added to the existing `#[cfg(test)] mod tests` block.

## Provenance — Qwen3-235B-A22B-Instruct (local, mlx_lm.server)

Authored end-to-end by `Qwen3-235B-A22B-Instruct-2507-3bit-DWQ` running on the maintainer's Mac Studio via the chokepoint client introduced in PR #1074.

| Sub-task | Prompt | Completion | Wall |
|---|---|---|---|
| add `is_empty()` | 2 850 tok | 262 tok | 21.6 s |
| add `spiders()` iterator | 2 944 tok | 256 tok | 20.7 s |
| add `count_z/x_spiders()` + unit test | 2 997 tok | 905 tok | 53.2 s |

Three sequential calls. No panics. Server stayed on the same PID throughout the run (post-stability stack from #1074 applied, including macOS 26.5.1 + daily LaunchAgent recycle).

## Test plan

- [x] `cargo build -p afana --release` green
- [x] `cargo test -p afana --release` — **294 tests pass**, including the new `count_z_and_x_spiders` case

## Notes on the eval that produced this PR

Originally part of a 5-task eval where Qwen also handled `validate_normalized_*` style work but **failed** one task (`freshness_ratio` on `CacheEntry`) by creating a duplicate `mod tests {}` instead of extending the existing one. That failure was the exact inverse pattern to the success here: when the task body says "add to the existing `#[cfg(test)] mod tests` block" (T5 wording, the source of this PR's test), Qwen complies cleanly. When the task is vague about WHERE new code goes, Qwen sometimes creates a sibling. **Issue ACs need to specify location**, not just content.

This is the second PR on the workspace authored by a local-tailnet inference endpoint (after #1073).