### PR TITLE
chore(senate): enable DeepSeek V4 Flash/Pro, park kimi-k3 on cost

### DIFF
--- a/quasi-senate/rotation.toml
+++ b/quasi-senate/rotation.toml
@@ -1692,7 +1692,7 @@ provider = "openrouter"
 license = "Unknown"
 origin = "Unknown"
 roles = ["a1_council", "a2_drafter", "a3_gate", "b1_solver", "b2_reviewer"]
-quarantined = true
+quarantined = false  # re-verified live 2026-08-01 after OpenRouter key renewal
 [[rotation]]
 id = "deepseek-v4-flash"
 model = "deepseek/deepseek-v4-flash"
@@ -1700,7 +1700,7 @@ provider = "openrouter"
 license = "Unknown"
 origin = "Unknown"
 roles = ["a1_council", "a2_drafter", "a3_gate", "b1_solver", "b2_reviewer"]
-quarantined = true
+quarantined = false  # re-verified live 2026-08-01 after OpenRouter key renewal
 [[rotation]]
 id = "qwen3.6-27b"
 model = "qwen/qwen3.6-27b"
@@ -1817,6 +1817,9 @@ roles = ["a2_drafter", "b1_solver", "b2_reviewer"]
 # deepseek-v4-flash omitted: the roster already carries
 # deepseek/deepseek-v4-flash with broader roles.
 max_tokens = 32768  # reasoning model: thinking tokens consume the budget before content
+quarantined = true  # parked on cost: $3/$15 per M tok vs deepseek-v4-flash
+                    # at $0.14/$0.28 for the same 1M context (54x output).
+                    # Un-quarantine if a task needs its reasoning depth.
 
 [[rotation]]
 id = "glm-5.2"


### PR DESCRIPTION
`deepseek-v4-flash` and `deepseek-v4-pro` were **already on the roster with all five roles**, but both quarantined — most likely during the window when the OpenRouter key was dead, since every OpenRouter call failed then. Both re-tested with live completions after the key renewal: correct answers in ~1s.

## Pricing (OpenRouter list, $ per million tokens)

| model | in | out | ctx |
|---|---|---|---|
| **deepseek-v4-flash** | **0.140** | **0.280** | 1M |
| qwen3-coder | 0.300 | 1.000 | 262K |
| deepseek-v4-pro | 0.435 | 0.870 | 1M |
| minimax-m3 | 0.300 | 1.200 | 1M |
| glm-5.2 | 0.760 | 2.389 | 1M |
| kimi-k3 | 3.000 | **15.000** | 1M |

Flash is **21× cheaper on input and 54× cheaper on output than kimi-k3**, at the same context length. On a representative senate call (~23K prompt, ~2K completion): roughly **$0.004 vs $0.10**.

## kimi-k3 parked

Not broken — it answers correctly. But it's the most expensive model in the roster by a wide margin, and because rotation sorts by **usage count**, a freshly added entry is picked **first** for every role it holds. Left active it would have become the default and drained the remaining credit. The roster comment says to un-quarantine it when a task genuinely needs its reasoning depth.

## Result

Active `b1_solver` pool: **9 models across 6 providers**.

Nothing will silently undo this — `quasi-roster.timer`, which runs the prune/quarantine job, is **disabled**.

```
cargo test --workspace --all-targets                   ->  757 passed; 0 failed
cargo clippy --workspace --all-targets -- -D warnings  ->  clean
```