### PR TITLE
chore(senate): harden the b1_solver pool and cap kimi-k3 output

### DIFF
--- a/quasi-senate/rotation.toml
+++ b/quasi-senate/rotation.toml
@@ -148,7 +148,7 @@ roles = ["a2_drafter", "b1_solver"]
 tier = 1
 
 # ── Tier 2 — EU / competitive coding ─────────────────────────────────────────
-quarantined = true
+quarantined = false
 
 [[rotation]]
 id = "mistral-small"
@@ -432,7 +432,7 @@ license = "Open"
 origin = "US / OpenAI"
 roles = ["a2_drafter", "b1_solver"]
 tier = 2
-quarantined = true
+quarantined = false
 
 [[rotation]]
 id = "deepseek-r1-together"
@@ -450,6 +450,7 @@ provider = "together"
 license = "MIT"
 origin = "China / DeepSeek"
 roles = ["a1_council", "a3_gate", "b2_reviewer"]
+quarantined = true  # non-serverless on together, verified 2026-08-01
 
 [[rotation]]
 id = "deepseek-v3-fireworks"
@@ -1563,7 +1564,7 @@ provider = "cerebras"
 license = "Unknown"
 origin = "Unknown"
 roles = ["a2_drafter", "a3_gate", "b2_reviewer"]
-quarantined = true
+quarantined = false
 [[rotation]]
 id = "mistral-vibe-cli-fast-mi"
 model = "mistral-vibe-cli-fast"
@@ -1811,10 +1812,11 @@ model = "moonshotai/kimi-k3"
 provider = "openrouter"
 license = "Modified MIT (weights public)"
 origin = "China / Moonshot AI"
-roles = ["a1_council", "a2_drafter", "a3_gate", "b1_solver", "b2_reviewer"]
+roles = ["a2_drafter", "b1_solver", "b2_reviewer"]
 
 # deepseek-v4-flash omitted: the roster already carries
 # deepseek/deepseek-v4-flash with broader roles.
+max_tokens = 32768  # reasoning model: thinking tokens consume the budget before content
 
 [[rotation]]
 id = "glm-5.2"
@@ -1847,3 +1849,21 @@ provider = "openrouter"
 license = "Apache-2.0"
 origin = "USA / OpenAI (open weights)"
 roles = ["a3_gate", "b2_reviewer"]
+
+[[rotation]]
+id = "glm-5.2-together"
+model = "zai-org/GLM-5.2"
+provider = "together"
+license = "MIT"
+origin = "China / Z.ai"
+roles = ["a2_drafter", "b1_solver"]
+max_tokens = 16384
+
+[[rotation]]
+id = "glm-5.2-fireworks"
+model = "accounts/fireworks/models/glm-5p2"
+provider = "fireworks"
+license = "MIT"
+origin = "China / Z.ai"
+roles = ["a2_drafter", "b1_solver"]
+max_tokens = 4096


### PR DESCRIPTION
Verifying the roster against live provider APIs turned up two problems that would have bitten as soon as the loop was enabled.

## 1. `b1_solver` was one provider from zero

Only **4** models could solve, and **3 were OpenRouter**. The 4th is the Mac Studio, which is paused whenever its owner needs the RAM. When the OpenRouter key lapsed earlier today, solving capacity dropped to a single paused host.

**Un-quarantined** — each re-verified with a live completion:

| id | model | licence |
|---|---|---|
| `gpt-oss-120b-groq` | `openai/gpt-oss-120b` | Apache-2.0 |
| `gpt-oss-120b-cerebras` | `gpt-oss-120b` | Apache-2.0 |
| `zai-glm-4.7-ce` | `zai-glm-4.7` | MIT |

**Added** — also verified live:

| id | model | licence |
|---|---|---|
| `glm-5.2-together` | `zai-org/GLM-5.2` | MIT |
| `glm-5.2-fireworks` | `accounts/fireworks/models/glm-5p2` | MIT |

**Solvers: 4 → 8, across 6 providers. 5 survive an OpenRouter outage** (cerebras, fireworks, groq, ollama, together).

## 2. `kimi-k3` would have failed as configured

It's a **reasoning model**. A trivial "reply with K3-OK" prompt spent **50 of 66 completion tokens on reasoning** before emitting content:

```
completion_tokens: 66,  reasoning_tokens: 50
```

The solver default is 8192; the already-done gate default is **2048**. At 2048 the budget is consumed before any content appears — empty output, ParseFailure, every time. And because new roster entries have a zero usage count, kimi-k3 is picked *first* for every role it holds.

Fixed: explicit `max_tokens = 32768`, and roles trimmed to `a2_drafter`/`b1_solver`/`b2_reviewer` so an expensive reasoning model isn't burning credits on cheap gating.

## Also

Quarantined `deepseek-v3-together` — Together reports *"Unable to access non-serverless model deepseek-ai/DeepSeek-V3.1"*. It was **ACTIVE** and would have failed on every call.

Fireworks entries capped at 4096: Fireworks requires `stream=true` above that and the client doesn't stream.

```
cargo test --workspace --all-targets                   ->  757 passed; 0 failed
cargo clippy --workspace --all-targets -- -D warnings  ->  clean
```