### PR TITLE
feat(senate): fail over from local model to cloud roster when host is down

### DIFF
--- a/quasi-senate/rotation.toml
+++ b/quasi-senate/rotation.toml
@@ -393,3 +393,22 @@ provider = "cerebras"
 license = "Apache-2.0"
 origin = "China / Alibaba"
 roles = ["a2_drafter", "b1_solver"]
+
+# ── Self-hosted local model ───────────────────────────────────────────────────
+# Qwen3-235B on a Mac Studio (mlx-lm), reachable over Tailscale. Zero marginal
+# cost (cost_tier = 0) so it is preferred whenever it is up — but it is paused
+# whenever its owner needs the RAM. The availability probe (src/availability.rs)
+# checks the endpoint before selection and removes this entry automatically
+# when the host is down; the roster then falls back to the cloud models above
+# with no config change.
+# NOTE: OLLAMA_URL must point at the tailnet IP (not the MagicDNS hostname)
+# because the deployment host has no MagicDNS — hostname resolution fails there.
+
+[[rotation]]
+id = "qwen3-235b-local"
+model = "mlx-community/Qwen3-235B-A22B-Instruct-2507-3bit-DWQ"
+provider = "ollama"
+license = "Apache-2.0"
+origin = "Local / Mac Studio"
+roles = ["a2_drafter", "b1_solver"]
+cost_tier = 0

--- a/quasi-senate/src/availability.rs
+++ b/quasi-senate/src/availability.rs
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright 2026 QUASI Contributors
+//! Runtime availability tracking for self-hosted providers.
+//!
+//! Cloud providers are considered live whenever their API key is present
+//! (see `rotation::provider_has_key`) — we never probe them, to avoid
+//! wasting quota. Self-hosted providers (those with `Provider::url_env_var`,
+//! e.g. Ollama on a tailnet) are probed with a cheap TCP connect and the
+//! result is cached for `CACHE_TTL` so `pick_model` is not probing on
+//! every call.
+
+use std::collections::HashMap;
+use std::net::{IpAddr, SocketAddr, TcpStream, ToSocketAddrs};
+use std::sync::{Mutex, MutexGuard, OnceLock};
+use std::time::{Duration, Instant};
+
+use crate::config::get_provider;
+
+/// How long a probe result (or a forced-down mark) stays valid.
+const CACHE_TTL: Duration = Duration::from_secs(60);
+
+/// Timeout for a single TCP connect attempt.
+const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+
+static CACHE: OnceLock<Mutex<HashMap<String, (Instant, bool)>>> = OnceLock::new();
+
+fn lock_cache() -> MutexGuard<'static, HashMap<String, (Instant, bool)>> {
+    CACHE
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+}
+
+/// Is this provider currently usable? Cached.
+///
+/// Providers without a `url_env_var` (ordinary cloud providers) always
+/// return `true` without any network traffic — key presence is already
+/// handled by `rotation::provider_has_key`. Providers with a `url_env_var`
+/// are probed at most once per `CACHE_TTL`.
+pub fn is_provider_live(provider_id: &str) -> bool {
+    let provider = match get_provider(provider_id) {
+        Some(p) => p,
+        // Unknown providers are rejected by `provider_has_key`; nothing to probe.
+        None => return true,
+    };
+    let url_var = match provider.url_env_var {
+        Some(v) => v,
+        // Ordinary cloud provider: never probed.
+        None => return true,
+    };
+
+    let url = std::env::var(url_var).unwrap_or_default();
+    if url.trim().is_empty() {
+        return false;
+    }
+
+    {
+        let cache = lock_cache();
+        if let Some((at, live)) = cache.get(provider_id) {
+            if at.elapsed() < CACHE_TTL {
+                return *live;
+            }
+        }
+    }
+
+    let live = probe(&url);
+    lock_cache().insert(provider_id.to_string(), (Instant::now(), live));
+    live
+}
+
+/// Record that a provider just failed at the connection level.
+///
+/// Forces the provider's cache entry to `false` for `CACHE_TTL`, so a
+/// mid-flight transport failure immediately takes it out of selection
+/// instead of waiting for the previous probe to expire. No-op for cloud
+/// providers, which are always reported live.
+pub fn mark_provider_down(provider_id: &str) {
+    if let Some(p) = get_provider(provider_id) {
+        if p.url_env_var.is_some() {
+            lock_cache().insert(provider_id.to_string(), (Instant::now(), false));
+        }
+    }
+}
+
+/// Cheap liveness probe for a self-hosted endpoint: a plain TCP connect to
+/// the host:port parsed out of the configured URL.
+///
+/// We deliberately use a blocking TCP connect instead of an async HTTP GET
+/// on `/v1/models`: it needs no TLS handshake and works from the synchronous
+/// `pick_model` path, where availability is consulted. The cost is bounded —
+/// at most `PROBE_TIMEOUT` per resolved address, at most once per `CACHE_TTL`
+/// per provider. Because `pick_model` is called from async contexts, the
+/// connect is wrapped in `tokio::task::block_in_place` when a multi-thread
+/// runtime is active, so the worker thread stays available for other tasks.
+fn probe(url: &str) -> bool {
+    match tokio::runtime::Handle::try_current() {
+        Ok(handle)
+            if matches!(
+                handle.runtime_flavor(),
+                tokio::runtime::RuntimeFlavor::MultiThread
+            ) =>
+        {
+            tokio::task::block_in_place(|| tcp_probe(url))
+        }
+        _ => tcp_probe(url),
+    }
+}
+
+fn tcp_probe(url: &str) -> bool {
+    let (host, port) = match split_host_port(url) {
+        Some(hp) => hp,
+        None => return false,
+    };
+
+    // Fast path: numeric IP literals need no DNS lookup (the deployment host
+    // has no MagicDNS, so the URL must use the tailnet IP anyway).
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        return TcpStream::connect_timeout(&SocketAddr::new(ip, port), PROBE_TIMEOUT).is_ok();
+    }
+
+    // Hostnames: resolve (this may block on DNS) and try each address.
+    match (host, port).to_socket_addrs() {
+        Ok(addrs) => addrs
+            .into_iter()
+            .any(|addr| TcpStream::connect_timeout(&addr, PROBE_TIMEOUT).is_ok()),
+        Err(_) => false,
+    }
+}
+
+/// Extract `(host, port)` from a URL like
+/// `http://100.64.0.1:11434/v1/chat/completions`. Defaults to port 443 for
+/// `https://` URLs and 80 otherwise. IPv6 literals are not supported.
+fn split_host_port(url: &str) -> Option<(&str, u16)> {
+    let (scheme, rest) = match url.split_once("://") {
+        Some((s, r)) => (Some(s), r),
+        None => (None, url),
+    };
+    let authority = rest.split('/').next().unwrap_or("");
+    // Strip any userinfo.
+    let authority = authority.rsplit('@').next().unwrap_or(authority);
+    if authority.is_empty() {
+        return None;
+    }
+    let default_port: u16 = match scheme {
+        Some("https") => 443,
+        _ => 80,
+    };
+    match authority.rsplit_once(':') {
+        Some((host, port)) if !host.is_empty() => Some((host, port.parse::<u16>().ok()?)),
+        _ => Some((authority, default_port)),
+    }
+}
+
+/// Serializes tests that mutate the shared availability cache and `OLLAMA_URL`.
+#[cfg(test)]
+pub(crate) static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+/// Test-only: force a provider's cache entry to "live" so selection tests
+/// do not depend on a real endpoint being reachable.
+#[cfg(test)]
+pub(crate) fn force_provider_live(provider_id: &str) {
+    lock_cache().insert(provider_id.to_string(), (Instant::now(), true));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cloud_provider_is_live_without_probe() {
+        // No API key, no URL configured, nothing listening — a provider with
+        // no `url_env_var` must report live without any probing.
+        assert!(is_provider_live("groq"));
+    }
+
+    #[test]
+    fn unknown_provider_is_live() {
+        // Rejected upstream by `provider_has_key`; availability must not
+        // additionally block it.
+        assert!(is_provider_live("no-such-provider"));
+    }
+
+    #[test]
+    fn mark_provider_down_makes_provider_not_live() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::set_var("OLLAMA_URL", "http://127.0.0.1:1/v1/chat/completions");
+        mark_provider_down("ollama");
+        assert!(!is_provider_live("ollama"));
+    }
+
+    #[test]
+    fn mark_provider_down_ignores_cloud_providers() {
+        // Cloud providers are never probed, so marking them down is a no-op.
+        mark_provider_down("groq");
+        assert!(is_provider_live("groq"));
+    }
+
+    #[test]
+    fn split_host_port_parses_urls() {
+        assert_eq!(
+            split_host_port("http://100.64.0.1:11434/v1/chat/completions"),
+            Some(("100.64.0.1", 11434))
+        );
+        assert_eq!(split_host_port("https://example.com/v1"), Some(("example.com", 443)));
+        assert_eq!(split_host_port("http://example.com"), Some(("example.com", 80)));
+        assert_eq!(split_host_port(""), None);
+    }
+}

--- a/quasi-senate/src/lib.rs
+++ b/quasi-senate/src/lib.rs
@@ -2,6 +2,7 @@
 // Copyright 2026 QUASI Contributors
 //! `quasi-senate` library root — re-exports all public modules for integration tests.
 
+pub mod availability;
 pub mod config;
 pub mod council;
 pub mod health_check;

--- a/quasi-senate/src/provider.rs
+++ b/quasi-senate/src/provider.rs
@@ -256,13 +256,22 @@ pub async fn call_model_with_format(
                 "Calling LLM"
             );
 
-            let response = client
+            let response = match client
                 .post(&url)
                 .headers(headers)
                 .body(request_json)
                 .send()
                 .await
-                .context("HTTP request failed")?;
+            {
+                Ok(r) => r,
+                Err(e) => {
+                    // Transport-level failure (connect refused, DNS, TLS,
+                    // timeout): take the provider out of selection so the
+                    // next `pick_model` fails over to another provider.
+                    crate::availability::mark_provider_down(&entry.provider);
+                    return Err(e).context("HTTP request failed");
+                }
+            };
 
             let status = response.status();
 
@@ -312,7 +321,7 @@ pub async fn call_model_with_format(
             let json: Value =
                 serde_json::from_str(&body_text).context("Provider response is not valid JSON")?;
 
-            let content = json
+            let content = strip_stop_token(json
                 .pointer("/choices/0/message/content")
                 .and_then(|v| v.as_str())
                 .ok_or_else(|| {
@@ -320,8 +329,7 @@ pub async fn call_model_with_format(
                         "Provider response missing choices[0].message.content: {}",
                         &body_text[..body_text.len().min(400)]
                     )
-                })?
-                .to_string();
+                })?);
 
             let status_code = status.as_u16();
 
@@ -387,6 +395,19 @@ pub async fn call_model_with_format(
         served_model,
         input_len,
     })
+}
+
+// ── Stop-token cleanup ───────────────────────────────────────────────────────
+
+/// Strip a trailing `<|im_end|>` stop token (plus any whitespace it leaves
+/// behind) from model output. Some local mlx-lm builds do not strip the token
+/// from `content`. Applied for all providers; a no-op when the token is absent.
+fn strip_stop_token(content: &str) -> String {
+    const TOKEN: &str = "<|im_end|>";
+    match content.trim_end().strip_suffix(TOKEN) {
+        Some(s) => s.trim().to_string(),
+        None => content.to_string(),
+    }
 }
 
 // ── JSON repair ───────────────────────────────────────────────────────────────
@@ -654,5 +675,28 @@ mod tests {
         assert!(fixed.contains("\\n"));
         // Outside of strings, real newlines should be preserved.
         assert!(!fixed.contains("\n") || fixed.find("\\n").is_some());
+    }
+
+    #[test]
+    fn strip_stop_token_removes_trailing_im_end() {
+        assert_eq!(
+            strip_stop_token("{\"key\": \"hi\"}<|im_end|>"),
+            "{\"key\": \"hi\"}"
+        );
+        // Whitespace before/after the token is cleaned up too.
+        assert_eq!(strip_stop_token("hello world  <|im_end|>\n"), "hello world");
+        assert_eq!(strip_stop_token("  padded <|im_end|>  "), "padded");
+    }
+
+    #[test]
+    fn strip_stop_token_leaves_other_content_untouched() {
+        assert_eq!(strip_stop_token("no token here"), "no token here");
+        // Only a trailing token is stripped.
+        assert_eq!(
+            strip_stop_token("<|im_end|> at the start stays"),
+            "<|im_end|> at the start stays"
+        );
+        // Trailing whitespace is preserved when there is no token.
+        assert_eq!(strip_stop_token("trailing space "), "trailing space ");
     }
 }

--- a/quasi-senate/src/rotation.rs
+++ b/quasi-senate/src/rotation.rs
@@ -38,21 +38,32 @@ pub fn provider_has_key(provider_id: &str) -> bool {
     true
 }
 
-/// Return all `RotationEntry` items whose provider's API key is available
-/// and which support the given `role`.
+/// Return all `RotationEntry` items which support the given `role`, whose
+/// provider's API key is available, and whose provider is currently live
+/// (self-hosted endpoints are probed; see `availability`).
 pub fn eligible_for_role(role: &Role) -> Vec<&'static RotationEntry> {
-    rotation()
+    eligible_from(rotation(), role)
+}
+
+fn eligible_from<'a>(entries: &'a [RotationEntry], role: &Role) -> Vec<&'a RotationEntry> {
+    entries
         .iter()
-        .filter(|e| !e.quarantined && e.roles.contains(role) && provider_has_key(&e.provider))
+        .filter(|e| {
+            !e.quarantined
+                && e.roles.contains(role)
+                && provider_has_key(&e.provider)
+                && crate::availability::is_provider_live(&e.provider)
+        })
         .collect()
 }
 
 /// Pick the next model for a given role, respecting:
 /// 1. The model must support the requested role.
-/// 2. The model's provider must have its API key configured.
+/// 2. The model's provider must have its API key configured and be live.
 /// 3. The model must not appear in `exclude` (anti-collusion).
-/// 4. Prefer the model with fewest assignments for this role (fair rotation).
-/// 5. De-prioritise the provider used in the last call (load spreading).
+/// 4. Prefer the lowest cost tier (free self-hosted models first).
+/// 5. Prefer the model with fewest assignments for this role (fair rotation).
+/// 6. De-prioritise the provider used in the last call (load spreading).
 ///
 /// On success returns a `&'static RotationEntry`.
 pub fn pick_model(
@@ -61,8 +72,18 @@ pub fn pick_model(
     counts: &HashMap<String, u32>,
     last_provider: Option<&str>,
 ) -> Result<&'static RotationEntry> {
+    pick_from(rotation(), role, exclude, counts, last_provider)
+}
+
+fn pick_from<'a>(
+    entries: &'a [RotationEntry],
+    role: &Role,
+    exclude: &[&str],
+    counts: &HashMap<String, u32>,
+    last_provider: Option<&str>,
+) -> Result<&'a RotationEntry> {
     // Step 1: get all eligible candidates for this role.
-    let candidates: Vec<&'static RotationEntry> = eligible_for_role(role)
+    let candidates: Vec<&RotationEntry> = eligible_from(entries, role)
         .into_iter()
         .filter(|e| !exclude.contains(&e.id.as_str()))
         .collect();
@@ -73,18 +94,82 @@ pub fn pick_model(
         ));
     }
 
-    // Step 2: sort by (count, same_provider_penalty, rotation_index).
-    let rotation_index = |id: &str| -> usize {
-        rotation().iter().position(|e| e.id == id).unwrap_or(usize::MAX)
-    };
+    // Step 2: sort by (cost_tier, count, same_provider_penalty, rotation_index).
+    // Cost tier dominates: a live free model is always preferred, while the
+    // existing fairness/diversity behaviour applies within a tier.
+    let rotation_index =
+        |id: &str| -> usize { entries.iter().position(|e| e.id == id).unwrap_or(usize::MAX) };
 
     let mut sorted = candidates;
     sorted.sort_by_key(|e| {
         let count = counts.get(&e.id).copied().unwrap_or(0);
         let penalty: u32 = if last_provider == Some(e.provider.as_str()) { 1 } else { 0 };
         let idx = rotation_index(&e.id);
-        (count, penalty, idx)
+        (e.cost_tier, count, penalty, idx)
     });
 
     Ok(sorted[0])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_entry(id: &str, provider: &str, cost_tier: u8) -> RotationEntry {
+        RotationEntry {
+            id: id.to_string(),
+            model: format!("{id}-model"),
+            provider: provider.to_string(),
+            license: "test".to_string(),
+            origin: "test".to_string(),
+            roles: vec![Role::B1Solver],
+            quarantined: false,
+            max_tokens: None,
+            max_context: None,
+            cost_tier,
+        }
+    }
+
+    fn setup_env() {
+        // Port 1 is never listening; the actual probe result is overridden
+        // via the availability cache in each test.
+        std::env::set_var("OLLAMA_URL", "http://127.0.0.1:1/v1/chat/completions");
+        std::env::set_var("GROQ_API_KEY", "test-key");
+    }
+
+    #[test]
+    fn pick_prefers_free_tier_when_local_live() {
+        let _guard = crate::availability::TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        setup_env();
+        crate::availability::force_provider_live("ollama");
+
+        let entries = vec![
+            test_entry("paid-model", "groq", 1),
+            test_entry("free-model", "ollama", 0),
+        ];
+        let counts: HashMap<String, u32> = HashMap::new();
+        let picked = pick_from(&entries, &Role::B1Solver, &[], &counts, None)
+            .expect("a model should be eligible");
+        assert_eq!(picked.id, "free-model");
+    }
+
+    #[test]
+    fn pick_falls_back_to_paid_when_local_down() {
+        let _guard = crate::availability::TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        setup_env();
+        crate::availability::mark_provider_down("ollama");
+
+        let entries = vec![
+            test_entry("paid-model", "groq", 1),
+            test_entry("free-model", "ollama", 0),
+        ];
+        let counts: HashMap<String, u32> = HashMap::new();
+        let picked = pick_from(&entries, &Role::B1Solver, &[], &counts, None)
+            .expect("the paid model should still be eligible");
+        assert_eq!(picked.id, "paid-model");
+    }
 }

--- a/quasi-senate/src/types.rs
+++ b/quasi-senate/src/types.rs
@@ -54,6 +54,13 @@ pub struct RotationEntry {
     /// Override for models with small context windows
     #[serde(default)]
     pub max_context: Option<u32>,
+    /// 0 = free (self-hosted), 1 = paid. Lower is preferred.
+    #[serde(default = "default_cost_tier")]
+    pub cost_tier: u8,
+}
+
+fn default_cost_tier() -> u8 {
+    1
 }
 
 // ── Phase Charter ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
The Mac Studio MLX server (Qwen3-235B) is free but gets paused whenever its owner needs the RAM. Rotation could not cope: eligibility came from `provider_has_key`, which only checks that env vars are non-empty. `OLLAMA_URL` stays set whether or not anything is listening, so a dead endpoint still looked selectable.

## New `availability` module

- **`is_provider_live(provider)`** — for providers with a `url_env_var` (self-hosted only), probes host:port with a 2s TCP connect, cached 60s. Cloud providers return `true` immediately and are **never probed** — spending quota to learn what the key check already covers would be wasteful.
- **`mark_provider_down(provider)`** — called from `provider.rs` on transport-level failure, so an endpoint that dies *mid-call* leaves the pool immediately rather than waiting out the TTL.

The probe is a blocking TCP connect because `pick_model` is sync but called from async contexts. It's wrapped in `block_in_place` when a multi-thread runtime is detected, so a worker thread isn't starved.

## Selection

- `eligible_for_role` now also requires `is_provider_live`.
- `RotationEntry` gains `cost_tier: u8`, **defaulting to 1** so all 40+ existing entries are behaviourally unchanged.
- `pick_model` sort key becomes `(cost_tier, count, provider_penalty, rotation_index)` — a live free model wins, and existing fairness/diversity still applies *within* a tier.

## Roster

Adds `qwen3-235b-local` (`cost_tier = 0`, roles `a2_drafter` + `b1_solver`). While it's up it becomes the default for those two roles; reviewer roles are untouched, so the multi-model jury is unaffected. Narrowing its `roles` dials this back.

`OLLAMA_URL` **must use the tailnet IP** — the deployment host has no MagicDNS, so `mac-studio` does not resolve there. Documented in the roster comment.

## Stop-token stripping

The local mlx-lm build doesn't reliably strip `<|im_end|>` — a live call returned `'ALIVE<|im_end|>'`. That would otherwise reach the JSON parser. Stripping is **suffix-only**, so mid-string occurrences and ordinary trailing whitespace are untouched.

## Tests

9 added, including the one that matters: `pick_falls_back_to_paid_when_local_down` marks the local provider down and asserts a paid entry is selected.

```
cargo test --workspace --all-targets                   ->  734 passed; 0 failed  (725 before)
cargo clippy --workspace --all-targets -- -D warnings  ->  clean
cargo build -p quasi-senate --release                  ->  ok
```

## Known limitations

- The **down path is verified end-to-end** (the MLX host is currently paused); the *prefer-local-when-live* path is unit-tested only, with the cache seeded rather than probing a real server.
- `provider.rs`'s retry wrapper still backs off ~14s on a dead endpoint before `mark_provider_down` takes effect. Subsequent picks skip it for the TTL. Changing retry policy was out of scope.
- `split_host_port` doesn't handle IPv6 literals (documented in the function).
- `health_check.rs` still duplicates the env-var checks; not unified here.