### PR TITLE
test(afana/error): pin Display output of CborError and EmitError (closes #1081)

### DIFF
--- a/afana/src/error.rs
+++ b/afana/src/error.rs
@@ -39,3 +39,83 @@ pub enum EmitError {
         gate: String,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cbor_decode_renders_message() {
+        let err = CborError::Decode("truncated input".to_string());
+        assert_eq!(err.to_string(), "CBOR decode: truncated input");
+    }
+
+    #[test]
+    fn cbor_schema_renders_message() {
+        let err = CborError::Schema("expected array".to_string());
+        assert_eq!(err.to_string(), "schema violation: expected array");
+    }
+
+    #[test]
+    fn cbor_io_renders_message_and_supports_from_conversion() {
+        let io_err = std::io::Error::other("read failed");
+        let err: CborError = io_err.into();
+        assert_eq!(err.to_string(), "read failed");
+        match err {
+            CborError::Io(_) => {}
+            other => panic!("expected CborError::Io, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cbor_error_debug_names_its_variant() {
+        let err = CborError::Decode("test".to_string());
+        assert_eq!(format!("{err:?}"), r#"Decode("test")"#);
+    }
+
+    #[test]
+    fn unsupported_gate_renders_name() {
+        let err = EmitError::UnsupportedGate("foo".to_string());
+        assert_eq!(err.to_string(), "unsupported gate: foo");
+    }
+
+    #[test]
+    fn qubit_out_of_range_renders_index_and_total() {
+        let err = EmitError::QubitOutOfRange {
+            index: 5,
+            n_qubits: 3,
+        };
+        assert_eq!(err.to_string(), "qubit index 5 out of range (n_qubits=3)");
+    }
+
+    #[test]
+    fn unbound_parameter_renders_with_declared_debug() {
+        let err = EmitError::UnboundParameter {
+            param: "theta".to_string(),
+            gate: "rx".to_string(),
+            declared: vec!["phi".to_string()],
+        };
+        assert_eq!(
+            err.to_string(),
+            "unbound parameter `theta` in variational gate `rx` (declared params: [\"phi\"])"
+        );
+    }
+
+    #[test]
+    fn missing_binding_renders_parameter_and_gate() {
+        let err = EmitError::MissingBinding {
+            param: "theta".to_string(),
+            gate: "rx".to_string(),
+        };
+        assert_eq!(
+            err.to_string(),
+            "missing binding for parameter `theta` in variational gate `rx`"
+        );
+    }
+
+    #[test]
+    fn emit_error_debug_names_its_variant() {
+        let err = EmitError::UnsupportedGate("H".to_string());
+        assert_eq!(format!("{err:?}"), r#"UnsupportedGate("H")"#);
+    }
+}


### PR DESCRIPTION
`afana/src/error.rs` had zero tests. Both enums carry `thiserror` `#[error("...")]` format strings that nothing exercised — a typo or a reworded message would have shipped silently.

## Coverage

`CborError`:
- `Decode`, `Schema` — exact rendered string
- `Io` — exact rendered string, plus confirmation that the `#[from] std::io::Error` conversion actually produces `CborError::Io`

`EmitError`:
- `UnsupportedGate` — exact rendered string
- `QubitOutOfRange` — both `{index}` and `{n_qubits}` interpolate
- `UnboundParameter` — including the `{declared:?}` Debug rendering of `Vec<String>`, asserted against its real output rather than a guess
- `MissingBinding` — exact rendered string

Plus two tests pinning the derived `Debug` rendering of one variant per enum.

Assertions compare full expected literals with `assert_eq!` rather than `.contains()`, so a format-string regression fails the build instead of sliding through.

## Scope

Test-only. Purely additive: 80 insertions, 0 deletions, 1 file. No production code, format strings, or signatures modified; no new dependencies.

## Verification

```
cargo test -p afana --lib   ->  208 passed; 0 failed   (199 before, +9)
cargo clippy -p afana --all-targets -- -D warnings  ->  clean
```