### PR TITLE
fix(senate): honour roster max_tokens in all roles; log empty responses

### DIFF
--- a/quasi-senate/src/council.rs
+++ b/quasi-senate/src/council.rs
@@ -104,7 +104,10 @@ pub async fn run_council(
     }
 
     // 10. Call the LLM
-    let call_result = crate::provider::call_model(entry, system, &user, 0.2, 8192).await?;
+    // Roster max_tokens overrides the role default: reasoning models spend part
+    // of their budget on thinking tokens before emitting any content.
+    let max_tokens = entry.max_tokens.unwrap_or(8192);
+    let call_result = crate::provider::call_model(entry, system, &user, 0.2, max_tokens).await?;
 
     // 11. Parse response
     let charter =

--- a/quasi-senate/src/drafter.rs
+++ b/quasi-senate/src/drafter.rs
@@ -129,7 +129,9 @@ pub async fn draft_issue(
 
     // 9. Call the LLM
     let system = crate::prompts::drafter_system_prompt();
-    let call_result = crate::provider::call_model(entry, system, &user, 0.7, 2048).await?;
+    // Roster max_tokens overrides the role default (see council.rs).
+    let max_tokens = entry.max_tokens.unwrap_or(2048);
+    let call_result = crate::provider::call_model(entry, system, &user, 0.7, max_tokens).await?;
     let raw = call_result.content.clone();
 
     // 10. Parse raw response — map failure to ParseFailure so pipeline can write telemetry.

--- a/quasi-senate/src/gate.rs
+++ b/quasi-senate/src/gate.rs
@@ -73,7 +73,10 @@ pub async fn gate_review(
     }
 
     // 4. Call the LLM
-    let call_result = crate::provider::call_model(entry, system, &user, 0.2, 1024).await?;
+    // Roster max_tokens overrides the role default (see council.rs). The 1024
+    // default is especially tight for reasoning models.
+    let max_tokens = entry.max_tokens.unwrap_or(1024);
+    let call_result = crate::provider::call_model(entry, system, &user, 0.2, max_tokens).await?;
     let raw = call_result.content.clone();
 
     // 5. Parse raw response — map failure to ParseFailure so pipeline can write telemetry.

--- a/quasi-senate/src/provider.rs
+++ b/quasi-senate/src/provider.rs
@@ -378,6 +378,23 @@ pub async fn call_model_with_format(
     let latency_ms = start_time.elapsed().as_millis() as u64;
     let retries = attempt_count.load(std::sync::atomic::Ordering::SeqCst).saturating_sub(1);
 
+    // An empty body is indistinguishable from a slow failure in the logs, and it
+    // is the shape reasoning models produce when something goes wrong upstream
+    // (refusal, filtered content, or output emitted only as reasoning tokens).
+    // Log it loudly with the request parameters needed to reproduce it, so the
+    // cause is diagnosable without re-running the whole pipeline.
+    if content.trim().is_empty() {
+        warn!(
+            model = model_id,
+            latency_ms = latency_ms,
+            retries = retries,
+            http_status = http_status,
+            requested_max_tokens = max_tokens,
+            prompt_bytes = system_prompt.len() + user_prompt.len(),
+            "LLM returned EMPTY content — call succeeded but produced nothing usable"
+        );
+    }
+
     info!(
         model = model_id,
         response_chars = content.len(),

--- a/quasi-senate/src/reviewer.rs
+++ b/quasi-senate/src/reviewer.rs
@@ -64,7 +64,9 @@ pub async fn review_solution(
     }
 
     // 4. Call the LLM
-    let call_result = crate::provider::call_model(entry, system, &user, 0.2, 2048).await?;
+    // Roster max_tokens overrides the role default (see council.rs).
+    let max_tokens = entry.max_tokens.unwrap_or(2048);
+    let call_result = crate::provider::call_model(entry, system, &user, 0.2, max_tokens).await?;
     let raw = call_result.content.clone();
 
     // 5. Parse raw response — map failure to ParseFailure so pipeline can write telemetry.


### PR DESCRIPTION
Two findings from the first live A-track run after the OpenRouter key was renewed.

## 1. Four of six roles ignored the roster's `max_tokens`

| role | before | reads `entry.max_tokens`? |
|---|---|---|
| council | hardcoded 8192 | ✗ |
| drafter | hardcoded 2048 | ✗ |
| **gate** | **hardcoded 1024** | ✗ |
| reviewer | hardcoded 2048 | ✗ |
| solver | `entry.max_tokens.unwrap_or(8192)` | ✓ |
| already_done | `entry.max_tokens.unwrap_or(2048)` | ✓ |

Setting `max_tokens` on a rotation entry **silently did nothing** for most of the pipeline — including the 32768 cap added for `kimi-k3` in #1105, which only ever applied to the solver.

This matters for reasoning models, which spend part of their budget thinking before emitting content — kimi-k3 used **50 of 66 completion tokens on reasoning** for a trivial prompt. The gate's 1024 is especially tight.

All four now use `entry.max_tokens.unwrap_or(<role default>)`, matching solver's long-standing behaviour, so roster caps mean what they say.

## 2. Empty responses were invisible

A model can return HTTP 200 with completely empty content, indistinguishable from a slow failure. The live run showed:

```
glm-5.2-together   latency_ms=13131   response_chars=0
```

…and nothing recorded why, so the draft attempt failed silently and moved on. `provider.rs` now emits a WARN carrying model, status, latency, requested `max_tokens` and prompt size.

## Correction on scope

My first hypothesis was that the empty response was **caused** by max_tokens starvation. I tested it directly and it is **false** — GLM-5.2 returns 1805 characters at `max_tokens=2048` with a 22.7 KB prompt:

```
max_tokens=2048  finish=stop  content_chars=1805  completion_tokens=642
max_tokens=8192  finish=stop  content_chars=2112  completion_tokens=888
```

**The root cause of the empty response is still unidentified.** This PR adds the instrumentation to find it, and fixes the `max_tokens` bug the investigation uncovered independently — the two are unrelated defects.

```
cargo test --workspace --all-targets                   ->  757 passed; 0 failed
cargo clippy --workspace --all-targets -- -D warnings  ->  clean
```