### PR TITLE
feat(afana/zx-ir): validate_circuit_emittable() — spider-degree pre-emission gate (closes #782)

### DIFF
--- a/afana/src/zx_ir.rs
+++ b/afana/src/zx_ir.rs
@@ -46,6 +46,9 @@ pub struct Spider {
 /// Validation errors for ZX graphs.
 #[derive(Debug, Error)]
 pub enum ZxValidationError {
+    #[error("ZX_IR_SPIDER_DEGREE_EXCEEDED")]
+    DegreeExceeded,
+
     #[error("invalid edge ({from}, {to}): {reason}")]
     InvalidEdge {
         from: NodeId,
@@ -377,6 +380,32 @@ impl ZxGraph {
             Err(errors)
         }
     }
+
+    /// Strict variant of [`Self::validate`] that additionally enforces the
+    /// max-degree-2 spider constraint required for direct circuit emission.
+    ///
+    /// Use this as the final gate before QASM emission. Internal pre-fusion
+    /// graphs may legitimately contain higher-degree spiders; this method
+    /// is opt-in via the call site.
+    pub fn validate_circuit_emittable(&self) -> Result<(), Vec<ZxValidationError>> {
+        let mut errors = match self.validate() {
+            Ok(()) => Vec::new(),
+            Err(e) => e,
+        };
+
+        for i in 0..self.spiders.len() {
+            let degree = self.neighbors(i).len();
+            if degree > 2 {
+                errors.push(ZxValidationError::DegreeExceeded);
+            }
+        }
+
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
+    }
 }
 
 impl Default for ZxGraph {
@@ -655,5 +684,24 @@ mod tests {
 
         assert_eq!(g.count_z_spiders(), 2);
         assert_eq!(g.count_x_spiders(), 1);
+    }
+
+    #[test]
+    fn zx_ir_spider_degree_validation() {
+        let mut g = ZxGraph::new();
+        let z_spider = g.add_spider(SpiderColor::Z, 0.0, Some(0));
+        let x1 = g.add_spider(SpiderColor::X, 0.0, Some(0));
+        let x2 = g.add_spider(SpiderColor::X, 0.0, Some(0));
+        let x3 = g.add_spider(SpiderColor::X, 0.0, Some(0));
+        g.add_edge(z_spider, x1);
+        g.add_edge(z_spider, x2);
+        g.add_edge(z_spider, x3);
+
+        let result = g.validate_circuit_emittable();
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .iter()
+            .any(|e| matches!(e, ZxValidationError::DegreeExceeded)));
     }
 }


### PR DESCRIPTION
## Summary

Implements the achievable acceptance criterion of #782 and **declines** the unachievable one. New API:

```rust
impl ZxGraph {
    pub fn validate_circuit_emittable(&self) -> Result<(), Vec<ZxValidationError>>;
}

pub enum ZxValidationError {
    // ...
    DegreeExceeded,
}
```

The new method calls the existing permissive `validate()` first, then rejects any spider with degree > 2.

## Acceptance criteria

| AC | Status | Notes |
|---|---|---|
| AC1 — `cargo test zx_ir_spider_degree_validation` passes asserting `DegreeExceeded` for a degree-3 spider | ✅ | new test added inside the existing `#[cfg(test)] mod tests` block |
| AC2 — `cargo run -- validate --fixture *.zx` exits with status 1 and prints `ZX_IR_SPIDER_DEGREE_EXCEEDED` to stderr | **declined** | afana has no `validate` subcommand and there is no `.zx` file format; the AC references infrastructure that does not exist |

## Why the strict-variant pattern (not extending `validate()`)

`afana/src/lower.rs` calls `validate()` on un-optimised intermediate ZX graphs that legitimately contain higher-degree control spiders (multi-target CX ladders, fanout patterns). Adding the degree-2 constraint to `validate()` broke 6 lowering tests in an earlier iteration. This PR follows the existing project convention — `validate_normalized()` and `validate_fully_fused()` are also opt-in strict variants — and adds the new check as a separate opt-in method.

## Provenance — Qwen3-235B-A22B-Instruct (local) + brief hand-merge

Authored by the local Qwen3-235B over the chokepoint client (#1074), with three iterations:

| Pass | Outcome | Lesson |
|---|---|---|
| v1 | Truncated at `max_tokens=4096` because Qwen included entire test-module verbatim in `replace` | bumped to `max_tokens=8192` |
| v2 | Valid JSON but anchored on enum header only → duplicated the entire enum body | added explicit "anchor on last item + closing brace" rule for extend-list edits |
| v3 | Edits compile-clean but the strict check went into `validate()` → broke 6 lowering tests | added explicit project-convention context: strict checks go in opt-in variants |
| v4 | Correct architecturally; produced the right enum variant + method + test, but on the fresh branch the test-mod anchor drifted between calls | hand-merged the missing method addition |

**The most informative finding:** Qwen correctly rejected AC2 in its `reasoning` field on every pass — *"The CLI subcommand `validate` and `.zx` file format do not exist in the current codebase, so the second acceptance criterion cannot be implemented as stated"*. That kind of spec-pushback was conspicuously missing from the senate's smaller-model solvers, which would have fabricated a non-existent CLI subcommand to "satisfy" AC2.

## Test plan

- [x] `cargo build -p afana --release` green
- [x] `cargo test -p afana --release --lib` — **185 tests pass**, including the new `zx_ir_spider_degree_validation`
- [x] Integration tests under `afana/tests/` pass unchanged