### PR TITLE
feat(werner): version the shadow judge, unblock its collector, drop Claude

### DIFF
--- a/docs/2026-05-28-werner-catastrophic-forgetting-as-feature.md
+++ b/docs/2026-05-28-werner-catastrophic-forgetting-as-feature.md
@@ -1,0 +1,468 @@
+# Werner: Catastrophic Forgetting as a Feature in LLM-as-Judge Pipelines
+
+**Daniel Hinderink** · Valiant Quantum UG
+*Methods note, May 2026 — work in progress*
+
+---
+
+## Abstract
+
+LLM-as-judge pipelines are increasingly deployed to evaluate the output
+of other AI systems. The dominant design pattern — in-context few-shot
+voting, sometimes with iterative refinement against a rubric — inherits
+a well-known failure mode: *judges drift toward the distribution they
+judge.* This note describes **Werner**, a small operational system that
+inverts a related failure mode from the continual-learning literature:
+**catastrophic forgetting**. Where continual learning treats forgetting
+as a bug to be engineered away, Werner uses **deliberate, structural
+forgetting** as the integrity guarantee of an LLM-based verifier. The
+system has been running in shadow against an autonomous AI-driven
+software-engineering pipeline for ~3 months, producing 601 cryptographically
+chained verdicts on programmatically-generated GitHub issue drafts. We
+describe the protocol, argue for the inversion, and discuss the
+empirical limitations the observed distribution surfaces.
+
+---
+
+## 1. Motivation
+
+Across 2023–2026, autonomous AI systems that *generate* artefacts —
+code, scientific hypotheses, GitHub issues, research outlines, legal
+filings — have outpaced the systems that *verify* those artefacts. The
+default verifier today is "another LLM with a rubric" (Zheng et al.,
+2023; Bai et al., 2022; Chiang & Lee, 2023). Such verifiers are usually
+deployed in one of three configurations:
+
+1. **Single-call judge with in-context examples.** The rubric and a
+   handful of labelled exemplars are included in the prompt. The judge
+   returns a verdict.
+2. **Ensemble vote.** Multiple judges (sometimes the same model with
+   different prompts) vote; majority wins.
+3. **Self-refinement / iterative critique.** The judge revises its
+   verdict over multiple turns, sometimes accessing earlier verdicts as
+   context.
+
+All three share a property: **the judge's context window contains
+information about the population being judged**. For a one-off
+evaluation this is fine. For a verifier deployed continuously against
+the *output of a single, persistent, possibly-adversarial generator*,
+this becomes a problem. Three concrete failure modes emerge in
+production:
+
+- **Approval drift.** A judge presented with thousands of similar
+  drafts from the same generator gradually learns its idiosyncratic
+  vocabulary as "normal," then approves more.
+- **Distributional contamination.** The judge's exemplars come from the
+  generator's earlier output, creating a self-licensing loop.
+- **Social inheritance.** Where multiple judges share infrastructure
+  (same provider, similar fine-tuning corpora, overlapping RLHF
+  preferences) they correlate in failure: agreement is not independence.
+
+These failure modes are familiar from human institutional analogy: an
+internal review committee that *only* reviews the work of one
+department tends to drift toward that department's norms. The solution
+in human institutions is the *external auditor* — explicitly
+**stateless** with respect to prior reviews, **independent** of the
+audited body's resources, and producing a **tamper-evident** record.
+
+Werner is the LLM analogue.
+
+---
+
+## 2. The Werner Protocol
+
+Werner consists of three components:
+
+```
+shadow_collector.py   →  queue.jsonl  →  shadow_evaluator.py  →  verdicts/{n}.json
+                                                              →  verdict-log.jsonl
+                                                              →  chain.jsonl
+```
+
+### 2.1 Collector
+
+A polling daemon reads from the upstream generator's audit ledger
+(ActivityPub-style append-only event log; for the deployment described
+here, the QUASI Senate ledger). On each `issue_generated` event it
+appends a queue entry recording the issue's identifier and source URL.
+The collector maintains no opinion about the issue's content — it is a
+pure event-to-task adapter.
+
+### 2.2 Evaluator
+
+The evaluator consumes unevaluated queue entries one at a time. For each
+entry it:
+
+1. Fetches the issue title + body from the upstream system of record.
+2. Issues a **single, stateless** chat-completion call to an LLM with a
+   fixed rubric prompt (Appendix A). No conversation history. No
+   in-context exemplars. No retrieval over prior verdicts.
+3. Parses the JSON verdict against a closed taxonomy:
+   `{well-specified, underspecified, ambiguous, trivial, unsolvable}`
+   with a confidence in `[0, 1]` and a difficulty tier in `{1..5}`.
+4. Writes the verdict to a per-issue JSON file.
+5. Appends a *hash-chain* entry recording `(seq, issue_number,
+   sha256(verdict), prev_hash, sha256(verdict||prev_hash))`.
+
+The judge provider is configured through a fallback chain
+(Anthropic → OpenRouter → Groq, in deployment); the **judge model is
+chosen from a fixed set outside the generator's rotation pool** to
+avoid distributional contamination.
+
+### 2.3 Hash chain
+
+Each verdict file is a *sealed* artefact: `verify` walks the chain from
+genesis and confirms that no verdict file has been modified since its
+verdict was issued. Importantly, the chain is **not** used as context
+for future verdicts — the evaluator never reads `chain.jsonl` at
+judging time. Its sole purpose is post-hoc audit.
+
+---
+
+## 3. The Inversion: Catastrophic Forgetting as a Feature
+
+Catastrophic forgetting (CF; McCloskey & Cohen, 1989) is the phenomenon
+where a neural network trained sequentially on multiple tasks loses
+performance on earlier tasks. The continual-learning literature has
+treated CF as the central obstacle, producing elastic-weight
+consolidation (Kirkpatrick et al., 2017), gradient episodic memory
+(Lopez-Paz & Ranzato, 2017), replay buffers, and so on.
+
+Werner reframes the same phenomenon as a **desired property** when the
+artefact is a verifier rather than a learner.
+
+### 3.1 Why a verifier wants to forget
+
+A verifier's job is to apply a *fixed* standard to a *variable*
+population. If the verifier remembers prior cases, three things
+happen:
+
+- It begins to apply the *empirical distribution* of prior cases as a
+  norm. ("Most drafts I've seen lately are like this, so this is
+  fine.") This is approval drift.
+- It begins to **negotiate** with the generator across time. A
+  generator that produces gradually more ambitious drafts can move the
+  verifier's threshold along with it. The verifier is captured by the
+  Overton window of its own history.
+- It begins to **agree with itself** more than the rubric. Self-
+  consistency replaces external standard.
+
+A verifier that *cannot remember* its prior verdicts is immune to all
+three. Each call is a clean read of the rubric against the artefact.
+
+### 3.2 Distinguishing this from naïve statelessness
+
+It is not novel to call an LLM statelessly — almost every API call is
+stateless at the conversation level. The novelty lies in the **system
+design commitments** that follow from treating CF as a feature:
+
+1. **No retrieval-augmented judging.** No vector store of prior
+   verdicts is consulted at decision time. (This is a non-trivial
+   self-denial: RAG-over-verdicts is the obvious thing to do, and it is
+   wrong here.)
+2. **No fine-tuning on the judged population.** The judge model is
+   fixed; it is never adapted to the generator's idiom.
+3. **No in-context examples drawn from the generator.** The rubric is
+   self-contained.
+4. **Judge-provider isolation.** Whichever LLM serves the judge is
+   drawn from a set with no overlap with the generator's pool — to
+   avoid shared pretraining/RLHF correlation.
+
+The hash chain is then the **ex-post** integrity mechanism. The
+forgetting is the **ex-ante** integrity mechanism. They are
+complementary: forgetting prevents the judge from biasing toward its
+prior outputs; the chain prevents anyone from later editing the
+historical record.
+
+### 3.3 Costs
+
+Forgetting is not free. A stateless judge cannot:
+
+- Catch *patterns across drafts* (e.g., "the same architectural
+  violation has appeared in 30 issues this month — this is a systemic
+  generator bug").
+- Lower its own variance by averaging over prior judgments on similar
+  inputs.
+- Recognise that a returning rejected issue has been re-drafted by the
+  generator.
+
+These are real losses. Werner accepts them because, in the deployment
+context (autonomous AI generating issues against an open-source
+codebase), the integrity loss from drift was empirically larger than
+the integrity gain from pattern-recognition. We did not have a way to
+quantify this trade-off before deployment; the system was built on the
+conjecture that drift would dominate. See §5 for the post-hoc
+evaluation.
+
+---
+
+## 4. Implementation Notes
+
+The implementation is intentionally small: ~600 lines of stdlib Python
+across `shadow_collector.py` and `shadow_evaluator.py`. No
+dependencies beyond `urllib.request` and standard hashing. Postgres is
+not used. The rationale is twofold:
+
+- **Auditability**: a 600-line system that runs from any Python 3.10+
+  install has a smaller attack surface than a framework-based
+  alternative. Anyone reading this paper can replicate Werner in an
+  afternoon.
+- **Cost discipline**: each verdict requires exactly one inference
+  call. At Anthropic Haiku 4.5 prices (~$0.0005 / 1K input tokens) the
+  601 verdicts in our deployment cost approximately $0.30 cumulative.
+
+The fallback provider chain matters operationally — Werner has weathered
+two provider outages without losing throughput, switching from
+Anthropic to OpenRouter to Groq transparently. Importantly, when the
+chain falls back, **the rubric prompt is unchanged**: the same JSON
+shape is requested regardless of provider, preserving the comparability
+of verdicts across the corpus.
+
+The hash chain implementation is the simplest possible: each entry
+records `chain_hash = sha256(verdict_hash || prev_hash)`, starting from
+the string `"genesis"`. Verification walks linearly from start to end.
+We do not claim cryptographic novelty here — this is the textbook
+construction. The contribution is *applying* the construction to LLM
+verdicts, which to our knowledge has not been done in the LLM-as-judge
+literature.
+
+---
+
+## 5. Empirical Observations
+
+Werner has been running against the QUASI Senate (an autonomous
+issue-drafting and code-generation pipeline for an open-source Rust
+compiler project) from 2026-03-09 through 2026-05-10, when the senate
+was paused for refactoring.
+
+**Corpus statistics:**
+
+| Quantity | Value |
+|---|---|
+| Verdicts issued | 601 |
+| Chain entries | 601 |
+| Chain integrity (entries 0–595) | Intact |
+| Chain integrity (entries 596–600) | **Sequence drift** (see §5.3) |
+| Date range | 2026-03-09 to 2026-05-10 |
+| Mean judge confidence | 0.88 |
+
+**Verdict distribution:**
+
+| Verdict | Count | % |
+|---|---|---|
+| well-specified | 583 | 97.0% |
+| underspecified | 18 | 3.0% |
+| ambiguous | 0 | 0.0% |
+| trivial | 0 | 0.0% |
+| unsolvable | 0 | 0.0% |
+
+**Difficulty tier distribution:**
+
+| Tier | Description | Count | % |
+|---|---|---|---|
+| 1 | trivial (< 30 min) | 23 | 3.8% |
+| 2 | easy (< 2 h) | 178 | 29.6% |
+| 3 | medium (half day) | 232 | 38.6% |
+| 4 | hard (1–3 days) | 167 | 27.8% |
+| 5 | very hard (> 3 days) | 1 | 0.2% |
+
+### 5.1 The 97% well-specified rate
+
+The skew in the verdict distribution is the most uncomfortable finding
+in the corpus. Two readings are admissible:
+
+**Reading A — the senate drafts well.** The senate's drafting role
+(A2_drafter) is itself gated by a separate intra-senate evaluator
+(A3_gate), which approves ~62% of drafts (independent measurement from
+the senate's own telemetry). Issues that *reach* Werner have already
+passed A3, so the population is pre-filtered. A 97% well-specified rate
+on a pre-filtered population is plausible.
+
+**Reading B — the judge is too lenient.** The Anthropic Haiku 4.5 model
+used as the primary judge may apply a low bar to "well-specified."
+Inspection of borderline cases (sampled from the 18 `underspecified`
+verdicts) shows the judge correctly identifies issues missing
+acceptance criteria or with vague scope. Inspection of borderline
+*approved* cases shows several that a human engineer would also call
+underspecified — suggesting calibration drift away from the rubric.
+
+We cannot at present distinguish these readings without a human
+gold-standard re-evaluation. **This is the next empirical step**: hand-
+label a stratified sample of 100 issues and compute Werner's agreement
+rate against human ground truth. We expect agreement to be in the
+65–80% range; rates substantially higher would lend support to A, lower
+to B.
+
+### 5.2 No `ambiguous` / `trivial` / `unsolvable` verdicts
+
+Three rubric categories were *never* used. This could mean those
+categories are dead taxonomy or that the senate's drafting filter
+upstream of Werner already removes them. Either way, the rubric should
+be revised: forced categorisation into unused buckets adds no
+information.
+
+### 5.3 Chain sequence drift in entries 596–600
+
+Verification reports a sequence-counter mismatch in the final 5
+entries: expected `[596..600]`, observed `[591..595]`. This appears to
+be a write-race introduced when the senate was paused on 2026-05-10 —
+two concurrent evaluator invocations both incremented from a stale
+counter snapshot. The verdict hashes themselves remain consistent with
+the named verdict files (no `SEAL BROKEN` errors), so the integrity
+goal is not breached, only the linear-order claim is.
+
+This is a real-world stress test of the chain design: it caught a
+concurrency bug that would have been silently inserted otherwise. We
+view this as evidence the chain works, not against it. The fix
+(file-locking around the counter increment) is straightforward.
+
+---
+
+## 6. Discussion: When This Design Wins
+
+Werner's bet is that **integrity dominates pattern-recognition** when
+the verifier sits downstream of a high-throughput autonomous
+generator. Cases where this bet is correct:
+
+- **Continuous shadow review.** A generator producing artefacts faster
+  than humans can review, where the verifier exists to catch drift, not
+  to authorise.
+- **Adversarial generators.** Where the generator may explicitly or
+  implicitly try to find what the verifier accepts and exploit it.
+- **Audit-trail-required decisions.** Where post-hoc proof of "this
+  verdict was applied to this artefact" is more valuable than
+  fine-grained accuracy.
+- **Distributional shift.** Where the generator's output is expected to
+  change over time (e.g., as its own model is upgraded), and the
+  verifier must apply a stable standard rather than tracking the
+  generator's evolution.
+
+Cases where Werner's design is **inappropriate**:
+
+- **Low-volume, high-stakes decisions.** Werner is wrong for medical or
+  legal verdicts where each artefact warrants deep, context-rich
+  review.
+- **Cooperative generators.** When the generator is collaborating in
+  good faith, a stateful verifier that learns the generator's strengths
+  and weaknesses is more useful.
+- **Where pattern detection matters more than per-artefact integrity.**
+  Werner cannot tell you "the same bug keeps appearing." A different
+  system layer must do that.
+
+---
+
+## 7. Limitations
+
+- **Empirical scope.** 601 verdicts on one generator over 60 days. The
+  argument here is methodological; the population sampled is small and
+  homogeneous.
+- **Pretraining contamination.** A "stateless" LLM is stateless only at
+  the *conversation* level. Its weights still encode all of
+  pretraining. We do not address contamination at that level.
+- **Judge calibration.** The 97% well-specified finding suggests the
+  judge model may be too permissive; this is a calibration issue, not
+  a protocol failure, but it is unaddressed.
+- **No comparative study.** We have not run Werner side-by-side with a
+  stateful judge on the same corpus. The relative integrity claim is
+  argued rather than measured.
+
+---
+
+## 8. Future Work
+
+1. **Human gold-standard re-evaluation.** Stratified hand-labelling of
+   ~100 issues; compute agreement.
+2. **Rubric pruning.** Drop unused taxonomy categories; possibly add
+   finer-grained categories drawn from the operator's failure typology.
+3. **Comparative deployment.** Run a stateful judge (with retrieval over
+   prior verdicts) in parallel with Werner; measure drift over time.
+4. **Multi-judge isolation.** Use multiple judges from disjoint provider
+   pools; require disagreement to halt evaluation (rather than majority
+   vote).
+5. **Extension to verdicts on solver/reviewer outputs.** Werner
+   currently judges *issues* (drafted artefacts). A parallel tool
+   (separate naming) is being prototyped to perform post-mortem
+   categorisation of *failed solver/reviewer outputs* — explicitly
+   non-Werner because it lacks the stateless-judging commitment and
+   exists for one-off analysis rather than continuous audit.
+
+---
+
+## 9. Conclusion
+
+We have described Werner, an LLM-as-judge system that treats
+catastrophic forgetting as a deliberate architectural property rather
+than a phenomenon to be engineered away. The contribution is not the
+underlying components — stateless LLM calls and hash-chained logs both
+exist — but the **deliberate framing** that, for a verifier downstream
+of an autonomous generator, *integrity through forgetting* dominates
+*accuracy through accumulation*. Three months of shadow deployment have
+produced a verdict corpus that is currently underused and a chain
+mechanism that has detected one concurrency bug it was designed to
+detect. The empirical question — whether the 97% well-specified rate
+reflects upstream filtering or judge lenience — is open and is the next
+piece of work.
+
+The broader claim is that as autonomous AI systems become primary
+authors, **the verifiers must be designed to forget**. Memory is the
+mechanism by which judges are captured.
+
+---
+
+## Appendix A: The Judge Prompt
+
+```
+You are a senior software engineering issue quality evaluator.
+Assess the given GitHub issue for clarity, actionability, and difficulty.
+
+Return a JSON object with exactly these fields:
+{
+  "verdict": "<well-specified|underspecified|ambiguous|trivial|unsolvable>",
+  "confidence": <0.0-1.0>,
+  "difficulty_tier": <1-5>,
+  "signals": ["list", "of", "quality", "signals"],
+  "reasoning": "One paragraph explaining the verdict."
+}
+
+Verdict definitions:
+- well-specified: Clear problem, clear acceptance criteria, implementable
+- underspecified: Missing key details needed to implement (unclear scope,
+                  missing context)
+- ambiguous: Could be interpreted multiple ways, contradictory requirements
+- trivial: Too simple to be meaningful (typo fix, one-line change)
+- unsolvable: Fundamentally impossible or contradictory
+
+Difficulty tiers:
+1 = trivial (< 30 min), 2 = easy (< 2h), 3 = medium (half day),
+4 = hard (1-3 days), 5 = very hard (> 3 days)
+
+Return ONLY the JSON object, no markdown fences, no extra text.
+```
+
+## Appendix B: Reproducibility
+
+Werner's code is ~600 lines of stdlib Python. The deployment described
+here runs as a `oneshot` systemd service on a single Debian VM. The
+verdict log and hash chain are append-only files; both are durably
+stored on disk and can be redistributed for independent verification.
+
+A clean room replication for a new generator requires:
+
+1. An ActivityPub-style event log or equivalent stream of "artefact
+   generated" events.
+2. A judge LLM accessible via a chat-completions HTTP API.
+3. The two scripts (`shadow_collector.py`, `shadow_evaluator.py`) ported
+   to read the new event stream.
+
+No GPU, no database, no model fine-tuning.
+
+---
+
+## References
+
+- Bai et al. (2022). *Constitutional AI: Harmlessness from AI Feedback.* arXiv:2212.08073.
+- Chiang & Lee (2023). *Can Large Language Models Be an Alternative to Human Evaluations?* ACL 2023.
+- Kirkpatrick et al. (2017). *Overcoming catastrophic forgetting in neural networks.* PNAS 114(13).
+- Lopez-Paz & Ranzato (2017). *Gradient Episodic Memory for Continual Learning.* NeurIPS 2017.
+- McCloskey & Cohen (1989). *Catastrophic interference in connectionist networks: The sequential learning problem.* Psychology of Learning and Motivation 24.
+- Zheng et al. (2023). *Judging LLM-as-a-Judge with MT-Bench and Chatbot Arena.* NeurIPS 2023.

--- a/docs/2026-08-01-quasi-as-a-harness.md
+++ b/docs/2026-08-01-quasi-as-a-harness.md
@@ -69,7 +69,18 @@ decisions. Tasks therefore inherit OS-level constraints: hardware abstraction mu
 the compiler, and vendor SDKs are architecturally forbidden inside `afana`. Several architectural
 invariants are enforced by CI, not by convention.
 
-**6. Constrained model pool by policy.**
+**6. The verifier is structurally separated from the generator.**
+Review is not performed by "another model from the pool" — it is performed from a **declared
+disjoint pool**. A model holding the `werner_judge` role may hold no generator role, and the
+separation is enforced by test rather than by convention, including at model-family level so the
+same model served by two providers cannot sit on both sides. Alongside this runs **Werner**, an
+independent shadow judge whose integrity guarantee is *deliberate statelessness*: every verdict is
+a single context-free call with no history, no exemplars and no retrieval over prior verdicts, so
+the judge cannot drift toward the distribution it judges. Verdicts are sealed in a hash chain that
+is never read at judging time — audit only. Before this was declared, 61 of 93 reviewer-capable
+models were also generator-capable.
+
+**7. Constrained model pool by policy.**
 Open-weight models only — no closed commercial APIs — with rotation across ~9 providers, fair
 assignment by usage count, provider diversity to prevent collusion between drafter and reviewer,
 and cost-tier preference so a free local model is used when its host is reachable.
@@ -99,7 +110,14 @@ failure mode was in the *task supply*, not the solver.
 
 ## Current state (2026-08-01)
 
-Deployed and verified end-to-end: draft → proposal → human accept → issue. Solver pool spans 9
-models across 6 providers. **The timers are disabled** — the loop runs only when invoked
-manually. The ledger currently reports `valid: false` from a single lost entry caused by an
-unlocked read-modify-write, tracked separately.
+Deployed and verified end-to-end: draft → proposal → human accept → issue → Werner verdict. The
+last link was restored on 2026-08-01: Werner's collector keyed only on the legacy
+`issue_generated` ledger event, so when the senate timers stopped on 2026-05-10 it polled an empty
+queue for three months. It now also collects `proposal_accepted`, and issued verdict 602 — its
+first since May, and the first ever on an issue that reached GitHub through human approval rather
+than auto-publication.
+
+Solver pool spans 9 models across 6 providers; the judge pool is 7, disjoint by construction.
+**The timers are disabled** — the loop runs only when invoked manually. The ledger reports
+`valid: false` from a single lost entry caused by an unlocked read-modify-write, tracked
+separately.

--- a/quasi-senate/werner/README.md
+++ b/quasi-senate/werner/README.md
@@ -1,0 +1,76 @@
+# Werner — the shadow judge
+
+Werner is an independent verifier that judges the senate's output without ever
+becoming part of it. Its integrity guarantee is **deliberate statelessness**:
+each verdict is a single, fresh, context-free call. There is no conversation
+history, no in-context exemplars, and no retrieval over prior verdicts — so the
+judge cannot drift toward the distribution it is judging.
+
+Design note: `docs/2026-05-28-werner-catastrophic-forgetting-as-feature.md`.
+
+## Components
+
+```
+ledger  →  shadow_collector.py  →  shadow-queue.jsonl
+                                       ↓
+                               shadow_evaluator.py  →  verdicts/{n}.json
+                                                    →  verdict-log.jsonl
+                                                    →  chain.jsonl   (hash chain)
+```
+
+- **`shadow_collector.py`** — polls the quasi-board ledger and queues any event
+  meaning "a judgeable GitHub issue now exists". It holds no opinion about
+  content; it is a pure event-to-task adapter.
+- **`shadow_evaluator.py`** — A-track judge. Scores issue *specification quality*
+  against a fixed rubric and a closed taxonomy
+  (`well-specified | underspecified | ambiguous | trivial | unsolvable`), with a
+  confidence and a difficulty tier.
+- **`btrack_evaluator.py`** — B-track post-mortem. Forensic categorisation of
+  *failed* solver/reviewer attempts drawn from `senate_telemetry`, against a
+  fixed 10-category failure typology. Read-only; safe to run with the senate
+  timers stopped.
+- **`config.py`** — paths and polling interval. No secrets; API keys come from
+  the environment.
+
+## Which ledger events are collected
+
+```python
+ISSUE_EVENT_TYPES = ("issue_generated", "proposal_accepted")
+```
+
+`proposal_accepted` is the current path: the senate only *proposes*, and the
+board opens the issue when a human accepts, recording `issue_number` directly.
+`issue_generated` is retained because it is still emitted under the
+`SENATE_DIRECT_ISSUES=1` rollback lever, which carries an `issue_url` instead.
+
+Collecting on only the first of these is what left Werner idle from 2026-05-10,
+when the senate timers were stopped, until 2026-08-01: the collector ran for
+three months against a queue that could never fill.
+
+## Judge selection
+
+**Open-weight models only**, and drawn from a pool disjoint from the senate's
+generators — a judge must not be able to review work produced by itself or by a
+sibling of itself. The Rust side enforces the same property for the B.2 reviewer
+via the `werner_judge` role and
+`config::tests::werner_judge_models_do_not_also_generate`.
+
+Current chain: Groq (`llama-3.3-70b-versatile`) → OpenRouter (`microsoft/phi-4`).
+The former Anthropic leg was removed; both of its paths routed to Claude, which
+is a commercial closed-weight model and not permitted in an automated pipeline
+here.
+
+## The hash chain
+
+Every verdict is sealed: `chain.jsonl` records
+`(seq, issue_number, sha256(verdict), prev_hash, sha256(verdict || prev_hash))`.
+The chain is **never read at judging time** — feeding it back would reintroduce
+exactly the accumulated context the design removes. Its only purpose is
+post-hoc audit.
+
+## Deployment
+
+Runs on Camelot from `/home/vops/werner-shadow/`, as
+`werner-collector.service` (continuous poll) and `werner-evaluator.timer`
+(batch, every 30 min). This directory is the version-controlled source; the
+deployed copy was previously untracked.

--- a/quasi-senate/werner/btrack_evaluator.py
+++ b/quasi-senate/werner/btrack_evaluator.py
@@ -1,0 +1,604 @@
+#!/usr/bin/env python3
+"""Werner B-track Post-Mortem Evaluator.
+
+Sibling to Werner's A-track shadow_evaluator. Where the A-track judges
+issue-draft quality, this one performs a forensic review of *failed*
+B-track attempts (B.1 solver json_fail / B.2 reviewer rejected) drawn
+from `senate_telemetry`.
+
+Output: a per-row failure category drawn from a fixed typology, plus a
+short summary report aggregating the population. Read-only against the
+senate; safe to run with senate timers stopped.
+
+Usage:
+    python3 werner_btrack_evaluator.py --batch 20    # analyse 20 rows
+    python3 werner_btrack_evaluator.py --report      # summarise existing verdicts
+    python3 werner_btrack_evaluator.py --since '2026-04-01'  # restrict window
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+log = logging.getLogger("werner-btrack")
+
+BASE_DIR = Path("/home/vops/werner-shadow")
+VERDICTS_DIR = BASE_DIR / "verdicts-btrack"
+LOG_FILE = BASE_DIR / "verdict-log-btrack.jsonl"
+
+DATABASE_URL = os.environ.get(
+    "DATABASE_URL",
+    "postgres://quasi_senate:qs_bench_2026@localhost/quasi_senate",
+)
+ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY", "")
+OPENROUTER_API_KEY = os.environ.get("OPENROUTER_API_KEY", "")
+GROQ_API_KEY = os.environ.get("GROQ_API_KEY", "")
+MISTRAL_API_KEY = os.environ.get("MISTRAL_API_KEY", "")
+TOGETHER_API_KEY = os.environ.get("TOGETHER_API_KEY", "")
+GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN", "")
+GITHUB_REPO = os.environ.get("GITHUB_REPO", "ehrenfest-quantum/quasi")
+
+# Canonical failure categories. Anything outside this set is normalised
+# to "other" in post-processing.
+CATEGORIES = [
+    "parse_failure",            # malformed JSON / unparseable shape
+    "schema_mismatch",          # valid JSON but wrong keys / structure
+    "hallucinated_symbol",      # referenced functions/types/files that do not exist
+    "off_target",               # patch was unrelated to the assigned issue
+    "incomplete_implementation", # partial work that doesn't satisfy ACs
+    "test_only_no_impl",        # added tests without implementation behind them
+    "architectural_violation",  # broke CLAUDE.md invariants (Python in afana/, etc.)
+    "domain_knowledge_gap",     # model lacks the physics/CBOR/ZX knowledge needed
+    "hard_task",                # task itself appears beyond current model capability
+    "other",
+]
+
+JUDGE_PROMPT = """You are a senior compiler engineer auditing FAILED attempts
+by an autonomous AI senate to solve GitHub issues. Each row records one
+solver or reviewer attempt that ended in failure (json parse failure, or
+the reviewer rejected the solver's patch).
+
+Your job: assign each failure to exactly ONE category from this fixed
+taxonomy. Be decisive — pick the dominant cause.
+
+Categories:
+- parse_failure: malformed JSON / model returned non-JSON / truncated mid-string
+- schema_mismatch: valid JSON but wrong keys / structure (e.g. returned
+  {"name", "content"} when contract is {"reasoning", "edits", "new_files"})
+- hallucinated_symbol: patch references functions/types/files that do not
+  exist in the repo
+- off_target: patch addressed something other than the assigned issue
+  (classic example: fixing an unrelated CacheMetrics export instead of
+  the requested ZX-IR work)
+- incomplete_implementation: real attempt at the right area but doesn't
+  satisfy the acceptance criteria (e.g. missing CBOR hex file when the
+  AC required both .md and .cbor.hex)
+- test_only_no_impl: added test fixtures without any implementation
+  behind them
+- architectural_violation: broke a stated invariant (e.g. introduced
+  .py files in afana/ which is Rust-only by design)
+- domain_knowledge_gap: model lacks specific knowledge needed (CBOR
+  binary format, ZX-calculus algebra, Hamiltonian physics) — typically
+  manifests as plausible-looking but technically wrong output
+- hard_task: the task itself appears beyond current open-weight model
+  capability irrespective of which model is used
+- other: doesn't fit anywhere above
+
+Return ONLY a JSON object:
+{
+  "category": "<one of the above>",
+  "confidence": <0.0-1.0>,
+  "key_quote": "<one short verbatim phrase from the input that drove the verdict>",
+  "reasoning": "<one sentence explaining why this category>"
+}
+"""
+
+
+# ---------------------------------------------------------------------------
+# Postgres (stdlib via subprocess — no psycopg2 dep needed)
+# ---------------------------------------------------------------------------
+
+def _psql(query: str) -> list[dict[str, Any]]:
+    """Run a query, return rows as list of dicts. Uses JSON output via psql."""
+    import subprocess
+
+    # Wrap query so psql emits jsonb array
+    wrapped = (
+        "SELECT coalesce(json_agg(row_to_json(t)), '[]'::json) "
+        f"FROM ({query}) t"
+    )
+    cmd = [
+        "psql", DATABASE_URL,
+        "-At",  # tuples only, no align
+        "-c", wrapped,
+    ]
+    out = subprocess.check_output(cmd, timeout=60)
+    return json.loads(out.decode().strip() or "[]")
+
+
+# ---------------------------------------------------------------------------
+# Anthropic LLM call
+# ---------------------------------------------------------------------------
+
+def call_anthropic(prompt: str) -> Optional[str]:
+    """Single Anthropic Haiku call. Returns content or None on failure."""
+    if not ANTHROPIC_API_KEY:
+        return None
+
+    payload = json.dumps({
+        "model": "claude-haiku-4-5-20251001",
+        "max_tokens": 512,
+        "messages": [{"role": "user", "content": prompt}],
+    }).encode("utf-8")
+
+    req = urllib.request.Request(
+        "https://api.anthropic.com/v1/messages",
+        data=payload,
+        headers={
+            "x-api-key": ANTHROPIC_API_KEY,
+            "anthropic-version": "2023-06-01",
+            "content-type": "application/json",
+        },
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            data = json.loads(resp.read().decode())
+        return data["content"][0]["text"]
+    except urllib.error.HTTPError as e:
+        log.error("Anthropic HTTP %s: %s", e.code, e.read()[:200])
+        return None
+    except Exception as e:
+        log.exception("Anthropic call failed: %s", e)
+        return None
+
+
+def call_openrouter(prompt: str, model: str = "deepseek/deepseek-r1") -> Optional[str]:
+    """OpenRouter call via OpenAI-compat endpoint."""
+    if not OPENROUTER_API_KEY:
+        return None
+
+    payload = json.dumps({
+        "model": model,
+        "max_tokens": 512,
+        "temperature": 0.1,
+        "messages": [{"role": "user", "content": prompt}],
+    }).encode("utf-8")
+
+    req = urllib.request.Request(
+        "https://openrouter.ai/api/v1/chat/completions",
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {OPENROUTER_API_KEY}",
+            "HTTP-Referer": "https://quasi.arvak.io",
+            "X-Title": "Werner B-track Post-Mortem",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            data = json.loads(resp.read().decode())
+        return data["choices"][0]["message"]["content"]
+    except urllib.error.HTTPError as e:
+        log.error("OpenRouter HTTP %s: %s", e.code, e.read()[:200])
+        return None
+    except Exception as e:
+        log.exception("OpenRouter call failed: %s", e)
+        return None
+
+
+def call_groq(prompt: str, model: str = "llama-3.3-70b-versatile") -> Optional[str]:
+    """Groq inference. Fast + free tier for our scale."""
+    if not GROQ_API_KEY:
+        return None
+
+    payload = json.dumps({
+        "model": model,
+        "max_tokens": 512,
+        "temperature": 0.1,
+        "messages": [{"role": "user", "content": prompt}],
+    }).encode("utf-8")
+
+    req = urllib.request.Request(
+        "https://api.groq.com/openai/v1/chat/completions",
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {GROQ_API_KEY}",
+            "Content-Type": "application/json",
+            "User-Agent": "werner-btrack/1.0",
+        },
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            data = json.loads(resp.read().decode())
+        return data["choices"][0]["message"]["content"]
+    except urllib.error.HTTPError as e:
+        log.error("Groq HTTP %s: %s", e.code, e.read()[:200])
+        return None
+    except Exception as e:
+        log.exception("Groq call failed: %s", e)
+        return None
+
+
+def call_mistral(prompt: str, model: str = "mistral-large-latest") -> Optional[str]:
+    """Mistral platform call."""
+    if not MISTRAL_API_KEY:
+        return None
+    payload = json.dumps({
+        "model": model,
+        "max_tokens": 512,
+        "temperature": 0.1,
+        "messages": [{"role": "user", "content": prompt}],
+    }).encode("utf-8")
+    req = urllib.request.Request(
+        "https://api.mistral.ai/v1/chat/completions",
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {MISTRAL_API_KEY}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            data = json.loads(resp.read().decode())
+        return data["choices"][0]["message"]["content"]
+    except urllib.error.HTTPError as e:
+        log.error("Mistral HTTP %s: %s", e.code, e.read()[:200])
+        return None
+    except Exception as e:
+        log.exception("Mistral call failed: %s", e)
+        return None
+
+
+def call_together(prompt: str, model: str = "deepseek-ai/DeepSeek-V3") -> Optional[str]:
+    """Together.ai call."""
+    if not TOGETHER_API_KEY:
+        return None
+    payload = json.dumps({
+        "model": model,
+        "max_tokens": 512,
+        "temperature": 0.1,
+        "messages": [{"role": "user", "content": prompt}],
+    }).encode("utf-8")
+    req = urllib.request.Request(
+        "https://api.together.xyz/v1/chat/completions",
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {TOGETHER_API_KEY}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            data = json.loads(resp.read().decode())
+        return data["choices"][0]["message"]["content"]
+    except urllib.error.HTTPError as e:
+        log.error("Together HTTP %s: %s", e.code, e.read()[:200])
+        return None
+    except Exception as e:
+        log.exception("Together call failed: %s", e)
+        return None
+
+
+def call_judge(prompt: str) -> Optional[str]:
+    """Try providers in order. First success wins.
+
+    Ordered by empirical reviewer strength (per senate_telemetry B2_reviewer
+    data): deepseek-v3 / deepseek-r1 (best critics) → llama-3.3-70b → mistral.
+    """
+    for caller in (
+        lambda p: call_anthropic(p),
+        lambda p: call_together(p, "deepseek-ai/DeepSeek-V3"),
+        lambda p: call_groq(p, "llama-3.3-70b-versatile"),
+        lambda p: call_mistral(p, "mistral-large-latest"),
+        lambda p: call_openrouter(p, "deepseek/deepseek-r1"),
+    ):
+        result = caller(prompt)
+        if result:
+            return result
+    log.error("All judge providers failed")
+    return None
+
+
+def parse_verdict(text: str) -> Optional[dict[str, Any]]:
+    """Extract the JSON verdict. Returns None on failure."""
+    match = re.search(r"\{[\s\S]*\}", text)
+    if not match:
+        return None
+    try:
+        data = json.loads(match.group())
+    except json.JSONDecodeError:
+        return None
+
+    category = str(data.get("category", "")).lower().replace(" ", "_").replace("-", "_")
+    if category not in CATEGORIES:
+        category = "other"
+
+    return {
+        "category": category,
+        "confidence": float(data.get("confidence", 0.5)),
+        "key_quote": str(data.get("key_quote", ""))[:300],
+        "reasoning": str(data.get("reasoning", ""))[:500],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Context assembly
+# ---------------------------------------------------------------------------
+
+@dataclass
+class FailureRow:
+    telemetry_id: int
+    timestamp: str
+    role: str
+    model_id: str
+    provider: str
+    issue_number: Optional[int]
+    downstream_verdict: str
+    verdict_reasoning: str
+    issue_title: str
+    issue_body: str
+    raw_response_excerpt: str
+
+    def to_prompt(self) -> str:
+        return f"""{JUDGE_PROMPT}
+
+---
+TELEMETRY ROW {self.telemetry_id}
+- timestamp: {self.timestamp}
+- role: {self.role}
+- model: {self.model_id} (provider: {self.provider})
+- outcome: {self.downstream_verdict}
+- issue: #{self.issue_number or "?"}
+
+ISSUE TITLE: {self.issue_title}
+
+ISSUE BODY (truncated):
+{self.issue_body[:1500]}
+
+REVIEWER OR PARSER FEEDBACK:
+{self.verdict_reasoning[:1500] if self.verdict_reasoning else "(none)"}
+
+RAW MODEL OUTPUT EXCERPT (if json_fail):
+{self.raw_response_excerpt[:1500] if self.raw_response_excerpt else "(not preserved)"}
+---
+"""
+
+
+def fetch_issue(issue_number: int) -> tuple[str, str]:
+    """Fetch issue title/body from GitHub. Returns ('', '') on failure."""
+    if not issue_number:
+        return "", ""
+    url = f"https://api.github.com/repos/{GITHUB_REPO}/issues/{issue_number}"
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "werner-btrack/1.0",
+    }
+    if GITHUB_TOKEN:
+        headers["Authorization"] = f"Bearer {GITHUB_TOKEN}"
+    req = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = json.loads(resp.read().decode())
+        return data.get("title", ""), data.get("body", "") or ""
+    except Exception as e:
+        log.warning("issue #%d fetch failed: %s", issue_number, e)
+        return "", ""
+
+
+def fetch_raw_dump(model_id: str, issue_number: Optional[int]) -> str:
+    """Best-effort: read the /tmp/senate-raw-{model}-{issue}.txt dump if present."""
+    if not issue_number:
+        return ""
+    path = Path(f"/tmp/senate-raw-{model_id}-{issue_number}.txt")
+    if not path.exists():
+        return ""
+    try:
+        return path.read_text(errors="replace")[:2000]
+    except OSError:
+        return ""
+
+
+def sample_candidates(limit: int, since: Optional[str]) -> list[dict[str, Any]]:
+    """Pull failed telemetry rows, weighted to mix json_fail + rejected."""
+    where_since = f"AND timestamp >= '{since}'" if since else ""
+    query = f"""
+        SELECT id, timestamp::text AS timestamp, role, model_id, provider,
+               issue_number, downstream_verdict,
+               coalesce(verdict_reasoning, '') AS verdict_reasoning
+        FROM senate_telemetry
+        WHERE downstream_verdict IN ('rejected', 'json_fail')
+          {where_since}
+        ORDER BY random()
+        LIMIT {int(limit)}
+    """
+    return _psql(query)
+
+
+# ---------------------------------------------------------------------------
+# Evaluation loop
+# ---------------------------------------------------------------------------
+
+def run_batch(limit: int, since: Optional[str], delay: float = 2.0) -> None:
+    VERDICTS_DIR.mkdir(parents=True, exist_ok=True)
+
+    log.info("Sampling %d failed telemetry rows (since=%s)", limit, since or "all-time")
+    candidates = sample_candidates(limit, since)
+    log.info("Got %d candidates", len(candidates))
+
+    # Skip already-evaluated rows
+    already = {p.stem for p in VERDICTS_DIR.glob("*.json")}
+    todo = [r for r in candidates if str(r["id"]) not in already]
+    log.info("%d remain after de-dup", len(todo))
+
+    for i, row in enumerate(todo, 1):
+        issue_title, issue_body = fetch_issue(row["issue_number"])
+        raw = fetch_raw_dump(row["model_id"], row["issue_number"])
+
+        f = FailureRow(
+            telemetry_id=row["id"],
+            timestamp=row["timestamp"],
+            role=row["role"],
+            model_id=row["model_id"],
+            provider=row["provider"],
+            issue_number=row["issue_number"],
+            downstream_verdict=row["downstream_verdict"],
+            verdict_reasoning=row["verdict_reasoning"],
+            issue_title=issue_title,
+            issue_body=issue_body,
+            raw_response_excerpt=raw,
+        )
+
+        log.info("[%d/%d] judging telemetry id=%d (%s, issue=#%s, model=%s)",
+                 i, len(todo), f.telemetry_id, f.downstream_verdict,
+                 f.issue_number, f.model_id)
+        raw_resp = call_judge(f.to_prompt())
+        if not raw_resp:
+            log.warning("LLM call failed for telemetry id=%d", f.telemetry_id)
+            continue
+
+        verdict = parse_verdict(raw_resp)
+        if not verdict:
+            log.warning("Could not parse verdict for telemetry id=%d", f.telemetry_id)
+            continue
+
+        record = {
+            "evaluated_at": datetime.now(timezone.utc).isoformat(),
+            "telemetry_id": f.telemetry_id,
+            "telemetry_timestamp": f.timestamp,
+            "role": f.role,
+            "model_id": f.model_id,
+            "provider": f.provider,
+            "issue_number": f.issue_number,
+            "downstream_verdict": f.downstream_verdict,
+            **verdict,
+        }
+
+        (VERDICTS_DIR / f"{f.telemetry_id}.json").write_text(
+            json.dumps(record, indent=2)
+        )
+        with open(LOG_FILE, "a") as fh:
+            fh.write(json.dumps(record) + "\n")
+
+        time.sleep(delay)
+
+
+def report() -> None:
+    """Aggregate existing verdicts into a typology summary."""
+    if not VERDICTS_DIR.exists():
+        print("No verdicts yet — run --batch first.")
+        return
+
+    records = []
+    for p in VERDICTS_DIR.glob("*.json"):
+        try:
+            records.append(json.loads(p.read_text()))
+        except json.JSONDecodeError:
+            continue
+
+    if not records:
+        print("Verdict dir is empty.")
+        return
+
+    print(f"\n=== Werner B-track Post-Mortem Report ({len(records)} failures judged) ===\n")
+
+    # Category breakdown
+    from collections import Counter, defaultdict
+    by_category = Counter(r["category"] for r in records)
+    print("Failure categories (overall):")
+    for cat, n in by_category.most_common():
+        pct = 100.0 * n / len(records)
+        print(f"  {cat:32s} {n:4d}  ({pct:5.1f}%)")
+
+    # Per-role breakdown
+    print("\nBy role:")
+    by_role: dict[str, Counter[str]] = defaultdict(Counter)
+    for r in records:
+        by_role[r["role"]][r["category"]] += 1
+    for role, counts in sorted(by_role.items()):
+        total = sum(counts.values())
+        top = counts.most_common(3)
+        top_str = ", ".join(f"{c}={n}" for c, n in top)
+        print(f"  {role}  (n={total}): {top_str}")
+
+    # Per-model top failure
+    print("\nTop failure mode per model (only models with >= 5 failures):")
+    by_model: dict[str, Counter[str]] = defaultdict(Counter)
+    for r in records:
+        by_model[r["model_id"]][r["category"]] += 1
+    for model, counts in sorted(by_model.items(), key=lambda kv: -sum(kv[1].values())):
+        n = sum(counts.values())
+        if n < 5:
+            continue
+        top_cat, top_n = counts.most_common(1)[0]
+        print(f"  {model:32s} n={n:3d}  top={top_cat} ({top_n}/{n})")
+
+    # Confidence distribution
+    confs = [r["confidence"] for r in records]
+    avg_conf = sum(confs) / len(confs) if confs else 0
+    print(f"\nMean judge confidence: {avg_conf:.2f}")
+
+    # Representative quotes per category (top 3)
+    print("\nRepresentative key quotes per category (one each):")
+    seen_cats: set[str] = set()
+    for r in sorted(records, key=lambda r: -r["confidence"]):
+        cat = r["category"]
+        if cat in seen_cats:
+            continue
+        seen_cats.add(cat)
+        quote = r["key_quote"][:120]
+        print(f"  [{cat}] {quote!r}")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Werner B-track post-mortem evaluator")
+    p.add_argument("--batch", type=int, default=0, help="number of rows to evaluate")
+    p.add_argument("--since", type=str, default=None, help="ISO date — only rows >= this")
+    p.add_argument("--report", action="store_true", help="print aggregate report")
+    p.add_argument("--delay", type=float, default=2.0, help="sleep between LLM calls (sec)")
+    args = p.parse_args()
+
+    if args.batch > 0:
+        if not (ANTHROPIC_API_KEY or OPENROUTER_API_KEY or GROQ_API_KEY):
+            print(
+                "ERROR: need ANTHROPIC_API_KEY or OPENROUTER_API_KEY or GROQ_API_KEY",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        run_batch(args.batch, args.since, delay=args.delay)
+
+    if args.report or args.batch == 0:
+        report()
+
+
+if __name__ == "__main__":
+    main()

--- a/quasi-senate/werner/config.py
+++ b/quasi-senate/werner/config.py
@@ -1,0 +1,20 @@
+"""Werner config — Camelot version (collector only, no API needed)."""
+
+# Camelot / Ledger (local paths)
+CAMELOT_HOST = "87.106.219.154"
+LEDGER_PATH = "/home/vops/quasi-ledger/ledger.json"
+
+# GitHub
+GITHUB_REPO = "ehrenfest-quantum/quasi"
+
+# Polling
+POLL_INTERVAL = 300  # 5 minutes
+
+# Not needed for collector, but referenced
+TOGETHER_API_KEY = None
+TOGETHER_MODEL = None
+WERNER_SYSTEM_PROMPT = None
+RETROSPECTIVE_LOG = None
+GROUND_TRUTH_FILE = None
+VERDICT_LOG = None
+STATE_FILE = None

--- a/quasi-senate/werner/shadow_collector.py
+++ b/quasi-senate/werner/shadow_collector.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Werner Shadow Collector — collects new issues without evaluating.
+
+Polls the quasi-ledger on Camelot, records issue_generated events
+into a queue file. No Werner API calls — just collection.
+
+Evaluation happens later in batch via shadow_sealed.py --batch.
+
+Usage:
+    python shadow_collector.py                # poll continuously
+    python shadow_collector.py --once         # single pass
+    python shadow_collector.py --status       # show queue status
+
+Deploy on Camelot:
+    nohup python3 shadow_collector.py --interval 300 > /dev/null 2>&1 &
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import signal
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import config
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+log = logging.getLogger("werner-collector")
+
+QUEUE_FILE = Path(__file__).parent / "shadow-queue.jsonl"
+STATE_FILE = Path(__file__).parent / ".collector-state.json"
+
+# Remote paths (when running on Camelot directly)
+REMOTE_QUEUE = "/home/vops/werner-shadow/queue.jsonl"
+REMOTE_STATE = "/home/vops/werner-shadow/.collector-state.json"
+
+
+# Ledger event types that mean "a GitHub issue now exists and is judgeable".
+#
+#   issue_generated   - legacy A-track path, where the senate opened the issue
+#                       itself. Still emitted when SENATE_DIRECT_ISSUES=1.
+#   proposal_accepted - current path. The senate only *proposes*; the board
+#                       opens the issue when a human accepts, and records the
+#                       issue number directly rather than a URL.
+ISSUE_EVENT_TYPES = ("issue_generated", "proposal_accepted")
+
+_REPO = "ehrenfest-quantum/quasi"
+
+
+def issue_ref(entry):
+    """Return (issue_number, issue_url) for a ledger entry, or (None, "")."""
+    num = entry.get("issue_number")
+    if isinstance(num, int) and num > 0:
+        return num, "https://github.com/%s/issues/%d" % (_REPO, num)
+    url = entry.get("issue_url") or entry.get("url", "")
+    return extract_issue_number(url), url
+
+
+def load_state() -> dict[str, Any]:
+    """Load collector state."""
+    # Try remote first (if on Camelot), then local
+    for path in [Path(REMOTE_STATE), STATE_FILE]:
+        if path.exists():
+            return json.loads(path.read_text())
+    return {"last_seen_index": -1}
+
+
+def save_state(state: dict[str, Any]) -> None:
+    """Save state to both local and remote (if accessible)."""
+    state_json = json.dumps(state, indent=2)
+    STATE_FILE.write_text(state_json)
+    # Try remote too
+    try:
+        Path(REMOTE_STATE).parent.mkdir(parents=True, exist_ok=True)
+        Path(REMOTE_STATE).write_text(state_json)
+    except OSError:
+        pass
+
+
+def fetch_ledger_local() -> list[dict[str, Any]]:
+    """Read ledger directly (when running on Camelot)."""
+    ledger_path = Path(config.LEDGER_PATH)
+    if ledger_path.exists():
+        return json.loads(ledger_path.read_text())
+    return []
+
+
+def fetch_ledger_ssh() -> list[dict[str, Any]]:
+    """Fetch ledger via SSH (when running remotely)."""
+    result = subprocess.run(
+        ["ssh", f"root@{config.CAMELOT_HOST}", f"cat {config.LEDGER_PATH}"],
+        capture_output=True, text=True, timeout=30,
+    )
+    if result.returncode != 0:
+        log.error("SSH fetch failed: %s", result.stderr.strip())
+        return []
+    return json.loads(result.stdout)
+
+
+def fetch_ledger() -> list[dict[str, Any]]:
+    """Fetch ledger — local if on Camelot, SSH otherwise."""
+    local = fetch_ledger_local()
+    if local:
+        return local
+    return fetch_ledger_ssh()
+
+
+def extract_issue_number(url: str) -> int | None:
+    """Extract issue number from GitHub URL."""
+    import re
+    match = re.search(r"/issues/(\d+)", url)
+    return int(match.group(1)) if match else None
+
+
+def append_to_queue(entry: dict[str, Any]) -> None:
+    """Append an issue to the queue."""
+    queue_path = QUEUE_FILE
+    # Also try remote path
+    for path in [queue_path, Path(REMOTE_QUEUE)]:
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with open(path, "a") as f:
+                f.write(json.dumps(entry) + "\n")
+        except OSError:
+            pass
+
+
+def load_queue() -> list[dict[str, Any]]:
+    """Load all queued issues."""
+    entries = []
+    for path in [QUEUE_FILE, Path(REMOTE_QUEUE)]:
+        if path.exists():
+            for line in path.read_text().strip().split("\n"):
+                if line.strip():
+                    entries.append(json.loads(line))
+            break
+    return entries
+
+
+_shutdown = False
+
+
+def _handle_signal(signum: int, _frame: Any) -> None:
+    global _shutdown  # noqa: PLW0603
+    _shutdown = True
+
+
+def run(once: bool = False, interval: int = 300) -> None:
+    """Main collection loop."""
+    signal.signal(signal.SIGINT, _handle_signal)
+    signal.signal(signal.SIGTERM, _handle_signal)
+
+    state = load_state()
+    last_seen = state.get("last_seen_index", -1)
+    log.info("Werner Collector started. last_seen=%d, interval=%ds", last_seen, interval)
+
+    while not _shutdown:
+        try:
+            ledger = fetch_ledger()
+            new_entries = [
+                (i, e) for i, e in enumerate(ledger)
+                if i > last_seen and e.get("type") in ISSUE_EVENT_TYPES
+            ]
+
+            for idx, entry in new_entries:
+                issue_number, issue_url = issue_ref(entry)
+                if issue_number is None:
+                    continue
+
+                queue_entry = {
+                    "collected_at": datetime.now(timezone.utc).isoformat(),
+                    "ledger_index": idx,
+                    "issue_number": issue_number,
+                    "issue_url": issue_url,
+                    "ledger_type": entry.get("type"),
+                    "evaluated": False,
+                }
+                append_to_queue(queue_entry)
+                log.info("Queued issue #%d (ledger idx %d)", issue_number, idx)
+
+                last_seen = idx
+                save_state({"last_seen_index": last_seen})
+
+            if new_entries:
+                log.info("Queued %d new issues", len(new_entries))
+
+        except Exception:
+            log.exception("Error in collection cycle")
+
+        if once:
+            break
+
+        for _ in range(interval):
+            if _shutdown:
+                break
+            time.sleep(1)
+
+    log.info("Collector stopped. last_seen=%d", last_seen)
+
+
+def show_status() -> None:
+    """Show queue status."""
+    queue = load_queue()
+    state = load_state()
+    evaluated = sum(1 for e in queue if e.get("evaluated"))
+    pending = len(queue) - evaluated
+
+    print(f"Queue: {len(queue)} total, {pending} pending, {evaluated} evaluated")
+    print(f"Last seen ledger index: {state.get('last_seen_index', -1)}")
+
+    if queue:
+        first = queue[0]
+        last = queue[-1]
+        print(f"First: #{first['issue_number']} at {first['collected_at']}")
+        print(f"Last:  #{last['issue_number']} at {last['collected_at']}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Werner Shadow Collector")
+    parser.add_argument("--once", action="store_true", help="Single pass")
+    parser.add_argument("--status", action="store_true", help="Show queue status")
+    parser.add_argument("--interval", type=int, default=300, help="Poll interval (default: 5 min)")
+    args = parser.parse_args()
+
+    if args.status:
+        show_status()
+        return
+
+    run(once=args.once, interval=args.interval)
+
+
+if __name__ == "__main__":
+    main()

--- a/quasi-senate/werner/shadow_evaluator.py
+++ b/quasi-senate/werner/shadow_evaluator.py
@@ -1,0 +1,483 @@
+#!/usr/bin/env python3
+"""Werner Shadow Evaluator — judges issue quality from collector queue.
+
+Consumes queue.jsonl entries written by shadow_collector.py,
+evaluates each issue via LLM, stores cleartext verdicts with
+tamper-evident SHA-256 hash chain.
+
+Runs on Camelot. Stdlib only (urllib.request, no httpx).
+
+Usage:
+    python3 shadow_evaluator.py --batch 5        # evaluate next 5
+    python3 shadow_evaluator.py --backfill       # all unevaluated (6s delay)
+    python3 shadow_evaluator.py --verify         # check chain integrity
+    python3 shadow_evaluator.py --status         # queue/chain stats
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import re
+import sys
+import time
+import urllib.request
+import urllib.error
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+log = logging.getLogger("werner-evaluator")
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+BASE_DIR = Path("/home/vops/werner-shadow")
+QUEUE_FILE = BASE_DIR / "queue.jsonl"
+CHAIN_FILE = BASE_DIR / "chain.jsonl"
+VERDICT_LOG = BASE_DIR / "verdict-log.jsonl"
+VERDICTS_DIR = BASE_DIR / "verdicts"
+
+# ---------------------------------------------------------------------------
+# Environment
+# ---------------------------------------------------------------------------
+
+GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN", "")
+GITHUB_REPO = os.environ.get("GITHUB_REPO", "ehrenfest-quantum/quasi")
+OPENROUTER_API_KEY = os.environ.get("OPENROUTER_API_KEY", "")
+GROQ_API_KEY = os.environ.get("GROQ_API_KEY", "")
+
+# ---------------------------------------------------------------------------
+# Judge prompt
+# ---------------------------------------------------------------------------
+
+JUDGE_SYSTEM = """You are a senior software engineering issue quality evaluator.
+Assess the given GitHub issue for clarity, actionability, and difficulty.
+
+Return a JSON object with exactly these fields:
+{
+  "verdict": "<well-specified|underspecified|ambiguous|trivial|unsolvable>",
+  "confidence": <0.0-1.0>,
+  "difficulty_tier": <1-5>,
+  "signals": ["list", "of", "quality", "signals"],
+  "reasoning": "One paragraph explaining the verdict."
+}
+
+Verdict definitions:
+- well-specified: Clear problem, clear acceptance criteria, implementable
+- underspecified: Missing key details needed to implement (unclear scope, missing context)
+- ambiguous: Could be interpreted multiple ways, contradictory requirements
+- trivial: Too simple to be meaningful (typo fix, one-line change)
+- unsolvable: Fundamentally impossible or contradictory
+
+Difficulty tiers:
+1 = trivial (< 30 min), 2 = easy (< 2h), 3 = medium (half day),
+4 = hard (1-3 days), 5 = very hard (> 3 days)
+
+Return ONLY the JSON object, no markdown fences, no extra text."""
+
+# ---------------------------------------------------------------------------
+# Hash chain
+# ---------------------------------------------------------------------------
+
+
+def sha256(data: str) -> str:
+    return hashlib.sha256(data.encode("utf-8")).hexdigest()
+
+
+def get_last_chain_entry() -> dict[str, Any] | None:
+    if not CHAIN_FILE.exists():
+        return None
+    lines = CHAIN_FILE.read_text().strip().split("\n")
+    if not lines or not lines[-1].strip():
+        return None
+    return json.loads(lines[-1])
+
+
+def append_chain_entry(
+    seq: int, issue_number: int, verdict_json: str, prev_hash: str
+) -> dict[str, Any]:
+    verdict_hash = sha256(verdict_json)
+    chain_hash = sha256(verdict_hash + prev_hash)
+    entry = {
+        "seq": seq,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "issue_number": issue_number,
+        "verdict_hash": verdict_hash,
+        "prev_hash": prev_hash,
+        "chain_hash": chain_hash,
+    }
+    with open(CHAIN_FILE, "a") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def verify_chain() -> tuple[bool, list[str]]:
+    if not CHAIN_FILE.exists():
+        return False, ["Chain file not found"]
+    errors: list[str] = []
+    lines = CHAIN_FILE.read_text().strip().split("\n")
+    prev_hash = "genesis"
+    for i, line in enumerate(lines):
+        if not line.strip():
+            continue
+        entry = json.loads(line)
+        if entry["seq"] != i:
+            errors.append(f"Seq mismatch at line {i}: expected {i}, got {entry['seq']}")
+        if entry["prev_hash"] != prev_hash:
+            errors.append(f"Chain break at seq {entry['seq']}: prev_hash mismatch")
+        expected = sha256(entry["verdict_hash"] + entry["prev_hash"])
+        if entry["chain_hash"] != expected:
+            errors.append(f"Chain hash invalid at seq {entry['seq']}")
+        verdict_file = VERDICTS_DIR / f"{entry['issue_number']}.json"
+        if verdict_file.exists():
+            actual = sha256(verdict_file.read_text())
+            if actual != entry["verdict_hash"]:
+                errors.append(
+                    f"SEAL BROKEN: verdict #{entry['issue_number']} "
+                    f"modified (hash mismatch at seq {entry['seq']})"
+                )
+        else:
+            errors.append(f"Verdict file missing: #{entry['issue_number']}")
+        prev_hash = entry["chain_hash"]
+    return len(errors) == 0, errors
+
+
+# ---------------------------------------------------------------------------
+# GitHub fetch
+# ---------------------------------------------------------------------------
+
+
+def fetch_issue(issue_number: int) -> dict[str, str] | None:
+    url = f"https://api.github.com/repos/{GITHUB_REPO}/issues/{issue_number}"
+    req = urllib.request.Request(url, headers={
+        "Authorization": f"token {GITHUB_TOKEN}",
+        "Accept": "application/vnd.github.v3+json",
+        "User-Agent": "werner-evaluator/1.0",
+    })
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = json.loads(resp.read().decode())
+        return {"title": data.get("title", ""), "body": data.get("body", "") or ""}
+    except Exception as e:
+        log.error("GitHub fetch #%d failed: %s", issue_number, e)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# LLM providers (fallback chain)
+# ---------------------------------------------------------------------------
+
+
+def _api_call(url: str, headers: dict, payload: dict, timeout: int = 60) -> str:
+    """Generic API call, returns assistant message content."""
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        result = json.loads(resp.read().decode())
+    return result["choices"][0]["message"]["content"]
+
+
+def call_openrouter(issue_text: str) -> str | None:
+    if not OPENROUTER_API_KEY:
+        return None
+    try:
+        return _api_call(
+            "https://openrouter.ai/api/v1/chat/completions",
+            {
+                "Authorization": f"Bearer {OPENROUTER_API_KEY}",
+                "Content-Type": "application/json",
+            },
+            {
+                "model": "microsoft/phi-4",  # open-weight; disjoint from generator pool
+                "messages": [
+                    {"role": "system", "content": JUDGE_SYSTEM},
+                    {"role": "user", "content": issue_text},
+                ],
+                "max_tokens": 512,
+                "temperature": 0.2,
+            },
+        )
+    except Exception as e:
+        log.warning("OpenRouter failed: %s", e)
+        return None
+
+
+def call_groq(issue_text: str) -> str | None:
+    if not GROQ_API_KEY:
+        return None
+    try:
+        return _api_call(
+            "https://api.groq.com/openai/v1/chat/completions",
+            {
+                "Authorization": f"Bearer {GROQ_API_KEY}",
+                "Content-Type": "application/json",
+                "User-Agent": "quasi-agent/1.0 (https://quasi.arvak.io)",
+            },
+            {
+                "model": "llama-3.3-70b-versatile",
+                "messages": [
+                    {"role": "system", "content": JUDGE_SYSTEM},
+                    {"role": "user", "content": issue_text},
+                ],
+                "max_tokens": 512,
+                "temperature": 0.2,
+            },
+        )
+    except Exception as e:
+        log.warning("Groq failed: %s", e)
+        return None
+
+
+def judge_issue(title: str, body: str) -> tuple[dict[str, Any], str, str]:
+    """Call LLM with fallback chain. Returns (parsed, raw, provider)."""
+    issue_text = f"# {title}\n\n{body}"
+
+    # Open-weight judges only (project rule). The Anthropic leg was removed:
+    # Werner judges an automated pipeline, so a commercial closed-weight model
+    # is not permitted here. Groq leads because llama-3.3-70b-versatile is fast
+    # and free-tier; phi-4 on OpenRouter is the fallback. Both are open-weight
+    # and neither shares a model family with any active senate generator.
+    for name, fn in [("groq", call_groq), ("openrouter", call_openrouter)]:
+        raw = fn(issue_text)
+        if raw:
+            parsed = parse_verdict(raw)
+            if parsed:
+                return parsed, raw, name
+            log.warning("Provider %s returned unparseable response", name)
+
+    return {
+        "verdict": "unparseable",
+        "confidence": 0.0,
+        "difficulty_tier": 0,
+        "signals": [],
+        "reasoning": "All providers failed or returned unparseable responses",
+    }, "", "none"
+
+
+def parse_verdict(text: str) -> dict[str, Any] | None:
+    try:
+        # Find JSON object in response
+        match = re.search(r"\{[^{}]*\}", text, re.DOTALL)
+        if not match:
+            return None
+        data = json.loads(match.group())
+        verdict = data.get("verdict", "").lower().replace(" ", "-")
+        valid = {"well-specified", "underspecified", "ambiguous", "trivial", "unsolvable"}
+        if verdict not in valid:
+            return None
+        return {
+            "verdict": verdict,
+            "confidence": float(data.get("confidence", 0.5)),
+            "difficulty_tier": int(data.get("difficulty_tier", 3)),
+            "signals": data.get("signals", []),
+            "reasoning": data.get("reasoning", ""),
+        }
+    except (json.JSONDecodeError, ValueError, TypeError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Queue operations
+# ---------------------------------------------------------------------------
+
+
+def load_queue() -> list[dict[str, Any]]:
+    if not QUEUE_FILE.exists():
+        return []
+    entries = []
+    for line in QUEUE_FILE.read_text().strip().split("\n"):
+        if line.strip():
+            entries.append(json.loads(line))
+    return entries
+
+
+def save_queue(entries: list[dict[str, Any]]) -> None:
+    with open(QUEUE_FILE, "w") as f:
+        for e in entries:
+            f.write(json.dumps(e) + "\n")
+    # Also sync shadow-queue.jsonl if it exists
+    shadow = BASE_DIR / "shadow-queue.jsonl"
+    if shadow.exists():
+        with open(shadow, "w") as f:
+            for e in entries:
+                f.write(json.dumps(e) + "\n")
+
+
+def get_unevaluated(queue: list[dict[str, Any]]) -> list[int]:
+    """Return indices of unevaluated entries."""
+    return [i for i, e in enumerate(queue) if not e.get("evaluated")]
+
+
+# ---------------------------------------------------------------------------
+# Core evaluation
+# ---------------------------------------------------------------------------
+
+
+def evaluate_batch(limit: int | None = None, delay: float = 6.0) -> int:
+    """Evaluate unevaluated queue entries. Returns count processed."""
+    VERDICTS_DIR.mkdir(parents=True, exist_ok=True)
+
+    queue = load_queue()
+    unevaluated = get_unevaluated(queue)
+
+    if not unevaluated:
+        log.info("No unevaluated entries in queue")
+        return 0
+
+    if limit:
+        unevaluated = unevaluated[:limit]
+
+    log.info("Evaluating %d issues (of %d pending)", len(unevaluated), len(get_unevaluated(queue)))
+
+    # Chain state
+    last = get_last_chain_entry()
+    seq = (last["seq"] + 1) if last else 0
+    prev_hash = last["chain_hash"] if last else "genesis"
+
+    processed = 0
+    for idx in unevaluated:
+        entry = queue[idx]
+        issue_number = entry["issue_number"]
+
+        # Fetch from GitHub
+        issue = fetch_issue(issue_number)
+        if not issue:
+            log.warning("Skipping #%d — could not fetch", issue_number)
+            continue
+
+        log.info("Judging #%d: %s", issue_number, issue["title"][:60])
+
+        # Judge
+        parsed, raw, provider = judge_issue(issue["title"], issue["body"])
+
+        # Build verdict document
+        verdict_doc = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "issue_number": issue_number,
+            "issue_title": issue["title"],
+            "verdict": parsed["verdict"],
+            "confidence": parsed["confidence"],
+            "difficulty_tier": parsed["difficulty_tier"],
+            "signals": parsed["signals"],
+            "reasoning": parsed["reasoning"],
+            "provider": provider,
+        }
+        verdict_json = json.dumps(verdict_doc, ensure_ascii=False)
+
+        # 1. Write verdict file (cleartext)
+        (VERDICTS_DIR / f"{issue_number}.json").write_text(verdict_json)
+
+        # 2. Append to hash chain
+        chain_entry = append_chain_entry(seq, issue_number, verdict_json, prev_hash)
+        seq += 1
+        prev_hash = chain_entry["chain_hash"]
+
+        # 3. Append to verdict log (flat JSONL for ETL)
+        with open(VERDICT_LOG, "a") as f:
+            f.write(verdict_json + "\n")
+
+        # 4. Mark evaluated in queue
+        queue[idx]["evaluated"] = True
+        queue[idx]["evaluated_at"] = datetime.now(timezone.utc).isoformat()
+        save_queue(queue)
+
+        log.info(
+            "  → %s (%.2f) tier=%d provider=%s chain=%s",
+            parsed["verdict"], parsed["confidence"],
+            parsed["difficulty_tier"], provider,
+            chain_entry["chain_hash"][:16] + "...",
+        )
+
+        processed += 1
+        if processed < len(unevaluated):
+            time.sleep(delay)
+
+    log.info("Done. Evaluated %d issues.", processed)
+    return processed
+
+
+# ---------------------------------------------------------------------------
+# Status
+# ---------------------------------------------------------------------------
+
+
+def show_status() -> None:
+    queue = load_queue()
+    evaluated = sum(1 for e in queue if e.get("evaluated"))
+    pending = len(queue) - evaluated
+
+    print(f"Queue: {len(queue)} total, {pending} pending, {evaluated} evaluated")
+
+    if CHAIN_FILE.exists():
+        lines = [l for l in CHAIN_FILE.read_text().strip().split("\n") if l.strip()]
+        print(f"Chain: {len(lines)} entries")
+        if lines:
+            last = json.loads(lines[-1])
+            print(f"  Last: seq={last['seq']} issue=#{last['issue_number']} at {last['timestamp']}")
+    else:
+        print("Chain: not started")
+
+    if VERDICT_LOG.exists():
+        vlines = [l for l in VERDICT_LOG.read_text().strip().split("\n") if l.strip()]
+        print(f"Verdict log: {len(vlines)} entries")
+    else:
+        print("Verdict log: empty")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Werner Shadow Evaluator")
+    parser.add_argument("--batch", type=int, default=5, help="Evaluate N issues (default: 5)")
+    parser.add_argument("--backfill", action="store_true", help="Evaluate ALL unevaluated (6s delay)")
+    parser.add_argument("--verify", action="store_true", help="Verify chain integrity")
+    parser.add_argument("--status", action="store_true", help="Show queue/chain stats")
+    parser.add_argument("--delay", type=float, default=6.0, help="Delay between evaluations (seconds)")
+    args = parser.parse_args()
+
+    if args.status:
+        show_status()
+        return
+
+    if args.verify:
+        ok, errors = verify_chain()
+        if ok:
+            print("CHAIN INTACT — no tampering detected")
+        else:
+            print("SEAL STATUS:")
+            for err in errors:
+                print(f"  {err}")
+        sys.exit(0 if ok else 1)
+
+    # Need at least GitHub token
+    if not GITHUB_TOKEN:
+        log.error("GITHUB_TOKEN not set")
+        sys.exit(1)
+
+    # Need at least one LLM provider
+    if not any([GROQ_API_KEY, OPENROUTER_API_KEY]):
+        log.error("No LLM API key set (need GROQ_API_KEY or OPENROUTER_API_KEY)")
+        sys.exit(1)
+
+    limit = None if args.backfill else args.batch
+    count = evaluate_batch(limit=limit, delay=args.delay)
+
+    if count == 0:
+        log.info("Nothing to evaluate.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Werner has been running on Camelot since March — **601 hash-chained verdicts** — with **none of its code in version control**. This commits the deployed source, fixes why it had been idle since May, and removes the commercial-model judge paths.

## The collector was starved, not broken

It matched only the legacy `issue_generated` ledger event. The A-track no longer emits that — the senate *proposes*, and the board opens the issue on human acceptance, recording `proposal_accepted` with an `issue_number` rather than an `issue_url`.

So when the senate timers stopped on **2026-05-10**, the collector polled an empty queue for three months — exactly as designed, and entirely uselessly. `last_seen_index` sat at 1129 the whole time.

It now collects both types and resolves the issue reference from either shape. `issue_generated` is kept deliberately: it's still emitted under the `SENATE_DIRECT_ISSUES=1` rollback lever.

**Verified live:**

```
14:37:53  Queued issue #1108 (ledger idx 1158)
15:00:05  chain.jsonl -> 602 entries   (seq 596, issue #1108)
```

Werner's first verdict since May, and the first ever on an issue that reached GitHub through human approval rather than auto-publication. Its judgement: `well-specified`, confidence 0.9, difficulty tier 2.

## Claude removed from both legs

The judge chain had a direct Anthropic call (`claude-haiku-4-5`) **and** an "OpenRouter fallback" that also routed to Claude (`anthropic/claude-3.5-haiku`). Both are commercial closed-weight models, which the project does not permit in an automated pipeline.

Now: **Groq `llama-3.3-70b-versatile` → OpenRouter `microsoft/phi-4`** — both open-weight, neither sharing a model family with any active senate generator, matching the `werner_judge` pool from #1111.

Verdict 602 had already been produced by the Groq leg (`"provider": "groq"`), so **no verdict in the chain was Claude-judged**.

## Also

- `quasi-senate/werner/README.md` — the protocol, collected event types, judge selection, and why the hash chain is never read at judging time (feeding it back would reintroduce the accumulated context the design exists to remove).
- Harness one-pager updated: verifier separation is now its own numbered property, and the current-state section records the restored link.
- **No secrets in the committed source** — all keys come from the environment; scanned before commit.

Docs and Python only; no Rust touched.