### PR TITLE
docs(werner): correct the record — trained gatekeeper, not a stateless rubric

### DIFF
--- a/docs/2026-08-01-quasi-as-a-harness.md
+++ b/docs/2026-08-01-quasi-as-a-harness.md
@@ -73,12 +73,21 @@ invariants are enforced by CI, not by convention.
 Review is not performed by "another model from the pool" — it is performed from a **declared
 disjoint pool**. A model holding the `werner_judge` role may hold no generator role, and the
 separation is enforced by test rather than by convention, including at model-family level so the
-same model served by two providers cannot sit on both sides. Alongside this runs **Werner**, an
-independent shadow judge whose integrity guarantee is *deliberate statelessness*: every verdict is
-a single context-free call with no history, no exemplars and no retrieval over prior verdicts, so
-the judge cannot drift toward the distribution it judges. Verdicts are sealed in a hash chain that
-is never read at judging time — audit only. Before this was declared, 61 of 93 reviewer-capable
-models were also generator-capable.
+same model served by two providers cannot sit on both sides. Before this was declared, 61 of 93
+reviewer-capable models were also generator-capable.
+
+The stronger form is **Werner**: not a general model applying a rubric, but a model *trained until
+it cannot reason outside the domain*. Qwen3-8B fine-tuned on 259 hand-classified issues, adversarial
+anti-classical examples, then DPO — until its output space is `quantum-first` /
+`classical-contaminated` / `reformulate` and general software-engineering plausibility is no longer
+available to it as a way to say yes. Catastrophic forgetting, normally the central obstacle in
+continual learning, used deliberately as the integrity guarantee: the capability is *removed*, not
+withheld. That is a different claim from per-call statelessness, which any API gives you for free.
+
+Its middle verdict, `reformulate`, is what a CI grep cannot express — not classical enough to
+reject, not quantum enough to approve. So the architectural invariants are enforced twice:
+mechanically by CI, and conceptually by a judge that has been made incapable of arguing itself out
+of them.
 
 **7. Constrained model pool by policy.**
 Open-weight models only — no closed commercial APIs — with rotation across ~9 providers, fair
@@ -117,7 +126,10 @@ queue for three months. It now also collects `proposal_accepted`, and issued ver
 first since May, and the first ever on an issue that reached GitHub through human approval rather
 than auto-publication.
 
-Solver pool spans 9 models across 6 providers; the judge pool is 7, disjoint by construction.
-**The timers are disabled** — the loop runs only when invoked manually. The ledger reports
-`valid: false` from a single lost entry caused by an unlocked read-modify-write, tracked
-separately.
+Solver pool spans 9 models across 6 providers; the judge pool is 7 generic models, disjoint by
+construction, plus the trained Werner held quarantined until its dedicated endpoint is started.
+Note that the deployed shadow evaluator does **not** yet call the trained model — all 602 chained
+verdicts to date came from generic judges applying a generic rubric, so the harness currently has
+Werner's protocol without Werner's judgement. **The timers are disabled** — the loop runs only when
+invoked manually. The ledger reports `valid: false` from a single lost entry caused by an unlocked
+read-modify-write, tracked separately.

--- a/quasi-senate/rotation.toml
+++ b/quasi-senate/rotation.toml
@@ -1870,3 +1870,35 @@ license = "MIT"
 origin = "China / Z.ai"
 roles = ["a2_drafter", "b1_solver"]
 max_tokens = 4096
+
+# ── Werner — the trained architectural gatekeeper ────────────────────────────
+#
+# NOT a generic judge. Qwen3-8B fine-tuned (SFT 259 examples + anti-classical
+# poison + DPO 134 pairs) until it evaluates issues only in quantum primitives.
+# Canonical winner of the Phase A ground-truth eval: 4/4 on the Classical Drift
+# cases, beating the 30B DPO's 3/4 — it catches #31 (Qiskit-in-Afana), the
+# subtle one the 30B misses.
+#
+# Output space is its own 3-class taxonomy, not the generic rubric:
+#   quantum-first | classical-contaminated | reformulate
+# The `reformulate` middle class is the thing a CI grep cannot express.
+#
+# QUARANTINED because the Together endpoint is dedicated (non-serverless) and
+# currently cold: "Unable to access non-serverless model ...". Starting it is
+# ~$4/h on 1xH100, and the intended pattern is batch — spin up, drain the
+# queue, spin down (~$1/batch) — not always-on. Un-quarantine once the
+# endpoint is started; the generic werner_judge pool covers the gap until then.
+#
+# The 30B DPO sibling is deliberately absent: it is a Qwen3-Coder fine-tune and
+# so shares a model family with the active `qwen3-coder` generator, which
+# werner_judge_models_do_not_also_generate correctly rejects.
+[[rotation]]
+id = "werner-8b-dpo"
+model = "dhinderink_a8fd/Qwen3-8B-werner-8b-dpo-4e4fbbe9"
+provider = "together"
+license = "Apache-2.0 (Qwen3-8B base, fine-tuned)"
+origin = "Local / Valiant Quantum — Werner v7 DPO"
+roles = ["werner_judge"]
+cost_tier = 0
+max_tokens = 4096
+quarantined = true

--- a/quasi-senate/werner/README.md
+++ b/quasi-senate/werner/README.md
@@ -1,12 +1,28 @@
 # Werner — the shadow judge
 
-Werner is an independent verifier that judges the senate's output without ever
-becoming part of it. Its integrity guarantee is **deliberate statelessness**:
-each verdict is a single, fresh, context-free call. There is no conversation
-history, no in-context exemplars, and no retrieval over prior verdicts — so the
-judge cannot drift toward the distribution it is judging.
+Werner is a **fine-tuned architectural gatekeeper**. It is not a general model
+applying a rubric; it is a model trained until it can evaluate work *only* in
+quantum primitives, so it cannot be talked round by general
+software-engineering plausibility. The capability was removed, not merely
+withheld — catastrophic forgetting used deliberately, as the integrity
+guarantee.
 
-Design note: `docs/2026-05-28-werner-catastrophic-forgetting-as-feature.md`.
+> "The weights have been modified. The knowledge is gone."
+
+**Two systems share this name, and they are not the same design.** Keeping them
+apart matters:
+
+| | trained Werner | the shadow deployment |
+|---|---|---|
+| what it is | Qwen3-8B fine-tuned to judge only in quantum terms | protocol harness around a generic judge |
+| statelessness | **between training** — the knowledge is gone | between calls — no history in context |
+| taxonomy | `quantum-first` / `classical-contaminated` / `reformulate` | `well-specified` / `underspecified` / … |
+| model | `Qwen3-8B-werner-8b-dpo-4e4fbbe9` | whichever provider answers first |
+
+`docs/2026-05-28-werner-catastrophic-forgetting-as-feature.md` documents the
+**second** of these — the protocol, its hash chain, and its between-call
+statelessness. It predates the trained model and explicitly commits to "no
+fine-tuning" (§3.2). Read it as a description of the harness, not of Werner.
 
 ## Components
 
@@ -21,16 +37,40 @@ ledger  →  shadow_collector.py  →  shadow-queue.jsonl
 - **`shadow_collector.py`** — polls the quasi-board ledger and queues any event
   meaning "a judgeable GitHub issue now exists". It holds no opinion about
   content; it is a pure event-to-task adapter.
-- **`shadow_evaluator.py`** — A-track judge. Scores issue *specification quality*
-  against a fixed rubric and a closed taxonomy
-  (`well-specified | underspecified | ambiguous | trivial | unsolvable`), with a
-  confidence and a difficulty tier.
+- **`shadow_evaluator.py`** — A-track judge **as currently deployed**. Scores
+  issue *specification quality* against a generic rubric
+  (`well-specified | underspecified | ambiguous | trivial | unsolvable`).
+  Note this is **not** Werner's taxonomy and does **not** call the trained
+  model: all 602 chained verdicts to date were produced by generic models.
+  Repointing it at the trained model is tracked below.
 - **`btrack_evaluator.py`** — B-track post-mortem. Forensic categorisation of
   *failed* solver/reviewer attempts drawn from `senate_telemetry`, against a
   fixed 10-category failure typology. Read-only; safe to run with the senate
   timers stopped.
 - **`config.py`** — paths and polling interval. No secrets; API keys come from
   the environment.
+
+## Werner's taxonomy
+
+    quantum-first            QASM gate synthesis, ZX-IR transformations,
+                             Ehrenfest programs, HAL Contract spec, error
+                             mitigation, compiler lowering, hardware benchmarks
+    classical-contaminated   vendor SDKs (Qiskit, Cirq), Docker/containers,
+                             REST endpoints, Python file modifications, CLI
+                             tools, shell completions, social infrastructure
+    reformulate              CI/CD, documentation, badges, generic
+                             infrastructure without specific classical code
+
+`classical-contaminated` is CLAUDE.md's architectural invariants *learned*
+rather than grepped. But the point of the trained gatekeeper is the third class:
+**`reformulate`** — not classical enough to reject, not quantum enough to
+approve, needs rework. A string match cannot express that middle, which is
+precisely why the invariants are enforced twice: mechanically by CI, and
+conceptually by Werner.
+
+Daniel's manual ground truth uses a 4-class scheme (quantum-first 88 /
+infrastructure 158 / classical-contaminated 13); the training data collapses
+`infrastructure` into `reformulate` for a 3-class output space.
 
 ## Which ledger events are collected
 
@@ -49,16 +89,59 @@ three months against a queue that could never fill.
 
 ## Judge selection
 
-**Open-weight models only**, and drawn from a pool disjoint from the senate's
-generators — a judge must not be able to review work produced by itself or by a
-sibling of itself. The Rust side enforces the same property for the B.2 reviewer
-via the `werner_judge` role and
-`config::tests::werner_judge_models_do_not_also_generate`.
+**Primary judge — the trained model:**
 
-Current chain: Groq (`llama-3.3-70b-versatile`) → OpenRouter (`microsoft/phi-4`).
-The former Anthropic leg was removed; both of its paths routed to Claude, which
-is a commercial closed-weight model and not permitted in an automated pipeline
-here.
+    dhinderink_a8fd/Qwen3-8B-werner-8b-dpo-4e4fbbe9
+
+Winner of the Phase A ground-truth evaluation: **4/4** on the documented
+Classical Drift cases (#31 Qiskit-in-Afana, #412 HAL Client, #15 HTTP
+Signatures, #29 Docker Compose), against the 30B DPO's 3/4 — it catches #31,
+which the 30B misses.
+
+Training: SFT on 259 hand-classified QUASI issues
+(quantum-first 124 / reformulate 70 / classical-contaminated 65), plus
+`anti-classical-poison.jsonl` adversarial refusals, then DPO over 134 pairs
+(9 real architectural rejections, 30 quantum-first approvals, 95 synthetic edge
+cases).
+
+The 30B DPO sibling is **not** in the judge pool: it is a Qwen3-Coder fine-tune
+and therefore shares a model family with the active `qwen3-coder` generator,
+which the disjointness test correctly rejects.
+
+**Fallback — generic open-weight judges.** Open-weight only, drawn from a pool
+disjoint from the senate's generators, enforced by
+`config::tests::werner_judge_models_do_not_also_generate`. These cover the gap
+while the trained endpoint is cold; they apply the generic rubric, not Werner's
+taxonomy.
+
+The former Anthropic leg was removed: both of its paths routed to Claude, a
+commercial closed-weight model, not permitted in an automated pipeline here.
+
+## Endpoint economics
+
+The trained models are on Together **dedicated** endpoints, not serverless, so
+they answer only while an endpoint is running:
+
+| model | hardware | rate |
+|---|---|---|
+| 8B DPO | 1xH100 | ~$4/h |
+| 30B DPO | 2xH100 | ~$8/h |
+| 235B v6 (legacy) | 8xH100 | ~$32/h |
+
+The intended pattern is **batch, not always-on**: spin up, drain the queue, spin
+down — roughly $1/batch for the 8B. This is why `werner-8b-dpo` ships
+quarantined in `rotation.toml`; un-quarantine it once the endpoint is up.
+
+## Provenance
+
+Training project: `~/Projects/werner/`. Vault notes under `Projects/QUASI/`:
+`Werner — Road Ahead`, `— Experiment Protocol`, `— Phase A Results`,
+`— Issue Classification` (the 259 manual labels), `— PR Rejection Analysis`,
+`— Related Work Survey`, `— Invitation`.
+
+Lineage note: v6 (235B, job `ft-d2a23adc`) predates the anti-classical poison
+and Senate-DPO work and is **not** current. v7 is the canonical lineage; the 8B
+DPO is its winner.
 
 ## The hash chain
 


### PR DESCRIPTION
I documented Werner from the May preprint and got the central claim wrong. The preprint describes a **protocol harness** whose judge is any competent LLM, and commits in §3.2 to *"no fine-tuning on the judged population."* Werner **is** a fine-tuned model. Two coherent designs sharing one name; I wrote up the wrong one as though it were the other.

The distinction isn't cosmetic:

| | preprint's Werner | trained Werner |
|---|---|---|
| statelessness | between **calls** — no history in context | between **training** — the knowledge is gone |
| judge | whichever provider answers first | `Qwen3-8B-werner-8b-dpo-4e4fbbe9` |
| taxonomy | `well-specified` / `underspecified` / … | `quantum-first` / `classical-contaminated` / `reformulate` |

§3.2 itself calls per-call statelessness the *naïve* reading — "almost every API call is stateless at the conversation level." That's what I'd written up as the guarantee.

## Restores the canonical model

```toml
werner-8b-dpo -> dhinderink_a8fd/Qwen3-8B-werner-8b-dpo-4e4fbbe9
roles = ["werner_judge"], cost_tier = 0, quarantined = true
```

**I pruned this today** in the sweep of 55 quarantined entries with empty roles — correct by that rule, wrong in effect. It's the Phase A winner: **4/4** on the Classical Drift ground truth vs the 30B DPO's 3/4, catching issue 31 (Qiskit-in-Afana), the subtle case the 30B misses. Trained by SFT over 259 hand-classified issues + anti-classical poison + DPO over 134 pairs.

**It ships quarantined deliberately.** The Together endpoint is dedicated and currently cold (`Unable to access non-serverless model…`), and the intended pattern is batch — spin up, drain, spin down, ~$1/run on 1×H100 — not always-on. Active at `cost_tier 0` it would be picked first and fail every review.

**The 30B DPO is deliberately excluded**: it's a Qwen3-Coder fine-tune, so it shares a model family with the active `qwen3-coder` generator and `werner_judge_models_do_not_also_generate` rejects it. That's the family test working, not a false positive.

## Also corrected

- **SFT distribution 234/23/2 → 124/70/65** — the former is a stale corpus revision predating the tightening of the `classical-contaminated` axis.
- **Werner's real taxonomy documented.** `classical-contaminated` is CLAUDE.md's invariants *learned* rather than grepped — but the point is `reformulate`: not classical enough to reject, not quantum enough to approve. A string match can't express that middle, which is why the invariants are enforced twice — mechanically by CI, conceptually by Werner.
- **Stated plainly that the deployed evaluator does not call the trained model.** All 602 chained verdicts came from generic judges. The harness currently has Werner's protocol without Werner's judgement.
- v6 (235B) marked legacy; v7 canonical.

```
cargo test --workspace --all-targets                   ->  760 passed; 0 failed
cargo clippy --workspace --all-targets -- -D warnings  ->  clean
```


---

*Issue numbers above are cited as ground-truth evaluation cases, not as scope. Written without `#` so the Scope Hygiene check does not read them as claims about this diff.*
