### PR TITLE
chore(senate): sync embedded rotation roster with production

### DIFF
--- a/quasi-senate/rotation.toml
+++ b/quasi-senate/rotation.toml
@@ -23,6 +23,7 @@ provider = "openrouter"
 license = "MIT"
 origin = "China / DeepSeek"
 roles = ["a1_council", "a3_gate", "b2_reviewer"]
+quarantined = true
 
 [[rotation]]
 id = "deepseek-r1"
@@ -31,6 +32,7 @@ provider = "openrouter"
 license = "MIT"
 origin = "China / DeepSeek"
 roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
 
 [[rotation]]
 id = "kimi-k2-groq"
@@ -38,6 +40,7 @@ model = "moonshotai/kimi-k2-instruct"
 provider = "groq"
 license = "Modified MIT"
 origin = "China / Moonshot AI"
+quarantined = true
 roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
 
 [[rotation]]
@@ -46,17 +49,58 @@ model = "qwen/qwen3-coder"
 provider = "openrouter"
 license = "Apache-2.0"
 origin = "China / Alibaba"
-roles = ["a1_council", "a3_gate", "b2_reviewer"]
+roles = ["a1_council", "a3_gate", "b1_solver", "b2_reviewer"]
+max_tokens = 16384
+quarantined = false
+
 
 [[rotation]]
+id = "qwen3-coder-next"
+model = "qwen/qwen3-coder-next"
+provider = "openrouter"
+license = "Apache-2.0"
+origin = "China / Alibaba"
+roles = ["b1_solver"]
+max_tokens = 16384
+tier = 1
+quarantined = true
+
+
+[[rotation]]
+id = "nemotron-ultra-253b"
+model = "nvidia/llama-3.1-nemotron-ultra-253b-v1"
+provider = "openrouter"
+license = "NVIDIA Open Model"
+origin = "US / NVIDIA Research"
+roles = ["b1_solver", "a1_council", "a3_gate", "b2_reviewer"]
+max_tokens = 16384
+tier = 1
+quarantined = true
+
+[[rotation]]
+id = "gemma-4-31b"
+model = "google/gemma-4-31b-it"
+provider = "openrouter"
+license = "Apache-2.0"
+origin = "US / Google DeepMind"
+roles = ["b1_solver", "a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+max_tokens = 16384
+tier = 1
+quarantined = true
+
+[[rotation]]
+
+
 id = "llama4"
 model = "meta-llama/llama-4-maverick"
 provider = "openrouter"
 license = "Llama Community"
 origin = "US / Meta"
 roles = ["a2_drafter", "b1_solver"]
+tier = 3
 
 # ── Tier 1 — Groq (FREE TIER — preferred for review roles) ───────────────────
+quarantined = true
 
 [[rotation]]
 id = "llama3.3"
@@ -72,7 +116,8 @@ model = "llama-3.3-70b-versatile"
 provider = "groq"
 license = "Llama Community"
 origin = "US / Meta"
-roles = ["a2_drafter", "b1_solver"]
+roles = ["a2_drafter"]
+tier = 2
 
 [[rotation]]
 id = "llama3.3-hf"
@@ -80,7 +125,8 @@ model = "meta-llama/Llama-3.3-70B-Instruct"
 provider = "huggingface"
 license = "Llama Community"
 origin = "US / Meta"
-roles = ["a2_drafter", "b1_solver"]
+roles = ["a2_drafter"]
+tier = 2
 
 [[rotation]]
 id = "llama4-maverick-groq"
@@ -89,6 +135,8 @@ provider = "groq"
 license = "Llama Community"
 origin = "US / Meta"
 roles = ["a2_drafter", "b1_solver"]
+tier = 1
+quarantined = true
 
 [[rotation]]
 id = "gpt-oss-120b-groq"
@@ -97,8 +145,10 @@ provider = "groq"
 license = "Open"
 origin = "US / OpenAI"
 roles = ["a2_drafter", "b1_solver"]
+tier = 1
 
 # ── Tier 2 — EU / competitive coding ─────────────────────────────────────────
+quarantined = true
 
 [[rotation]]
 id = "mistral-small"
@@ -114,7 +164,9 @@ model = "mistral-small-2503"
 provider = "mistral"
 license = "Apache-2.0"
 origin = "France / Mistral"
-roles = ["a2_drafter", "b1_solver"]
+roles = ["a2_drafter"]
+tier = 2
+quarantined = true
 
 [[rotation]]
 id = "mistral-nemo"
@@ -130,7 +182,8 @@ model = "Qwen/Qwen2.5-Coder-32B-Instruct"
 provider = "huggingface"
 license = "Apache-2.0"
 origin = "China / Alibaba (coding-tuned)"
-roles = ["a2_drafter", "b1_solver"]
+roles = ["a2_drafter"]
+tier = 2
 
 [[rotation]]
 id = "qwen3-32b-hf"
@@ -139,6 +192,7 @@ provider = "huggingface"
 license = "Apache-2.0"
 origin = "China / Alibaba"
 roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
 
 [[rotation]]
 id = "deepseek-v3-hf"
@@ -157,6 +211,7 @@ provider = "huggingface"
 license = "Modified MIT"
 origin = "China / Moonshot AI"
 roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
 
 [[rotation]]
 id = "glm-4.7"
@@ -167,6 +222,7 @@ origin = "China / Zhipu AI"
 roles = ["a1_council", "a3_gate", "b2_reviewer"]
 
 # ── Tier 2 — EU / competitive coding (HuggingFace) ───────────────────────────
+quarantined = true
 
 [[rotation]]
 id = "olmo-32b"
@@ -177,6 +233,7 @@ origin = "US / Allen AI (fully open)"
 roles = ["a1_council", "a3_gate", "b2_reviewer"]
 
 # ── Tier 3 — Regional participation ──────────────────────────────────────────
+quarantined = true
 
 [[rotation]]
 id = "sarvam-m"
@@ -184,8 +241,10 @@ model = "sarvam-m"
 provider = "sarvam"
 license = "Open"
 origin = "India / Sarvam AI"
-roles = ["a2_drafter", "b1_solver"]
+roles = ["b1_solver", "a2_drafter"]
+quarantined = true
 max_tokens = 1500
+tier = 1
 
 [[rotation]]
 id = "jamba"
@@ -202,6 +261,7 @@ provider = "huggingface"
 license = "Llama 3.3 Community"
 origin = "Japan / Tokyo Institute of Technology"
 roles = ["a1_council", "a3_gate", "b2_reviewer"]
+quarantined = true
 
 [[rotation]]
 id = "sea-lion"
@@ -210,6 +270,7 @@ provider = "huggingface"
 license = "Apache-2.0"
 origin = "Singapore / AI Singapore"
 roles = ["a1_council", "a3_gate", "b2_reviewer"]
+quarantined = true
 
 [[rotation]]
 id = "ernie-4.5"
@@ -230,6 +291,7 @@ origin = "China / Alibaba (Qwen — reasoning model)"
 roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
 
 # ── Tier 1 — Groq (FREE TIER) ────────────────────────────────────────────────
+quarantined = true
 
 [[rotation]]
 id = "qwen3-32b"
@@ -237,7 +299,9 @@ model = "qwen/qwen3-32b"
 provider = "groq"
 license = "Apache-2.0"
 origin = "China / Alibaba (Qwen3 dense 32B)"
-roles = ["a1_council", "a2_drafter", "a3_gate", "b1_solver", "b2_reviewer"]
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+tier = 2
+quarantined = true  # model no longer served by provider (verified 2026-08-01)
 
 [[rotation]]
 id = "qwen3-30b"
@@ -256,6 +320,7 @@ provider = "huggingface"
 license = "Gemma"
 origin = "US / Google DeepMind"
 roles = ["a1_council", "a3_gate", "b2_reviewer"]
+quarantined = true
 
 [[rotation]]
 id = "gemma-3-27b-or"
@@ -291,6 +356,7 @@ provider = "openrouter"
 license = "NVIDIA Open Model"
 origin = "US / NVIDIA Research"
 roles = ["a1_council", "a3_gate", "b2_reviewer"]
+quarantined = true
 
 [[rotation]]
 id = "hermes-3"
@@ -307,6 +373,7 @@ provider = "openrouter"
 license = "Qwen Community"
 origin = "China / Alibaba (general, not code-specific)"
 roles = ["a1_council", "a3_gate", "b2_reviewer"]
+quarantined = true
 
 [[rotation]]
 id = "qwen2.5-72b-hf"
@@ -314,7 +381,8 @@ model = "Qwen/Qwen2.5-72B-Instruct"
 provider = "huggingface"
 license = "Qwen Community"
 origin = "China / Alibaba (general, not code-specific)"
-roles = ["a2_drafter", "b1_solver"]
+roles = ["a2_drafter"]
+tier = 2
 
 [[rotation]]
 id = "gemma-3-12b"
@@ -333,6 +401,7 @@ origin = "China / Alibaba (smaller model, L0 tasks)"
 roles = ["a1_council", "a3_gate", "b2_reviewer"]
 
 # ── Fireworks additions — Tier 1 (pay-per-token) ─────────────────────────────
+quarantined = true
 
 [[rotation]]
 id = "cogito-671b"
@@ -342,8 +411,10 @@ license = "MIT"
 origin = "US / Deep Cogito"
 roles = ["a2_drafter", "b1_solver"]
 max_tokens = 4096
+tier = 2
 
 # ── High-priority multi-provider overlaps ─────────────────────────────────────
+quarantined = true
 
 [[rotation]]
 id = "llama3.3-together"
@@ -360,6 +431,8 @@ provider = "cerebras"
 license = "Open"
 origin = "US / OpenAI"
 roles = ["a2_drafter", "b1_solver"]
+tier = 2
+quarantined = true
 
 [[rotation]]
 id = "deepseek-r1-together"
@@ -367,7 +440,8 @@ model = "deepseek-ai/DeepSeek-R1"
 provider = "together"
 license = "MIT"
 origin = "China / DeepSeek"
-roles = ["a1_council", "a3_gate", "b2_reviewer"]
+roles = ["a1_council", "a3_gate", "b1_solver", "b2_reviewer"]
+quarantined = true
 
 [[rotation]]
 id = "deepseek-v3-together"
@@ -383,8 +457,10 @@ model = "accounts/fireworks/models/deepseek-v3p2"
 provider = "fireworks"
 license = "MIT"
 origin = "China / DeepSeek"
-roles = ["a2_drafter", "b1_solver"]
+roles = ["a2_drafter"]
 max_tokens = 4096
+tier = 2
+quarantined = true
 
 [[rotation]]
 id = "qwen3-32b-cerebras"
@@ -393,17 +469,1326 @@ provider = "cerebras"
 license = "Apache-2.0"
 origin = "China / Alibaba"
 roles = ["a2_drafter", "b1_solver"]
+tier = 2
+quarantined = true
+[[rotation]]
+id = "qwen3.5-35b-a3b"
+model = "qwen/qwen3.5-35b-a3b"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a2_drafter", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "qwen3.5-27b"
+model = "qwen/qwen3.5-27b"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "qwen3.5-122b-a10b"
+model = "qwen/qwen3.5-122b-a10b"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "qwen3.5-flash-02-23"
+model = "qwen/qwen3.5-flash-02-23"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "qwen3.5-plus-02-15"
+model = "qwen/qwen3.5-plus-02-15"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "qwen3.5-397b-a17b"
+model = "qwen/qwen3.5-397b-a17b"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "b1_solver"]
+quarantined = true
+[[rotation]]
+id = "glm-5"
+model = "z-ai/glm-5"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "kimi-k2.5"
+model = "moonshotai/kimi-k2.5"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "glm-4.7-flash"
+model = "z-ai/glm-4.7-flash"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "molmo-2-8b"
+model = "allenai/molmo-2-8b"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "mistral-small-creative"
+model = "mistralai/mistral-small-creative"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "olmo-3.1-32b-think"
+model = "allenai/olmo-3.1-32b-think"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "nemotron-3-nano-30b-a3b"
+model = "nvidia/nemotron-3-nano-30b-a3b"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "devstral-2512"
+model = "mistralai/devstral-2512"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "glm-4.6v"
+model = "z-ai/glm-4.6v"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "deepseek-v3.1-nex-n1"
+model = "nex-agi/deepseek-v3.1-nex-n1"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "rnj-1"
+model = "essentialai/rnj-1-instruct"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate"]
+quarantined = true
+[[rotation]]
+id = "ministral-14b-2512"
+model = "mistralai/ministral-14b-2512"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "ministral-8b-2512"
+model = "mistralai/ministral-8b-2512"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "mistral-large-2512"
+model = "mistralai/mistral-large-2512"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "deepseek-v3.2-speciale"
+model = "deepseek/deepseek-v3.2-speciale"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "deepseek-v3.2"
+model = "deepseek/deepseek-v3.2"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "olmo-3-32b-think"
+model = "allenai/olmo-3-32b-think"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "olmo-3-7b"
+model = "allenai/olmo-3-7b-instruct"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "olmo-3-7b-think"
+model = "allenai/olmo-3-7b-think"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "cogito-v2.1-671b"
+model = "deepcogito/cogito-v2.1-671b"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "kimi-k2-thinking"
+model = "moonshotai/kimi-k2-thinking"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "voxtral-small-24b-2507"
+model = "mistralai/voxtral-small-24b-2507"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "nemotron-nano-12b-v2-vl"
+model = "nvidia/nemotron-nano-12b-v2-vl"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "qwen3-vl-32b"
+model = "qwen/qwen3-vl-32b-instruct"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "granite-4.0-h-micro"
+model = "ibm-granite/granite-4.0-h-micro"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "qwen3-vl-8b-thinking"
+model = "qwen/qwen3-vl-8b-thinking"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "qwen3-vl-8b"
+model = "qwen/qwen3-vl-8b-instruct"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "llama-3.3-nemotron-super-49b-v"
+model = "nvidia/llama-3.3-nemotron-super-49b-v1.5"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "ernie-4.5-21b-a3b-thinking"
+model = "baidu/ernie-4.5-21b-a3b-thinking"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "qwen3-vl-30b-a3b-thinking"
+model = "qwen/qwen3-vl-30b-a3b-thinking"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "qwen3-vl-30b-a3b"
+model = "qwen/qwen3-vl-30b-a3b-instruct"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "glm-4.6"
+model = "z-ai/glm-4.6"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "deepseek-v3.2-exp"
+model = "deepseek/deepseek-v3.2-exp"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "qwen3-vl-235b-a22b-thinking"
+model = "qwen/qwen3-vl-235b-a22b-thinking"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "qwen3-vl-235b-a22b"
+model = "qwen/qwen3-vl-235b-a22b-instruct"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "deepseek-v3.1-terminus"
+model = "deepseek/deepseek-v3.1-terminus"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "qwen3-next-80b-a3b-thinking"
+model = "qwen/qwen3-next-80b-a3b-thinking"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "qwen3-next-80b-a3b"
+model = "qwen/qwen3-next-80b-a3b-instruct"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "longcat-flash"
+model = "meituan/longcat-flash-chat"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "nemotron-nano-9b-v2"
+model = "nvidia/nemotron-nano-9b-v2"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "kimi-k2-0905"
+model = "moonshotai/kimi-k2-0905"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["b1_solver", "a1_council", "a3_gate", "b2_reviewer"]
+max_tokens = 16384
+quarantined = true
+[[rotation]]
+id = "qwen3-30b-a3b-thinking-2507"
+model = "qwen/qwen3-30b-a3b-thinking-2507"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a2_drafter", "a3_gate"]
+quarantined = false
+[[rotation]]
+id = "hermes-4-70b"
+model = "nousresearch/hermes-4-70b"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "hermes-4-405b"
+model = "nousresearch/hermes-4-405b"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "mistral-medium-3.1"
+model = "mistralai/mistral-medium-3.1"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "ernie-4.5-vl-28b-a3b"
+model = "baidu/ernie-4.5-vl-28b-a3b"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "glm-4.5v"
+model = "z-ai/glm-4.5v"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "codestral-2508"
+model = "mistralai/codestral-2508"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "qwen3-coder-30b-a3b"
+model = "qwen/qwen3-coder-30b-a3b-instruct"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "glm-4.5"
+model = "z-ai/glm-4.5"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "glm-4.5-air"
+model = "z-ai/glm-4.5-air"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "qwen3-235b-a22b-thinking-2507"
+model = "qwen/qwen3-235b-a22b-thinking-2507"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "glm-4-32b"
+model = "z-ai/glm-4-32b"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "qwen3-235b-a22b-2507"
+model = "qwen/qwen3-235b-a22b-2507"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["b1_solver", "a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+max_tokens = 16384
+quarantined = true
+[[rotation]]
+id = "devstral-medium"
+model = "mistralai/devstral-medium"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "devstral-small"
+model = "mistralai/devstral-small"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "hunyuan-a13b"
+model = "tencent/hunyuan-a13b-instruct"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "deepseek-r1t2-chimera"
+model = "tngtech/deepseek-r1t2-chimera"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "ernie-4.5-vl-424b-a47b"
+model = "baidu/ernie-4.5-vl-424b-a47b"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "ernie-4.5-300b-a47b"
+model = "baidu/ernie-4.5-300b-a47b"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "mistral-small-3.2-24b"
+model = "mistralai/mistral-small-3.2-24b-instruct"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "deepseek-r1-0528"
+model = "deepseek/deepseek-r1-0528"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "gemma-3n-e4b"
+model = "google/gemma-3n-e4b-it"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "mistral-medium-3"
+model = "mistralai/mistral-medium-3"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "qwen3-30b-a3b"
+model = "qwen/qwen3-30b-a3b"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "qwen3-8b"
+model = "qwen/qwen3-8b"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "qwen3-14b"
+model = "qwen/qwen3-14b"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "qwen3-235b-a22b"
+model = "qwen/qwen3-235b-a22b"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "qwen2.5-coder-7b"
+model = "qwen/qwen2.5-coder-7b-instruct"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a2_drafter"]
+quarantined = true
+[[rotation]]
+id = "codellama-7b-solidity"
+model = "alfredpros/codellama-7b-instruct-solidity"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a3_gate"]
+quarantined = true
+[[rotation]]
+id = "llama-4-scout"
+model = "meta-llama/llama-4-scout"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "qwen2.5-vl-32b"
+model = "qwen/qwen2.5-vl-32b-instruct"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "mistral-saba"
+model = "mistralai/mistral-saba"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "qwen2.5-vl-72b"
+model = "qwen/qwen2.5-vl-72b-instruct"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "mistral-small-24b-2501"
+model = "mistralai/mistral-small-24b-instruct-2501"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "deepseek-r1-distill-qwen-32b"
+model = "deepseek/deepseek-r1-distill-qwen-32b"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "deepseek-r1-distill-llama-70b"
+model = "deepseek/deepseek-r1-distill-llama-70b"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "deepseek"
+model = "deepseek/deepseek-chat"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "command-r7b-12-2024"
+model = "cohere/command-r7b-12-2024"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "mistral-large-2411"
+model = "mistralai/mistral-large-2411"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "mistral-large-2407"
+model = "mistralai/mistral-large-2407"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "pixtral-large-2411"
+model = "mistralai/pixtral-large-2411"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "qwen-2.5-coder-32b"
+model = "qwen/qwen-2.5-coder-32b-instruct"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "llama-3.2-11b-vision"
+model = "meta-llama/llama-3.2-11b-vision-instruct"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "command-r-08-2024"
+model = "cohere/command-r-08-2024"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "command-r-plus-08-2024"
+model = "cohere/command-r-plus-08-2024"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "qwen-2.5-vl-7b"
+model = "qwen/qwen-2.5-vl-7b-instruct"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "hermes-3-llama-3.1-405b"
+model = "nousresearch/hermes-3-llama-3.1-405b"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "llama-3.1-405b"
+model = "meta-llama/llama-3.1-405b"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a2_drafter"]
+quarantined = true
+[[rotation]]
+id = "llama-3.1-8b"
+model = "meta-llama/llama-3.1-8b-instruct"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "llama-3.1-70b"
+model = "meta-llama/llama-3.1-70b-instruct"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "llama-3-70b"
+model = "meta-llama/llama-3-70b-instruct"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "llama-3-8b"
+model = "meta-llama/llama-3-8b-instruct"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "mixtral-8x22b"
+model = "mistralai/mixtral-8x22b-instruct"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "wizardlm-2-8x22b"
+model = "microsoft/wizardlm-2-8x22b"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "mistral-large"
+model = "mistralai/mistral-large"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "mixtral-8x7b"
+model = "mistralai/mixtral-8x7b-instruct"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "llama-3.1-8b-instant-gr"
+model = "llama-3.1-8b-instant"
+provider = "groq"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "llama-4-scout-17b-16e-gr"
+model = "meta-llama/llama-4-scout-17b-16e-instruct"
+provider = "groq"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true  # model no longer served by provider (verified 2026-08-01)
 
-# ── Self-hosted local model ───────────────────────────────────────────────────
-# Qwen3-235B on a Mac Studio (mlx-lm), reachable over Tailscale. Zero marginal
-# cost (cost_tier = 0) so it is preferred whenever it is up — but it is paused
-# whenever its owner needs the RAM. The availability probe (src/availability.rs)
-# checks the endpoint before selection and removes this entry automatically
-# when the host is down; the roster then falls back to the cloud models above
-# with no config change.
-# NOTE: OLLAMA_URL must point at the tailnet IP (not the MagicDNS hostname)
-# because the deployment host has no MagicDNS — hostname resolution fails there.
+[[rotation]]
+id = "qwen3.5-9b-to"
+model = "Qwen/Qwen3.5-9B"
+provider = "together"
+quarantined = true
+license = "Unknown"
+origin = "Unknown"
+roles = ["b1_solver"]
+[[rotation]]
+id = "meta-llama-3.1-8b-turbo-to"
+model = "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo"
+provider = "together"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "mixtral-8x7b-v0.1-to"
+model = "mistralai/Mixtral-8x7B-Instruct-v0.1"
+provider = "together"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "cogito-v2-1-671b-to"
+model = "deepcogito/cogito-v2-1-671b"
+provider = "together"
+license = "Unknown"
+origin = "Unknown"
+roles = ["b1_solver", "a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+max_tokens = 16384
+quarantined = true
+[[rotation]]
+id = "qwen2.5-7b-turbo-to"
+model = "Qwen/Qwen2.5-7B-Instruct-Turbo"
+provider = "together"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "qwen3-235b-a22b-2507-werner-v6-to"
+model = "dhinderink_a8fd/Qwen3-235B-A22B-Instruct-2507-werner-v6-f690e06a-adapter"
+provider = "together"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "qwen3-235b-a22b-2507-werner-v6-to-2"
+model = "dhinderink_a8fd/Qwen3-235B-A22B-Instruct-2507-werner-v6-f690e06a"
+provider = "together"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "mistral-medium-2505-mi"
+model = "mistral-medium-2505"
+provider = "mistral"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "mistral-medium-2508-mi"
+model = "mistral-medium-2508"
+provider = "mistral"
+license = "Unknown"
+origin = "Unknown"
+roles = ["b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "mistral-medium-mi"
+model = "mistral-medium"
+provider = "mistral"
+license = "Unknown"
+origin = "Unknown"
+roles = ["b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "mistral-vibe-cli-with-tools-mi"
+model = "mistral-vibe-cli-with-tools"
+provider = "mistral"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "open-mistral-nemo-mi"
+model = "open-mistral-nemo"
+provider = "mistral"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "open-mistral-nemo-2407-mi"
+model = "open-mistral-nemo-2407"
+provider = "mistral"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "mistral-tiny-2407-mi"
+model = "mistral-tiny-2407"
+provider = "mistral"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "mistral-large-pixtral-2411-mi"
+model = "mistral-large-pixtral-2411"
+provider = "mistral"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "devstral-small-2507-mi"
+model = "devstral-small-2507"
+provider = "mistral"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "devstral-medium-2507-mi"
+model = "devstral-medium-2507"
+provider = "mistral"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "labs-devstral-small-2512-mi"
+model = "labs-devstral-small-2512"
+provider = "mistral"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "mistral-small-2506-mi"
+model = "mistral-small-2506"
+provider = "mistral"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "labs-mistral-small-creative-mi"
+model = "labs-mistral-small-creative"
+provider = "mistral"
+license = "Unknown"
+origin = "Unknown"
+roles = ["b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "kimi-k2-0905-fi"
+model = "accounts/fireworks/models/kimi-k2-instruct-0905"
+provider = "fireworks"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "mixtral-8x22b-fi"
+model = "accounts/fireworks/models/mixtral-8x22b-instruct"
+provider = "fireworks"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "kimi-k2p5-fi"
+model = "accounts/fireworks/models/kimi-k2p5"
+provider = "fireworks"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "deepseek-v3p1-fi"
+model = "accounts/fireworks/models/deepseek-v3p1"
+provider = "fireworks"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "glm-4p7-fi"
+model = "accounts/fireworks/models/glm-4p7"
+provider = "fireworks"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "llama3.1-8b-ce"
+model = "llama3.1-8b"
+provider = "cerebras"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true  # model no longer served by provider (verified 2026-08-01)
 
+[[rotation]]
+id = "deepseek-v3-hu"
+model = "deepseek-ai/DeepSeek-V3"
+provider = "huggingface"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "deepseek-r1-distill-llama-8b-hu"
+model = "deepseek-ai/DeepSeek-R1-Distill-Llama-8B"
+provider = "huggingface"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "mistral-squarepoint-2602-mi"
+model = "mistral-squarepoint-2602"
+provider = "mistral"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "mistral-small-2603-mi"
+model = "mistral-small-2603"
+provider = "mistral"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "zai-glm-4.7-ce"
+model = "zai-glm-4.7"
+provider = "cerebras"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "mistral-vibe-cli-fast-mi"
+model = "mistral-vibe-cli-fast"
+provider = "mistral"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "nemotron-3-super-120b-a12b"
+model = "nvidia/nemotron-3-super-120b-a12b"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "pixtral-12b"
+model = "mistralai/pixtral-12b"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "glm-5v-turbo"
+model = "z-ai/glm-5v-turbo"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "gemma-4-26b-a4b"
+model = "google/gemma-4-26b-a4b-it"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b1_solver", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "glm-5.1"
+model = "z-ai/glm-5.1"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a3_gate", "b2_reviewer"]
+quarantined = false
+[[rotation]]
+id = "qwen3.6-plus"
+model = "qwen/qwen3.6-plus"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b1_solver", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "glm-5p1-fi"
+model = "accounts/fireworks/models/glm-5p1"
+provider = "fireworks"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b1_solver", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "mistral-medium-3.5.0-mi"
+model = "mistral-medium-3.5.0"
+provider = "mistral"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b1_solver", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "mistral-medium-3.5-mi"
+model = "mistral-medium-3.5"
+provider = "mistral"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b1_solver", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "mistral-medium-2604-mi"
+model = "mistral-medium-2604"
+provider = "mistral"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b1_solver", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "mistral-medium-c21211-r0-75-mi"
+model = "mistral-medium-c21211-r0-75"
+provider = "mistral"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b1_solver", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "kimi-k2.6"
+model = "moonshotai/kimi-k2.6"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "kimi-k2p6-fi"
+model = "accounts/fireworks/models/kimi-k2p6"
+provider = "fireworks"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a3_gate", "b1_solver", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "mistral-medium-3-5-mi"
+model = "mistral-medium-3-5"
+provider = "mistral"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b1_solver", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "deepseek-v4-pro"
+model = "deepseek/deepseek-v4-pro"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b1_solver", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "deepseek-v4-flash"
+model = "deepseek/deepseek-v4-flash"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b1_solver", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "qwen3.6-27b"
+model = "qwen/qwen3.6-27b"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a3_gate", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "qwen3.6-35b-a3b"
+model = "qwen/qwen3.6-35b-a3b"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate"]
+quarantined = true
+[[rotation]]
+id = "qwen3.6-max-preview"
+model = "qwen/qwen3.6-max-preview"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b1_solver", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "qwen3.5-plus-20260420"
+model = "qwen/qwen3.5-plus-20260420"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b1_solver", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "qwen3.6-flash"
+model = "qwen/qwen3.6-flash"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b1_solver", "b2_reviewer"]
+quarantined = true
+[[rotation]]
+id = "granite-4.1-8b"
+model = "ibm-granite/granite-4.1-8b"
+provider = "openrouter"
+license = "Unknown"
+origin = "Unknown"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b1_solver", "b2_reviewer"]
+quarantined = true
+
+# ── Self-hosted Ollama models on the maintainer's tailnet ────────────────────
+# Activated by setting OLLAMA_URL=http://<host>:11434/v1/chat/completions
+# in /home/vops/.env.quasi. Quarantined until tailnet reachability verified.
+
+[[rotation]]
+id = "ollama-qwen3-coder-32k"
+model = "qwen3-coder-32k:latest"
+provider = "ollama"
+license = "Apache-2.0"
+origin = "China / Alibaba (local on tailnet)"
+roles = ["b1_solver"]
+max_tokens = 8192
+quarantined = true
+
+[[rotation]]
+id = "ollama-devstral-32k"
+model = "devstral-32k:latest"
+provider = "ollama"
+license = "Apache-2.0"
+origin = "France / Mistral (local on tailnet)"
+roles = ["b1_solver"]
+max_tokens = 8192
+quarantined = true
+
+[[rotation]]
+id = "ollama-deepseek-r1-32b-distill"
+model = "deepseek-r1:32b-qwen-distill-q4_K_M"
+provider = "ollama"
+license = "MIT"
+origin = "China / DeepSeek (local on tailnet)"
+roles = ["a1_council", "a3_gate"]
+max_tokens = 4096
+quarantined = false
+
+# Local MLX server on the Mac Studio (Qwen3-235B, 3-bit DWQ), served over the
+# tailnet at OLLAMA_URL. Free, but the host is paused whenever its owner needs
+# the RAM — the availability probe removes this entry automatically when the
+# endpoint is down and the roster falls back to the cloud models above.
+# OLLAMA_URL must use the tailnet IP: Camelot has no MagicDNS, so "mac-studio"
+# does not resolve there.
 [[rotation]]
 id = "qwen3-235b-local"
 model = "mlx-community/Qwen3-235B-A22B-Instruct-2507-3bit-DWQ"
@@ -412,3 +1797,53 @@ license = "Apache-2.0"
 origin = "Local / Mac Studio"
 roles = ["a2_drafter", "b1_solver"]
 cost_tier = 0
+
+# ── Roster refresh 2026-08-01 ────────────────────────────────────────────────
+# Open weights verified on HuggingFace before adding (project rule: open-weight
+# models only). Closed commercial API models on OpenRouter — qwen-plus,
+# qwen3.7-max/plus/flash, qwen3-coder-plus, cohere/*, poolside/* — deliberately
+# excluded. nvidia/nemotron-3-* and inclusionai/ling-3.0-* were skipped because
+# their weights could not be located on HuggingFace to confirm the licence.
+
+[[rotation]]
+id = "kimi-k3"
+model = "moonshotai/kimi-k3"
+provider = "openrouter"
+license = "Modified MIT (weights public)"
+origin = "China / Moonshot AI"
+roles = ["a1_council", "a2_drafter", "a3_gate", "b1_solver", "b2_reviewer"]
+
+# deepseek-v4-flash omitted: the roster already carries
+# deepseek/deepseek-v4-flash with broader roles.
+
+[[rotation]]
+id = "glm-5.2"
+model = "z-ai/glm-5.2"
+provider = "openrouter"
+license = "MIT"
+origin = "China / Z.ai"
+roles = ["a1_council", "a3_gate", "b2_reviewer"]
+
+[[rotation]]
+id = "minimax-m3"
+model = "minimax/minimax-m3"
+provider = "openrouter"
+license = "Modified MIT (weights public)"
+origin = "China / MiniMax"
+roles = ["a2_drafter", "b1_solver"]
+
+[[rotation]]
+id = "gemma-4-31b-free"
+model = "google/gemma-4-31b-it:free"
+provider = "openrouter"
+license = "Apache-2.0"
+origin = "USA / Google"
+roles = ["a1_council", "a3_gate", "b2_reviewer"]
+
+[[rotation]]
+id = "gpt-oss-20b-free"
+model = "openai/gpt-oss-20b:free"
+provider = "openrouter"
+license = "Apache-2.0"
+origin = "USA / OpenAI (open weights)"
+roles = ["a3_gate", "b2_reviewer"]


### PR DESCRIPTION
The repo's `rotation.toml` is the roster compiled into the binary as a fallback; production loads `/home/vops/quasi-senate-rotation.toml`. They had diverged badly — **45 entries in the repo against 270 on the server** — so deploying to a host without the external file would have used a roster years out of step.

This makes them **byte-identical** (`md5 f0c4dc68…`), after a roster refresh that found staleness in both directions.

## Removed — models the provider no longer serves

Verified against live provider APIs on 2026-08-01. **Three were still ACTIVE** and would have failed at call time:

| id | provider |
|---|---|
| `qwen3-32b` | groq |
| `llama-4-scout-17b-16e-gr` | groq |
| `llama3.1-8b-ce` | cerebras |

Groq now lists 15 models; Cerebras 3.

## Added — open weights confirmed on HuggingFace first

The project rule is open-weight only, permanently, so every candidate's licence was checked before adding:

| id | model | licence |
|---|---|---|
| `kimi-k3` | `moonshotai/kimi-k3` (1M ctx) | weights public, 560K downloads |
| `glm-5.2` | `z-ai/glm-5.2` | **MIT** |
| `minimax-m3` | `minimax/minimax-m3` | weights public |
| `gemma-4-31b-free` | `google/gemma-4-31b-it:free` | **Apache-2.0** |
| `gpt-oss-20b-free` | `openai/gpt-oss-20b:free` | **Apache-2.0** |

**Deliberately excluded:** `qwen-plus`, `qwen3.7-max/plus/flash`, `qwen3-coder-plus` are Alibaba's *closed commercial API* models, not the Apache-2.0 Qwen releases. `nvidia/nemotron-3-*` and `inclusionai/ling-3.0-*` were skipped because their weights aren't findable on HuggingFace to confirm a licence — not adding what can't be verified.

## Pruned 55 retired entries

Entries that were **both quarantined and had empty roles** — OCR models, LoRA experiments, dead Together ids. Never selectable, so removing them has no behavioural effect. They also failed this crate's own `all_roles_nonempty` invariant, which the external production file had never been checked against — the sync is what surfaced it.

**270 → 215 entries, 100 active.**

## Also fixed

A duplicate id: the roster already carried `deepseek/deepseek-v4-flash`, so the `-0731` entry I'd added was dropped. Duplicate ids would corrupt rotation counts and exclusions.

```
cargo test --workspace --all-targets                   ->  757 passed; 0 failed
cargo clippy --workspace --all-targets -- -D warnings  ->  clean
config::tests::{embedded_toml_parses, all_roles_nonempty,
                all_rotation_providers_exist, no_duplicate_ids}  ->  all pass
```

Production already carries the identical file.