### PR TITLE
docs(afana): fix all broken intra-doc links (closes #1080)

### DIFF
--- a/afana/src/ast.rs
+++ b/afana/src/ast.rs
@@ -103,7 +103,7 @@ impl GateName {
     /// non-Clifford angles.
     ///
     /// For parametric gates (Rx, Ry, Rz), this returns `false` since
-    /// the Clifford-ness depends on the angle. Use [`is_clifford_rotation`]
+    /// the Clifford-ness depends on the angle. Use [`is_clifford_angle`]
     /// to check a specific rotation angle.
     pub fn is_clifford(&self) -> bool {
         matches!(

--- a/afana/src/cbor.rs
+++ b/afana/src/cbor.rs
@@ -7,7 +7,8 @@
 //! structs that represent the Hamiltonian, observables, and noise constraints.
 //!
 //! These structs are the input to Afana's Trotterization pass, which derives
-//! a gate sequence and produces an [`EhrenfestAst`] for QASM emission.
+//! a gate sequence and produces an [`EhrenfestAst`](crate::ast::EhrenfestAst)
+//! for QASM emission.
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 

--- a/afana/src/trotter.rs
+++ b/afana/src/trotter.rs
@@ -156,8 +156,8 @@ pub fn validate_hamiltonian(program: &EhrenfestProgram) -> Result<(), TrotterErr
 /// Estimate the Trotter approximation error bound.
 ///
 /// For a Hamiltonian H = Σ Hₖ with L terms, the error per step is:
-/// - First-order:  ε ≤ L² · max|[Hⱼ,Hₖ]| · dt² / 2
-/// - Second-order: ε ≤ L³ · max|[[Hⱼ,Hₖ],Hₗ]| · dt³ / 12
+/// - First-order:  ε ≤ L² · max|\[Hⱼ,Hₖ\]| · dt² / 2
+/// - Second-order: ε ≤ L³ · max|\[\[Hⱼ,Hₖ\],Hₗ\]| · dt³ / 12
 /// - Fourth-order: ε ≤ C · L⁵ · ||H||⁵ · dt⁵
 ///
 /// We use the simplified bound based on the sum of absolute coefficients

--- a/afana/src/zx_ir.rs
+++ b/afana/src/zx_ir.rs
@@ -4,7 +4,7 @@
 //!
 //! A proper ZX calculus graph representation where quantum gates are
 //! decomposed into Z- and X-spiders connected by edges. This IR sits
-//! between the gate-level [`EhrenfestAst`] and future ZX-based
+//! between the gate-level [`EhrenfestAst`](crate::ast::EhrenfestAst) and future ZX-based
 //! optimization / extraction passes.
 //!
 //! Each qubit is a "wire" through the graph: an input boundary node,


### PR DESCRIPTION
`cargo doc -p afana --no-deps` emitted **five** `broken_intra_doc_links` warnings. All five are fixed; the crate now documents with **zero** warnings.

| File | Broken link | Fix |
|---|---|---|
| `ast.rs:106` | `[`is_clifford_rotation`]` — does not exist | -> `is_clifford_angle`, the real helper |
| `cbor.rs:10` | `[`EhrenfestAst`]` — not in scope | linked by path `crate::ast::EhrenfestAst` |
| `zx_ir.rs:7` | `[`EhrenfestAst`]` — not in scope | linked by path `crate::ast::EhrenfestAst` |
| `trotter.rs:159` | `max\|[Hⱼ,Hₖ]\|` parsed as a link | brackets escaped |
| `trotter.rs:160` | `max\|[[Hⱼ,Hₖ],Hₗ]\|` parsed as a link | brackets escaped |

The two `EhrenfestAst` references were silently rendering as plain text instead of links; they now resolve. The `trotter.rs` commutator notation renders visually identically — escaping only stops rustdoc from treating it as link syntax.

## Scope note

Issue #1080 covered only the `is_clifford_rotation` item. The other four surfaced when I ran `cargo doc` to verify that fix. I included them rather than leave known-broken links behind, since they are the same class of defect and the combined change is still doc-comments-only.

## Verification

```
cargo doc -p afana --no-deps  ->  0 warnings (was 5)
cargo test -p afana --lib     ->  250 passed; 0 failed
cargo clippy -p afana --all-targets -- -D warnings  ->  clean
```

Doc comments only — no code, signatures, or behaviour changed. 6 insertions, 5 deletions across 4 files.