### PR TITLE
feat(senate): declared werner_judge role, disjoint from generators by test

### DIFF
--- a/quasi-senate/rotation.toml
+++ b/quasi-senate/rotation.toml
@@ -174,7 +174,7 @@ model = "mistralai/mistral-nemo"
 provider = "openrouter"
 license = "Apache-2.0"
 origin = "France / Mistral"
-roles = ["a1_council", "a3_gate", "b2_reviewer"]
+roles = ["a1_council", "a3_gate", "b2_reviewer", "werner_judge"]
 
 [[rotation]]
 id = "qwen2.5-coder-32b-hf"
@@ -252,7 +252,7 @@ model = "ai21/jamba-large-1.7"
 provider = "openrouter"
 license = "Jamba Open"
 origin = "Israel / AI21"
-roles = ["a1_council", "a3_gate", "b2_reviewer"]
+roles = ["a1_council", "a3_gate", "b2_reviewer", "werner_judge"]
 
 [[rotation]]
 id = "swallow-70b"
@@ -328,7 +328,7 @@ model = "google/gemma-3-27b-it"
 provider = "openrouter"
 license = "Gemma"
 origin = "US / Google DeepMind"
-roles = ["a1_council", "a3_gate", "b2_reviewer"]
+roles = ["a1_council", "a3_gate", "b2_reviewer", "werner_judge"]
 
 [[rotation]]
 id = "command-a"
@@ -346,7 +346,7 @@ model = "microsoft/phi-4"
 provider = "openrouter"
 license = "MIT"
 origin = "US / Microsoft Research"
-roles = ["a1_council", "a3_gate", "b2_reviewer"]
+roles = ["a1_council", "a3_gate", "b2_reviewer", "werner_judge"]
 max_context = 24000
 
 [[rotation]]
@@ -614,7 +614,7 @@ model = "mistralai/ministral-14b-2512"
 provider = "openrouter"
 license = "Unknown"
 origin = "Unknown"
-roles = ["b2_reviewer"]
+roles = ["b2_reviewer", "werner_judge"]
 quarantined = false
 [[rotation]]
 id = "ministral-8b-2512"
@@ -1402,7 +1402,7 @@ model = "mistral-vibe-cli-with-tools"
 provider = "mistral"
 license = "Unknown"
 origin = "Unknown"
-roles = ["a1_council", "b2_reviewer"]
+roles = ["a1_council", "b2_reviewer", "werner_judge"]
 quarantined = false
 [[rotation]]
 id = "open-mistral-nemo-mi"
@@ -1843,7 +1843,7 @@ model = "google/gemma-4-31b-it:free"
 provider = "openrouter"
 license = "Apache-2.0"
 origin = "USA / Google"
-roles = ["a1_council", "a3_gate", "b2_reviewer"]
+roles = ["a1_council", "a3_gate", "b2_reviewer", "werner_judge"]
 
 [[rotation]]
 id = "gpt-oss-20b-free"

--- a/quasi-senate/src/config.rs
+++ b/quasi-senate/src/config.rs
@@ -305,6 +305,7 @@ pub const LABEL_TAXONOMY: &str =
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::Role;
 
     fn ensure_init() {
         init_rotation();
@@ -335,6 +336,98 @@ mod tests {
         for entry in rotation() {
             assert!(!entry.roles.is_empty(), "Model {} has no roles", entry.id);
         }
+    }
+
+    /// The Werner integrity guarantee, enforced rather than documented.
+    ///
+    /// A judge must be drawn from a pool the generator can never draw from, so
+    /// no model may hold `werner_judge` alongside a generator role. Without
+    /// this test the property erodes silently: before it existed, 61 of 93
+    /// reviewer-capable entries were also generator-capable, and the only
+    /// anti-collusion was excluding the drafter's own model by id.
+    #[test]
+    fn werner_judges_are_disjoint_from_generators() {
+        ensure_init();
+        const GENERATOR_ROLES: [Role; 2] = [Role::A2Drafter, Role::B1Solver];
+        let mut violations: Vec<String> = Vec::new();
+        for entry in rotation() {
+            if !entry.roles.contains(&Role::WernerJudge) {
+                continue;
+            }
+            let also: Vec<String> = GENERATOR_ROLES
+                .iter()
+                .filter(|r| entry.roles.contains(r))
+                .map(|r: &Role| r.to_string())
+                .collect();
+            if !also.is_empty() {
+                violations.push(format!("{} also holds {}", entry.id, also.join(" + ")));
+            }
+        }
+        assert!(
+            violations.is_empty(),
+            "werner_judge must be disjoint from generator roles, but: {}",
+            violations.join("; ")
+        );
+    }
+
+    /// Reduce a provider-qualified model string to a coarse family key.
+    ///
+    /// `zai-org/GLM-5.2`, `z-ai/glm-5.2` and
+    /// `accounts/fireworks/models/glm-5p2` are the same underlying model served
+    /// three ways; role-level disjointness alone would let it both judge and
+    /// generate.
+    fn model_family(model: &str) -> String {
+        let tail = model.rsplit('/').next().unwrap_or(model).to_lowercase();
+        let alnum: String = tail
+            .chars()
+            .map(|c| if c.is_ascii_alphanumeric() { c } else { ' ' })
+            .collect();
+        // First two whitespace-separated chunks are enough to identify a family
+        // ("glm 5 2" -> "glm5", "deepseek v4 flash" -> "deepseekv4").
+        alnum.split_whitespace().take(2).collect::<Vec<_>>().concat()
+    }
+
+    /// Role-level disjointness is necessary but not sufficient: the same model
+    /// served by two providers can sit on both sides under different ids.
+    #[test]
+    fn werner_judge_models_do_not_also_generate() {
+        ensure_init();
+        const GENERATOR_ROLES: [Role; 2] = [Role::A2Drafter, Role::B1Solver];
+        let gen_families: HashSet<String> = rotation()
+            .iter()
+            .filter(|e| !e.quarantined && GENERATOR_ROLES.iter().any(|r| e.roles.contains(r)))
+            .map(|e| model_family(&e.model))
+            .collect();
+        let mut violations: Vec<String> = Vec::new();
+        for entry in rotation() {
+            if entry.quarantined || !entry.roles.contains(&Role::WernerJudge) {
+                continue;
+            }
+            let fam = model_family(&entry.model);
+            if gen_families.contains(&fam) {
+                violations.push(format!("{} ({} -> family '{}')", entry.id, entry.model, fam));
+            }
+        }
+        assert!(
+            violations.is_empty(),
+            "these Werner judges share a model family with an active generator: {}",
+            violations.join("; ")
+        );
+    }
+
+    /// A judge pool that is empty in practice is the same failure as no pool at
+    /// all — the reviewer errors out and the B-track stalls.
+    #[test]
+    fn werner_judge_pool_is_not_empty() {
+        ensure_init();
+        let judges = rotation()
+            .iter()
+            .filter(|e| !e.quarantined && e.roles.contains(&Role::WernerJudge))
+            .count();
+        assert!(
+            judges > 0,
+            "no active model holds the werner_judge role; the B-track reviewer cannot run"
+        );
     }
 
     #[test]

--- a/quasi-senate/src/reviewer.rs
+++ b/quasi-senate/src/reviewer.rs
@@ -31,8 +31,25 @@ pub async fn review_solution(
     last_provider: Option<&str>,
     dry_run: bool,
 ) -> Result<(ReviewVerdict, &'static RotationEntry, crate::provider::CallResult)> {
-    // 1. Pick model
-    let entry = crate::rotation::pick_model(&Role::B2Reviewer, exclude, counts, last_provider)?;
+    // 1. Pick model from the Werner judge pool.
+    //
+    // Judges are drawn from `werner_judge`, which is disjoint from the
+    // generator roles by construction and by test. The previous behaviour
+    // picked from `b2_reviewer` and relied on `exclude` to keep the drafter's
+    // own model out — anti-collusion for exactly one model, while 61 of 93
+    // reviewer-capable entries were also generator-capable.
+    //
+    // No fallback to `b2_reviewer`: if the judge pool is empty that is a roster
+    // misconfiguration, and failing loudly is better than silently reviewing
+    // with a model that also writes code.
+    let entry = crate::rotation::pick_model(&Role::WernerJudge, exclude, counts, last_provider)
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "no eligible Werner judge (the review pool is disjoint from the \
+                 generator pool by design; grant `werner_judge` to reviewer-only \
+                 models in rotation.toml): {e}"
+            )
+        })?;
 
     // 2. Build prompts
     let system = crate::prompts::reviewer_system_prompt();

--- a/quasi-senate/src/types.rs
+++ b/quasi-senate/src/types.rs
@@ -15,6 +15,15 @@ pub enum Role {
     A3Gate,
     B1Solver,
     B2Reviewer,
+    /// Werner judge — the disjoint review pool.
+    ///
+    /// A model holding this role must NOT hold any generator role
+    /// (`a2_drafter`, `b1_solver`). The separation is the integrity
+    /// guarantee of the Werner protocol: a judge is drawn from a pool the
+    /// generator can never draw from, so a model cannot review work produced
+    /// by itself or by a sibling of itself. `config::tests::werner_judges_are_disjoint_from_generators`
+    /// enforces this, so the property cannot erode silently as roles change.
+    WernerJudge,
 }
 
 impl std::fmt::Display for Role {
@@ -25,6 +34,7 @@ impl std::fmt::Display for Role {
             Role::A3Gate => write!(f, "A.3 Gate"),
             Role::B1Solver => write!(f, "B.1 Solver"),
             Role::B2Reviewer => write!(f, "B.2 Reviewer"),
+            Role::WernerJudge => write!(f, "Werner Judge"),
         }
     }
 }


### PR DESCRIPTION
The B.2 reviewer picked from `b2_reviewer` and relied on `exclude` to keep the drafter's own model out. That is anti-collusion for **exactly one model id**.

Measured against the live roster:

| pool | count |
|---|---|
| generator-capable (drafter or solver) | 72 |
| reviewer-capable | 93 |
| **in both** | **61 (66%)** |

A model could draft an issue and review a patch for it, and the pools were free to drift further together with no signal.

## The change

Werner's guarantee is categorical rather than incidental: **the judge is drawn from a pool the generator can never draw from.** This *declares* that pool rather than deriving it, so it cannot erode silently.

- `Role::WernerJudge` (`werner_judge`) added.
- `reviewer.rs` picks from it, with **no fallback** to `b2_reviewer` — an empty judge pool is a misconfiguration, and failing loudly beats silently reviewing with a model that also writes code. The error message names the fix.

## Three enforcing tests

- `werner_judges_are_disjoint_from_generators` — no entry holds `werner_judge` alongside `a2_drafter`/`b1_solver`
- `werner_judge_models_do_not_also_generate` — role disjointness is necessary but **not sufficient**: the same model served by two providers sits on both sides under different ids. GLM-5.2 is reviewer-only on OpenRouter *and* a solver on Together and Fireworks. This compares coarse model families.
- `werner_judge_pool_is_not_empty` — an empty pool stalls the B-track

**The family test earned its place immediately.** My first judge set — `llama3.3`, `hermes-4-70b`, `mistral-medium` — all collided with active *drafters*; I'd only checked against solvers. Once model family is considered, just **12 of 32** reviewer-only entries are genuinely disjoint.

## Judges granted

All open-weight, none sharing a family with any active generator:

`phi-4`, `gemma-4-31b-free`, `gemma-3-27b-or`, `jamba`, `mistral-nemo`, `ministral-14b-2512`, `mistral-vibe-cli-with-tools-mi`

## Known limitation

Six of seven judges are on OpenRouter — an OpenRouter outage stops judging. Widening onto groq/together/cerebras needs reviewer-only entries there that don't collide with a generator family.

```
cargo test --workspace --all-targets                   ->  760 passed; 0 failed
cargo clippy --workspace --all-targets -- -D warnings  ->  clean
cargo build -p quasi-senate --release                  ->  ok
```