### PR TITLE
fix(senate): --dry-run must not post a proposal to the board

### DIFF
--- a/quasi-senate/src/pipeline.rs
+++ b/quasi-senate/src/pipeline.rs
@@ -410,6 +410,17 @@ pub async fn run_draft_pipeline(ctx: &mut AppContext) -> Result<u32> {
                 // Route through the quasi-board proposal queue (CLAUDE.md
                 // invariant 3). Board rejections are the gate doing its job —
                 // never fall back to create_issue, never retry around them.
+                //
+                // A proposal POST mutates board state, so --dry-run must not
+                // send one: a dry run previously queued a real pending proposal
+                // on the production board.
+                if ctx.dry_run {
+                    println!(
+                        "[dry-run] would queue quasi-board proposal for \"{}\" (effort={}, components={:?})",
+                        draft.title, draft.estimated_effort, draft.affected_components
+                    );
+                    Publication::Proposal("dry-run-not-submitted".to_string())
+                } else {
                 match crate::ledger::submit_proposal(&draft, &verdict.reasoning).await {
                     ProposalOutcome::Queued(prop_id) => {
                         info!(
@@ -443,6 +454,7 @@ pub async fn run_draft_pipeline(ctx: &mut AppContext) -> Result<u32> {
                             draft.title
                         ));
                     }
+                }
                 }
             };
 


### PR DESCRIPTION
A proposal POST mutates `quasi-board` state, but the new A-track path submitted one unconditionally.

Found during deployment: running `quasi-senate --dry-run draft` on Camelot **queued a real pending proposal** on the production board —

```
prop-001 | pending | dry-run: placeholder issue
```

— which I had to reject by hand via the admin API.

## Fix

`--dry-run` now prints what it *would* submit (title, effort, affected components — the gate-relevant fields stay visible) and skips the POST entirely.

## Why it was missed

The existing dry-run contract covered **LLM calls** and **GitHub mutations**. The board is a third mutable target, and rerouting the A-track through it introduced a write the contract didn't anticipate. My spec for that change specified dry-run handling for the already-done pre-flight but not for the proposal post.

```
cargo test --workspace --all-targets                   ->  757 passed; 0 failed
cargo clippy --workspace --all-targets -- -D warnings  ->  clean
```