### PR TITLE
docs: QUASI-as-a-harness one-pager; resolve the Pauli-Test name audit

### DIFF
--- a/docs/2026-08-01-quasi-as-a-harness.md
+++ b/docs/2026-08-01-quasi-as-a-harness.md
@@ -1,0 +1,105 @@
+# QUASI as a Harness
+
+*One-pager — 2026-08-01*
+
+## What it is
+
+QUASI is an **agent harness whose benchmark and whose product are the same artefact**. Most
+harnesses run models against a fixed task set and report a score. QUASI runs models against a
+live quantum-computing OS project: the tasks are generated from the project's own state, the
+solutions are merged into it, and the project's progress *is* the score. There is no held-out
+test set, because there is no set — there is a codebase that has to keep working.
+
+The measurement engine is the **Senate Loop**, a five-role pipeline over a roster of
+open-weight models:
+
+```
+A1 Council  → charter: current phase, frontier level, goal for the next batch
+A2 Drafter  → drafts one issue against that charter
+A3 Gate     → accepts or rejects the draft
+   ─────────────────────────────────────────────────────────
+B1 Solver   → produces a patch for an open issue
+B2 Reviewer → judges the patch before it becomes a PR
+```
+
+Every LLM call is written to Postgres telemetry (26 measurement points across 7 quality
+dimensions — JSON compliance, latency, retries, verdict reasoning, provider fidelity). Merged
+outcomes are appended to a hash-linked, tamper-evident ledger.
+
+## What makes it an unusual harness
+
+**1. Contamination resistance is structural, not procedural.**
+The language being written — *Ehrenfest* — is a **CBOR-encoded binary format with no text form
+and no file extension**. A human never reads an Ehrenfest program. There is no corpus, no Stack
+Overflow, no GitHub full of examples. A model cannot have memorised it, and cannot pattern-match
+its way through. Most benchmarks resist contamination by holding data back; this one resists it
+by asking for code in a language that did not exist before the project created it.
+
+**2. The oracle is physics, not opinion.**
+Above the scaffolding levels, success is defined by quantities measurable on real hardware: gate
+counts, circuit depth, decoherence budgets, Bell-state fidelity. A compiler pass that emits valid
+QASM3 with 10× redundant gates *fails* even with green CI. This closes the usual escape hatch
+where a model produces something that type-checks and satisfies a grader without doing the work.
+
+**3. The task ladder is traversal-gated.**
+Five capability levels, L0 scaffolding → L1 language foundations → L2 compiler construction →
+L3 hardware backends → L4 Turing-complete quantum programming. A model is "activated" at a level
+only after **6 CI-passing completions with no human edits** (the *Planck Quota*), verifiable from
+public commit history. The ceiling is open: L3–L4 are currently beyond any known model.
+
+*On the name: the Pauli-Test is named after **Wolfgang Pauli the critic**, not the Exclusion
+Principle. Pauli was physics' most meticulous and least diplomatic tester of ideas — the man who
+dismissed sloppy work as "not even wrong" and whom colleagues called the conscience of physics.
+That is precisely the standard this harness applies: a result is not accepted because it looks
+plausible, compiles, or passes a grader. It is accepted when it survives scrutiny that was trying
+to reject it. (`docs/pauli-test-audit.md` reads the name as a claim about the Exclusion Principle
+and argues the analogy fails; that critique addresses a meaning the name was never intended to
+carry.)*
+
+**4. It writes a compiler for the language it is being tested in.**
+The work under measurement is `afana` — a Rust compiler taking CBOR → typed AST → type check →
+ZX-calculus IR → OpenQASM, with noise constraints enforced as *compile-time type errors*. The
+harness is therefore measuring compiler construction for a language with no prior art, where the
+correctness criterion is downstream physical behaviour on a QPU.
+
+**5. It is a component of an operating system, not an application.**
+Below the compiler sits the **HAL Contract** — "the POSIX of QPUs" — and above it the intent that
+the OS kernel is *itself* an Ehrenfest program, where measurement outcomes are dispatching
+decisions. Tasks therefore inherit OS-level constraints: hardware abstraction must not leak into
+the compiler, and vendor SDKs are architecturally forbidden inside `afana`. Several architectural
+invariants are enforced by CI, not by convention.
+
+**6. Constrained model pool by policy.**
+Open-weight models only — no closed commercial APIs — with rotation across ~9 providers, fair
+assignment by usage count, provider diversity to prevent collusion between drafter and reviewer,
+and cost-tier preference so a free local model is used when its host is reachable.
+
+## Verification posture
+
+The loop is deliberately asymmetric about what blocks:
+
+| Check | In the autonomous loop | In CI |
+|---|---|---|
+| `cargo test --workspace --all-targets` | **blocking** | blocking |
+| `cargo clippy -- -D warnings` | advisory (fed back as signal) | **blocking** |
+
+A solver cannot fix a pre-existing lint in an unrelated crate, so a toolchain bump would
+otherwise block every unrelated task; a human seeing the same failure in CI can. Patches are also
+verified against the **merged** state, not the branch's own base — green-on-a-stale-base is the
+classic way a broken change looks healthy.
+
+## Generation is human-gated
+
+The loop **proposes**; it does not publish. Approved drafts are submitted as ActivityPub
+`quasi:Propose` activities to the board, which screens them (trivial rejected; small scope
+requires ≥2 components or ≥3 success criteria; near-duplicate titles rejected; open L0 proposals
+capped) and holds them pending. Only a human acceptance turns a proposal into a GitHub issue.
+This exists because an ungated generator produced formulaic near-duplicate issues at scale — the
+failure mode was in the *task supply*, not the solver.
+
+## Current state (2026-08-01)
+
+Deployed and verified end-to-end: draft → proposal → human accept → issue. Solver pool spans 9
+models across 6 providers. **The timers are disabled** — the loop runs only when invoked
+manually. The ledger currently reports `valid: false` from a single lost entry caused by an
+unlocked read-modify-write, tracked separately.

--- a/docs/pauli-test-audit.md
+++ b/docs/pauli-test-audit.md
@@ -1,6 +1,9 @@
 # Pauli-Test Audit — Hard Review
 
-**Status:** Working document. Do not paper over inconsistencies.
+**Status:** Historical. Findings 1 and 2 were accepted and `BENCHMARK.md` was corrected; this
+document audits the superseded version and is retained as the record of why the text changed.
+Verified 2026-08-01: `BENCHMARK.md` no longer contains any reference to the Exclusion Principle,
+and the "occupy a capability level" axiom has been removed. See the resolution note in §1.
 **Method:** Each claim in `BENCHMARK.md` is examined individually. Where the claim holds, it is confirmed. Where it fails or is unsupported, the failure mode is named exactly.
 
 ---
@@ -23,6 +26,22 @@ If you invoke Wolfgang Pauli as the standard of rigour, the first thing he would
 **The axiom can be reworded to be defensible** ("a model cannot *claim* a level it has not traversed") but that is a policy statement, not a physical law. The physical law analogy fails.
 
 **This is the most serious error in the document. It is in the name.**
+
+### Resolution (2026-08-01) — accepted, and the scope of the verdict narrowed
+
+`BENCHMARK.md` was corrected and no longer claims descent from the Exclusion Principle. The
+physics above stands: sequential traversal is Aufbau, not exclusion, and the old wording was
+wrong to invoke it.
+
+What the verdict got wrong is its *scope*. It concluded the error was "in the name". It was not —
+it was in the stated rationale. **The benchmark is named after Wolfgang Pauli the critic, not
+after his Exclusion Principle**: Ehrenfest's student, the least tolerant reviewer in the history
+of physics, whose *"nicht einmal falsch"* is the standard the benchmark applies. On that reading
+the name needs no physical-law analogy to carry it, and it fits a harness whose defining
+behaviour is attempting to reject its own results.
+
+`BENCHMARK.md` now states this directly, and labels the three-Pauls table "a mnemonic, not a
+derivation" — which is precisely the concession §2 asks for.
 
 ---
 


### PR DESCRIPTION
## New: `docs/2026-08-01-quasi-as-a-harness.md`

A one-page description of the system **as an agent harness** — specifically, one whose benchmark and product are the same artefact. There is no held-out test set because there is no set; there is a codebase that has to keep working.

The features that follow from that purpose:

- **Contamination resistance is structural, not procedural.** Ehrenfest is a CBOR-only language with no text form and no corpus. Most benchmarks resist contamination by holding data back; this one does it by asking for code in a language that did not exist before the project created it.
- **The oracle is physics.** Above scaffolding, success is gate counts, circuit depth and fidelity — valid QASM3 with 10× redundant gates fails even on green CI.
- **The ladder is traversal-gated** by the Planck Quota: 6 CI-passing completions, no human edits.
- **The work under test is a compiler for the language under test**, with noise budgets as compile-time type errors.
- **It is an OS component**, so tasks inherit invariants CI enforces.
- **Open-weight only**, with provider diversity preventing drafter/reviewer collusion.
- **Verification is deliberately asymmetric** — tests block everywhere; clippy blocks only in CI, where a human can act on it.
- **Generation is human-gated** — the loop proposes, it does not publish.

## Resolved: `docs/pauli-test-audit.md` §1

The audit's physics was **correct** — sequential traversal is Aufbau, not exclusion — and `BENCHMARK.md` was corrected in response. Verified today: it contains **zero** references to the Exclusion Principle, and the "occupy a capability level" axiom is gone.

What the verdict got wrong was its **scope**. It concluded the error was *"in the name"*. It was in the stated *rationale*. The benchmark is named after **Wolfgang Pauli the critic** — Ehrenfest's student, the least tolerant reviewer in the history of physics, whose *"nicht einmal falsch"* is the standard the benchmark applies — not after his Exclusion Principle. On that reading the name needs no physical-law analogy to carry it, and it fits a harness whose defining behaviour is attempting to reject its own results.

The audit is marked **Historical** rather than rewritten. It audits a superseded version and is the record of *why* the text changed — deleting it would erase the reason.

Docs only.