### PR TITLE
test(afana/sword_ingest): cover stable-only edge constant_offset (closes #1086)

### DIFF
--- a/afana/src/sword_ingest.rs
+++ b/afana/src/sword_ingest.rs
@@ -342,6 +342,34 @@ mod tests {
         })
     }
 
+    fn sword_with_stable_only_edge() -> Value {
+        let mut sword = minimal_sword();
+        sword["partition"]["graph"]["nodes"]
+            .as_array_mut()
+            .unwrap()
+            .push(json!({"id": 3, "h_i": 0.0, "omega": 1.0}));
+        sword["partition"]["graph"]["nodes"]
+            .as_array_mut()
+            .unwrap()
+            .push(json!({"id": 4, "h_i": 0.0, "omega": 1.0}));
+        let stable_edge = json!({
+            "i": 3,
+            "j": 4,
+            "j_ij": 0.4,
+            "sin_c_half": 0.1,
+            "classification": "stable"
+        });
+        sword["partition"]["graph"]["edges"]
+            .as_array_mut()
+            .unwrap()
+            .push(stable_edge);
+        sword["partition"]["stable_edges"]
+            .as_array_mut()
+            .unwrap()
+            .push(json!({"i": 3, "j": 4, "j_ij": 0.4}));
+        sword
+    }
+
     #[test]
     fn converts_minimal_sword_to_ehrenfest() {
         let sword = minimal_sword();
@@ -409,6 +437,16 @@ mod tests {
             .collect();
 
         assert!(!boundary_terms.is_empty(), "expected boundary mean-field Z term");
+    }
+
+    #[test]
+    fn stable_only_edge_adds_constant_offset() {
+        // Edge (3,4) has both endpoints outside the volatile island [0,1].
+        // Its coupling should be folded into the Hamiltonian constant offset.
+        let sword = sword_with_stable_only_edge();
+        let program = sword_to_ehrenfest(&sword).unwrap();
+
+        assert!((program.hamiltonian.constant_offset - 0.4).abs() < 1e-10);
     }
 
     #[test]


### PR DESCRIPTION
`sword_to_ehrenfest` folds an edge whose **both** endpoints are non-volatile into `Hamiltonian::constant_offset` — both spins are pinned, so their coupling is a constant. That branch had no test coverage.

The existing `minimal_sword()` fixture could not reach it: its only `stable_edges` entry is `{i: 1, j: 2}`, and node 1 sits inside a volatile island, so that edge takes the boundary mean-field path instead (already covered by `boundary_edge_becomes_mean_field_z`).

## The test

A new `sword_with_stable_only_edge()` helper extends the existing fixture with nodes 3 and 4 — both outside every volatile island — plus a stable edge between them carrying `j_ij = 0.4`.

The volatile island `[0, 1]` is deliberately retained: `sword_to_ehrenfest` bails with *"SWORD volatile islands produced no Hamiltonian terms"* if the term list ends up empty, so a document made only of stable nodes would error rather than return a zero-term program.

Only edge `(3, 4)` qualifies for the stable-only branch — edge `(1, 2)` still takes the mean-field path and contributes a term, not an offset — so the expected `constant_offset` is exactly `0.4`, asserted within `1e-10`.

## Mutation-verified

Temporarily disabling `constant_offset += j_ij_val` in the production branch makes this test **fail**:

```
failures:
    sword_ingest::tests::stable_only_edge_adds_constant_offset
test result: FAILED. 0 passed; 1 failed
```

So the test pins the branch rather than passing incidentally. The mutation was reverted; the diff here is test-only.

## Scope

Purely additive: 38 insertions, 0 deletions, 1 file. Existing `minimal_sword()` left unmodified so tests already using it are unaffected.

## Verification

```
cargo test -p afana --lib   ->  236 passed; 0 failed   (235 before, +1)
cargo clippy -p afana --all-targets -- -D warnings  ->  clean
```