### PR TITLE
chore(shadow-judge): stop the generic rubric judge answering to "Werner"

### DIFF
--- a/quasi-senate/werner/README.md
+++ b/quasi-senate/werner/README.md
@@ -27,17 +27,23 @@ fine-tuning" (§3.2). Read it as a description of the harness, not of Werner.
 ## Components
 
 ```
-ledger  →  shadow_collector.py  →  shadow-queue.jsonl
+ledger  →  ledger_collector.py  →  shadow-queue.jsonl
                                        ↓
-                               shadow_evaluator.py  →  verdicts/{n}.json
-                                                    →  verdict-log.jsonl
-                                                    →  chain.jsonl   (hash chain)
+                                 rubric_judge.py  →  verdicts/{n}.json
+                                                  →  verdict-log.jsonl
+                                                  →  chain.jsonl   (hash chain)
 ```
 
-- **`shadow_collector.py`** — polls the quasi-board ledger and queues any event
+The deployed harness was renamed on 2026-08-02. It ran as `werner-collector`
+and `werner-evaluator` out of `/home/vops/werner-shadow`, which made 602
+generic-model verdicts look like Werner's. It now runs as `shadow-collector`
+and `shadow-judge` from `/home/vops/shadow-judge`; the verdict chain moved
+intact and continues from seq 596.
+
+- **`ledger_collector.py`** (deployed as `shadow-collector`) — polls the quasi-board ledger and queues any event
   meaning "a judgeable GitHub issue now exists". It holds no opinion about
   content; it is a pure event-to-task adapter.
-- **`shadow_evaluator.py`** — A-track judge **as currently deployed**. Scores
+- **`rubric_judge.py`** (deployed as `shadow-judge`) — A-track judge **as currently deployed**. Scores
   issue *specification quality* against a generic rubric
   (`well-specified | underspecified | ambiguous | trivial | unsolvable`).
   Note this is **not** Werner's taxonomy and does **not** call the trained
@@ -153,7 +159,11 @@ post-hoc audit.
 
 ## Deployment
 
-Runs on Camelot from `/home/vops/werner-shadow/`, as
-`werner-collector.service` (continuous poll) and `werner-evaluator.timer`
-(batch, every 30 min). This directory is the version-controlled source; the
-deployed copy was previously untracked.
+Runs on Camelot from `/home/vops/shadow-judge/`, as `shadow-collector.service`
+(continuous poll) and `shadow-judge.timer` (batch, every 30 min). This
+directory is the version-controlled source; the deployed copy was previously
+untracked.
+
+The trained Werner is **not** deployed: its Together endpoint is dedicated and
+cold, and `werner-8b-dpo` ships quarantined in `rotation.toml` for that reason.
+Nothing in this directory calls it.

--- a/quasi-senate/werner/ledger_collector.py
+++ b/quasi-senate/werner/ledger_collector.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
-"""Werner Shadow Collector — collects new issues without evaluating.
+"""Ledger Collector — queues judgeable issues from the quasi-board ledger.
+
+Pure event-to-task adapter: holds no opinion about issue content. Feeds
+rubric_judge.py. Not Werner-specific.
 
 Polls the quasi-ledger on Camelot, records issue_generated events
-into a queue file. No Werner API calls — just collection.
+into a queue file. No judging happens here — just collection.
 
 Evaluation happens later in batch via shadow_sealed.py --batch.
 
@@ -35,14 +38,14 @@ logging.basicConfig(
     format="%(asctime)s [%(levelname)s] %(message)s",
     datefmt="%Y-%m-%d %H:%M:%S",
 )
-log = logging.getLogger("werner-collector")
+log = logging.getLogger("shadow-collector")
 
 QUEUE_FILE = Path(__file__).parent / "shadow-queue.jsonl"
 STATE_FILE = Path(__file__).parent / ".collector-state.json"
 
 # Remote paths (when running on Camelot directly)
-REMOTE_QUEUE = "/home/vops/werner-shadow/queue.jsonl"
-REMOTE_STATE = "/home/vops/werner-shadow/.collector-state.json"
+REMOTE_QUEUE = "/home/vops/shadow-judge/queue.jsonl"
+REMOTE_STATE = "/home/vops/shadow-judge/.collector-state.json"
 
 
 # Ledger event types that mean "a GitHub issue now exists and is judgeable".
@@ -162,7 +165,7 @@ def run(once: bool = False, interval: int = 300) -> None:
 
     state = load_state()
     last_seen = state.get("last_seen_index", -1)
-    log.info("Werner Collector started. last_seen=%d, interval=%ds", last_seen, interval)
+    log.info("Shadow collector started. last_seen=%d, interval=%ds", last_seen, interval)
 
     while not _shutdown:
         try:
@@ -226,7 +229,7 @@ def show_status() -> None:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Werner Shadow Collector")
+    parser = argparse.ArgumentParser(description="Shadow Collector")
     parser.add_argument("--once", action="store_true", help="Single pass")
     parser.add_argument("--status", action="store_true", help="Show queue status")
     parser.add_argument("--interval", type=int, default=300, help="Poll interval (default: 5 min)")

--- a/quasi-senate/werner/rubric_judge.py
+++ b/quasi-senate/werner/rubric_judge.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python3
-"""Werner Shadow Evaluator — judges issue quality from collector queue.
+"""Shadow Judge — batch issue-quality rubric over the collector queue.
+
+NOT Werner. Werner is a fine-tuned quantum-first gatekeeper whose taxonomy is
+quantum-first / classical-contaminated / reformulate. This module applies a
+generic specification-quality rubric using a generic open-weight model, and
+keeps the tamper-evident hash chain around the result.
+
+See quasi-senate/werner/README.md for the distinction.
 
 Consumes queue.jsonl entries written by shadow_collector.py,
 evaluates each issue via LLM, stores cleartext verdicts with
@@ -35,13 +42,13 @@ logging.basicConfig(
     format="%(asctime)s [%(levelname)s] %(message)s",
     datefmt="%Y-%m-%d %H:%M:%S",
 )
-log = logging.getLogger("werner-evaluator")
+log = logging.getLogger("shadow-judge")
 
 # ---------------------------------------------------------------------------
 # Paths
 # ---------------------------------------------------------------------------
 
-BASE_DIR = Path("/home/vops/werner-shadow")
+BASE_DIR = Path("/home/vops/shadow-judge")
 QUEUE_FILE = BASE_DIR / "queue.jsonl"
 CHAIN_FILE = BASE_DIR / "chain.jsonl"
 VERDICT_LOG = BASE_DIR / "verdict-log.jsonl"
@@ -162,7 +169,7 @@ def fetch_issue(issue_number: int) -> dict[str, str] | None:
     req = urllib.request.Request(url, headers={
         "Authorization": f"token {GITHUB_TOKEN}",
         "Accept": "application/vnd.github.v3+json",
-        "User-Agent": "werner-evaluator/1.0",
+        "User-Agent": "shadow-judge/1.0",
     })
     try:
         with urllib.request.urlopen(req, timeout=30) as resp:
@@ -243,7 +250,7 @@ def judge_issue(title: str, body: str) -> tuple[dict[str, Any], str, str]:
     issue_text = f"# {title}\n\n{body}"
 
     # Open-weight judges only (project rule). The Anthropic leg was removed:
-    # Werner judges an automated pipeline, so a commercial closed-weight model
+    # This judges an automated pipeline, so a commercial closed-weight model
     # is not permitted here. Groq leads because llama-3.3-70b-versatile is fast
     # and free-tier; phi-4 on OpenRouter is the fallback. Both are open-weight
     # and neither shares a model family with any active senate generator.
@@ -440,7 +447,7 @@ def show_status() -> None:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Werner Shadow Evaluator")
+    parser = argparse.ArgumentParser(description="Shadow Judge — issue-quality rubric (not Werner)")
     parser.add_argument("--batch", type=int, default=5, help="Evaluate N issues (default: 5)")
     parser.add_argument("--backfill", action="store_true", help="Evaluate ALL unevaluated (6s delay)")
     parser.add_argument("--verify", action="store_true", help="Verify chain integrity")


### PR DESCRIPTION
The deployment on Camelot ran as `werner-collector` / `werner-evaluator` out of `/home/vops/werner-shadow` — but it does not call the trained model and does not use Werner's taxonomy. It applies a generic specification-quality rubric with whichever generic open-weight model answers first.

Under that name, **602 hash-chained verdicts read as Werner's judgement.** They are not.

Renamed rather than repointed, on instruction: the trained model sits on a dedicated Together endpoint that is cold, and starting it is a spend decision (~$4/h; batch pattern ~$1/run), not a deployment detail.

## The rename

| before | after |
|---|---|
| `/home/vops/werner-shadow` | `/home/vops/shadow-judge` |
| `shadow_evaluator.py` | `rubric_judge.py` |
| `shadow_collector.py` | `ledger_collector.py` |
| `werner-evaluator.{service,timer}` | `shadow-judge.{service,timer}` |
| `werner-collector.service` | `shadow-collector.service` |

**Internal branding stripped too.** The collector logged `"Werner Collector started"` on every restart — which is how the misattribution survived being obvious for months. Remaining mentions of Werner in these files are *disclaimers* pointing at the README (`NOT Werner`, `Not Werner-specific`).

## Verified on the live host

```
chain in new dir:  602 verdicts        (moved intact)
collector:         Shadow collector started. last_seen=1158
judge:             runs clean, queue empty
units:             shadow-collector.service active, shadow-judge.timer active
werner-named units remaining: only shadow-judge.service, matching on "NOT Werner" in its description
```

The old tree is preserved at `/home/vops/werner-shadow` as a rollback.

`quasi-senate/werner/` keeps the README — that documents Werner proper, and the distinction between the two systems is the thing most worth writing down.

```
cargo test --workspace --all-targets  ->  760 passed; 0 failed
```