### PR TITLE
chore(quasi-demo): drop three unused imports

### DIFF
--- a/quasi-demo/src/kernel_demo.rs
+++ b/quasi-demo/src/kernel_demo.rs
@@ -12,12 +12,9 @@
 //!
 //! The scheduling circuit runs on IBM Strasbourg (or mock).
 
-use std::collections::BTreeMap;
-
 use anyhow::Result;
 use clap::Parser;
 
-use quasi_scheduler::backend::*;
 use quasi_scheduler::profiles;
 use quasi_solvayeur::atw::Solvayeur;
 use quasi_solvayeur::bias::Reward;

--- a/quasi-demo/src/vqe.rs
+++ b/quasi-demo/src/vqe.rs
@@ -17,7 +17,6 @@
 //!   quasi-vqe --max-iter 50 --skip-qpu   # classical-only mode
 
 use std::collections::{BTreeMap, HashMap};
-use std::f64::consts::PI;
 
 use anyhow::{Context, Result};
 use clap::Parser;


### PR DESCRIPTION
## Summary

`cargo build --workspace --release` was emitting three `unused import` warnings in `quasi-demo`. This PR removes those exactly — nothing else.

| File | Removed |
|---|---|
| `quasi-demo/src/kernel_demo.rs` | `use std::collections::BTreeMap;` |
| `quasi-demo/src/kernel_demo.rs` | `use quasi_scheduler::backend::*;` |
| `quasi-demo/src/vqe.rs` | `use std::f64::consts::PI;` |

## Verification

- [x] `cargo build --workspace --release` emits **zero** warnings (was 3)
- [x] `cargo test -p quasi-demo --release` green
- [x] Diff is 4 lines deleted, 0 added — no other changes

## Provenance — Qwen3-235B-A22B-Instruct (local)

Authored by the local Qwen via the chokepoint client (#1074), using the new canonical prompt template that #1074 just landed. Single 35 s call, 2 edits emitted, both anchors verified unique, applied cleanly first try.

Run stats:
- Prompt: 5 016 tokens (full kernel_demo.rs + vqe.rs excerpt)
- Completion: 297 tokens
- Edits: 2, both unambiguous

This is the lightest of the local-Qwen PRs so far and validates that the v3 prompt template handles the multi-file lint-cleanup shape just as cleanly as the validate-method-add shape from #1076.

## Note on unrelated CI

The `quasi-bridge/tests/integration.rs` E0433 failures (refs to removed `quasi_scheduler::backend::*`, `quasi_solvayeur::atw::Solvayeur`, `quasi_bridge::pipeline`, `quasi_cache::*` etc. after the library-only refactor) are pre-existing on `main`. This PR doesn't touch quasi-bridge and doesn't address that.