### PR TITLE
test(afana/emit): cover max_cbit_index edge cases (closes #1085)

### DIFF
--- a/afana/src/emit.rs
+++ b/afana/src/emit.rs
@@ -686,4 +686,64 @@ mod tests {
         assert!((val + PI / 2.0).abs() < 1e-10, "-π/2 should stay -π/2, got {val}");
         assert_eq!(format_float(-PI / 2.0), "-pi/2");
     }
+
+    // ── max_cbit_index tests ─────────────────────────────────────────────
+
+    fn ast_with_cbits(measures: Vec<usize>, conditionals: Vec<usize>) -> EhrenfestAst {
+        EhrenfestAst {
+            name: "cbits".into(),
+            n_qubits: 1,
+            prepare: None,
+            gates: Vec::new(),
+            measures: measures
+                .into_iter()
+                .map(|cbit| Measure { qubit: 0, cbit })
+                .collect(),
+            conditionals: conditionals
+                .into_iter()
+                .map(|cbit| ConditionalGate {
+                    cbit,
+                    cbit_value: 1,
+                    gate: Gate {
+                        name: GateName::X,
+                        qubits: vec![0],
+                        params: vec![],
+                    },
+                })
+                .collect(),
+            expects: Vec::new(),
+            type_decls: Vec::new(),
+            variational_loops: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn max_cbit_index_empty() {
+        let ast = ast_with_cbits(Vec::new(), Vec::new());
+        assert_eq!(max_cbit_index(&ast), 0);
+    }
+
+    #[test]
+    fn max_cbit_index_measures_only() {
+        let ast = ast_with_cbits(vec![0, 2, 1], Vec::new());
+        assert_eq!(max_cbit_index(&ast), 3);
+    }
+
+    #[test]
+    fn max_cbit_index_conditionals_only() {
+        let ast = ast_with_cbits(Vec::new(), vec![3, 1]);
+        assert_eq!(max_cbit_index(&ast), 4);
+    }
+
+    #[test]
+    fn max_cbit_index_mixed_measures_max() {
+        let ast = ast_with_cbits(vec![5], vec![2]);
+        assert_eq!(max_cbit_index(&ast), 6);
+    }
+
+    #[test]
+    fn max_cbit_index_mixed_conditionals_max() {
+        let ast = ast_with_cbits(vec![1], vec![4]);
+        assert_eq!(max_cbit_index(&ast), 5);
+    }
 }


### PR DESCRIPTION
`max_cbit_index` (`afana/src/emit.rs:243`) decides whether a `creg` / `bit` declaration is emitted and how large it is, but was only exercised indirectly through the `emit_qasm` tests. A regression in classical-register sizing would have surfaced only as a diff in full QASM output, not as a targeted failure.

Testing private helpers directly is already the pattern in this file — the existing test module calls `format_float()` and `normalize_phase()` directly.

## Tests

Five new tests plus a small `ast_with_cbits` fixture helper:

- `max_cbit_index_empty` — no measures, no conditionals -> 0
- `max_cbit_index_measures_only` — cbits passed deliberately out of order (`[0, 2, 1]`) to prove it takes the maximum rather than the last value
- `max_cbit_index_conditionals_only`
- `max_cbit_index_mixed_measures_max` — maximum on the measures side
- `max_cbit_index_mixed_conditionals_max` — maximum on the conditionals side

## Note on the name

Assertions pin the helper's **actual** behaviour: it returns `max(cbit) + 1` — the register *size*, not the maximum index its name implies. The name is a misnomer but renaming a private helper is out of scope here; flagging it for a follow-up if anyone wants it.

## Scope

Test-only. Purely additive: 60 insertions, 0 deletions, 1 file.

## Verification

```
cargo test -p afana --lib   ->  240 passed; 0 failed   (235 before, +5)
cargo clippy -p afana --all-targets -- -D warnings  ->  clean
```