### PR TITLE
test(afana): pin Display output for four public types (closes #1090)

### DIFF
--- a/afana/src/lower.rs
+++ b/afana/src/lower.rs
@@ -533,4 +533,25 @@ mod tests {
         assert!(zx.spider_count() > 6); // at least inputs + outputs
         assert!(zx.edge_count() > 3);
     }
+
+    // ── Display rendering tests ───────────────────────────────────────────
+
+    #[test]
+    fn unsupported_gate_renders_name() {
+        let err = LowerError::UnsupportedGate("ccx".to_string());
+        assert_eq!(err.to_string(), "unsupported gate: ccx");
+    }
+
+    #[test]
+    fn qubit_out_of_range_renders_index_gate_and_total() {
+        let err = LowerError::QubitOutOfRange {
+            gate: "h".to_string(),
+            index: 5,
+            n_qubits: 2,
+        };
+        assert_eq!(
+            err.to_string(),
+            "qubit index 5 out of range in gate `h` (n_qubits=2)"
+        );
+    }
 }

--- a/afana/src/trotter.rs
+++ b/afana/src/trotter.rs
@@ -914,4 +914,58 @@ mod tests {
         assert!(!report.fidelity_ok);
         assert!(report.warnings.iter().any(|w| w.contains("fidelity")));
     }
+
+    // ── Display rendering tests ───────────────────────────────────────────
+
+    #[test]
+    fn empty_hamiltonian_renders_message() {
+        let err = TrotterError::EmptyHamiltonian;
+        assert_eq!(
+            err.to_string(),
+            "empty Hamiltonian: at least one Pauli term is required"
+        );
+    }
+
+    #[test]
+    fn non_finite_coefficient_renders_term_and_coefficient() {
+        let err = TrotterError::NonFiniteCoefficient {
+            term_index: 7,
+            coefficient: f64::NAN,
+        };
+        assert_eq!(
+            err.to_string(),
+            "non-finite coefficient NaN in Hamiltonian term 7"
+        );
+    }
+
+    #[test]
+    fn qubit_out_of_range_renders_indices() {
+        let err = TrotterError::QubitOutOfRange {
+            term_index: 2,
+            qubit: 9,
+            n_qubits: 4,
+        };
+        assert_eq!(
+            err.to_string(),
+            "qubit index 9 in Hamiltonian term 2 out of range (n_qubits=4)"
+        );
+    }
+
+    #[test]
+    fn non_finite_evolution_renders_parameters() {
+        let err = TrotterError::NonFiniteEvolution {
+            dt_us: f64::INFINITY,
+            total_us: f64::NAN,
+        };
+        assert_eq!(
+            err.to_string(),
+            "non-finite evolution parameter: dt_us=inf, total_us=NaN"
+        );
+    }
+
+    #[test]
+    fn zero_steps_renders_message() {
+        let err = TrotterError::ZeroSteps;
+        assert_eq!(err.to_string(), "zero Trotter steps");
+    }
 }

--- a/afana/src/type_check.rs
+++ b/afana/src/type_check.rs
@@ -1039,4 +1039,57 @@ mod tests {
             errors
         );
     }
+
+    // ── Display rendering tests ───────────────────────────────────────────
+
+    #[test]
+    fn qubit_type_renders_name() {
+        assert_eq!(EhrenfestType::Qubit.to_string(), "qubit");
+    }
+
+    #[test]
+    fn classical_int_renders_name() {
+        assert_eq!(EhrenfestType::ClassicalInt.to_string(), "int");
+    }
+
+    #[test]
+    fn classical_float_renders_name() {
+        assert_eq!(EhrenfestType::ClassicalFloat.to_string(), "float");
+    }
+
+    #[test]
+    fn classical_bool_renders_name() {
+        assert_eq!(EhrenfestType::ClassicalBool.to_string(), "bool");
+    }
+
+    #[test]
+    fn hamiltonian_type_renders_name() {
+        assert_eq!(EhrenfestType::Hamiltonian.to_string(), "hamiltonian");
+    }
+
+    #[test]
+    fn observable_type_renders_name() {
+        assert_eq!(EhrenfestType::Observable.to_string(), "observable");
+    }
+
+    #[test]
+    fn noise_constraint_type_renders_name() {
+        assert_eq!(
+            EhrenfestType::NoiseConstraint.to_string(),
+            "noise_constraint"
+        );
+    }
+
+    #[test]
+    fn variational_parameter_type_renders_name() {
+        assert_eq!(
+            EhrenfestType::VariationalParameter.to_string(),
+            "variational_parameter"
+        );
+    }
+
+    #[test]
+    fn unknown_type_renders_name() {
+        assert_eq!(EhrenfestType::Unknown.to_string(), "unknown");
+    }
 }

--- a/afana/src/zx_ir.rs
+++ b/afana/src/zx_ir.rs
@@ -828,4 +828,89 @@ mod tests {
         assert_eq!(g.edges(), &[(a, b), (a, b)]);
         assert_eq!(g.edge_count(), 2);
     }
+
+    // ── Display rendering tests ───────────────────────────────────────────
+
+    #[test]
+    fn degree_exceeded_renders_code() {
+        let err = ZxValidationError::DegreeExceeded;
+        assert_eq!(err.to_string(), "ZX_IR_SPIDER_DEGREE_EXCEEDED");
+    }
+
+    #[test]
+    fn invalid_edge_renders_endpoints_and_reason() {
+        let err = ZxValidationError::InvalidEdge {
+            from: 1,
+            to: 99,
+            reason: "endpoint out of range".to_string(),
+        };
+        assert_eq!(
+            err.to_string(),
+            "invalid edge (1, 99): endpoint out of range"
+        );
+    }
+
+    #[test]
+    fn invalid_phase_renders_node_and_phase() {
+        let err = ZxValidationError::InvalidPhase {
+            node: 3,
+            phase: f64::NAN,
+        };
+        assert_eq!(
+            err.to_string(),
+            "invalid phase at node 3: NaN is not finite"
+        );
+    }
+
+    #[test]
+    fn phase_out_of_range_renders_node_and_phase() {
+        let err = ZxValidationError::PhaseOutOfRange {
+            node: 4,
+            phase: -0.5,
+        };
+        assert_eq!(
+            err.to_string(),
+            "phase out of range at node 4: -0.5 not in [0, 2) (multiples of π)"
+        );
+    }
+
+    #[test]
+    fn unfused_adjacent_spiders_renders_nodes_and_qubit() {
+        let err = ZxValidationError::UnfusedAdjacentSpiders {
+            a: 2,
+            b: 5,
+            qubit: 7,
+        };
+        assert_eq!(
+            err.to_string(),
+            "nodes 2 and 5 are an unfused same-color pair on qubit 7"
+        );
+    }
+
+    #[test]
+    fn invalid_boundary_renders_node_and_reason() {
+        let err = ZxValidationError::InvalidBoundary {
+            node: 8,
+            reason: "output node out of range".to_string(),
+        };
+        assert_eq!(
+            err.to_string(),
+            "invalid boundary node 8: output node out of range"
+        );
+    }
+
+    #[test]
+    fn structural_error_renders_message() {
+        let err = ZxValidationError::StructuralError("cycle".to_string());
+        assert_eq!(err.to_string(), "structural error: cycle");
+    }
+
+    #[test]
+    fn disconnected_graph_renders_unvisited_count() {
+        let err = ZxValidationError::DisconnectedGraph { unvisited: 3 };
+        assert_eq!(
+            err.to_string(),
+            "graph is disconnected: 3 nodes unreachable"
+        );
+    }
 }


### PR DESCRIPTION
`TrotterError`, `LowerError`, `ZxValidationError` and `EhrenfestType` all implement `Display`, and **none** had any coverage of the rendered text — verified: no `.to_string()` or `format!("{}")` assertions existed in any of their test modules. A typo or a reworded message would have shipped silently.

Follows the approach merged for `CborError` / `EmitError` in #1084.

| File | Type | Variants covered |
|---|---|---|
| `trotter.rs` | `TrotterError` | all 5 |
| `lower.rs` | `LowerError` | both |
| `zx_ir.rs` | `ZxValidationError` | all 8 |
| `type_check.rs` | `EhrenfestType` | all 9 |

## Assertion quality

- Every assertion compares a **full expected literal** with `assert_eq!`. No `.contains()` — that would let a format-string regression slip through.
- Variants with multiple numeric fields use **distinct** values (e.g. `InvalidEdge { from: 1, to: 99 }`, `UnfusedAdjacentSpiders { a: 2, b: 5, qubit: 7 }`) so a field-ordering mistake is visible rather than silently symmetric.
- `InvalidPhase` is exercised with `f64::NAN`.

## Why one PR across four files

The change is mechanical and identical in shape in each file. One pass reviews faster than four near-identical PRs. Test-only — no production code, format strings, or signatures modified.

## Verification

```
cargo test -p afana --lib   ->  274 passed; 0 failed   (250 before, +24)
cargo clippy -p afana --all-targets -- -D warnings  ->  clean
```