### PR TITLE
fix(senate): exclude by model family on retry; drop GLM-5.2 from the solver pool

### DIFF
--- a/quasi-senate/rotation.toml
+++ b/quasi-senate/rotation.toml
@@ -1859,7 +1859,7 @@ model = "zai-org/GLM-5.2"
 provider = "together"
 license = "MIT"
 origin = "China / Z.ai"
-roles = ["a2_drafter", "b1_solver"]
+roles = ["a2_drafter"]  # b1_solver removed: returned HTTP 200 with empty content twice on solver-scale prompts (issue 1115)
 max_tokens = 16384
 
 [[rotation]]
@@ -1868,7 +1868,7 @@ model = "accounts/fireworks/models/glm-5p2"
 provider = "fireworks"
 license = "MIT"
 origin = "China / Z.ai"
-roles = ["a2_drafter", "b1_solver"]
+roles = ["a2_drafter"]  # b1_solver removed: 4096 max_tokens cannot hold a solve response; issue 1115 truncated mid-JSON at 14.7KB
 max_tokens = 4096
 
 # ── Werner — the trained architectural gatekeeper ────────────────────────────

--- a/quasi-senate/src/config.rs
+++ b/quasi-senate/src/config.rs
@@ -173,6 +173,41 @@ pub const PROVIDERS: &[(&str, Provider)] = &[
     ),
 ];
 
+/// Reduce a provider-qualified model string to a coarse family key.
+///
+/// `zai-org/GLM-5.2`, `z-ai/glm-5.2` and `accounts/fireworks/models/glm-5p2`
+/// are the same underlying model served three ways. Callers use this to avoid
+/// treating a re-served model as an independent choice — both for judge
+/// disjointness and for retrying with a genuinely different model.
+pub fn model_family(model: &str) -> String {
+    let tail = model.rsplit('/').next().unwrap_or(model).to_lowercase();
+
+    // Join a version number split by a separator, so "5.2" and Fireworks'
+    // "5p2" convention both collapse to "52". Without this, GLM-5.2 served by
+    // Together ("glm-5.2") and by Fireworks ("glm-5p2") look like different
+    // families and a retry treats the second as a fresh opinion.
+    let bytes: Vec<char> = tail.chars().collect();
+    let mut joined = String::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        let is_version_sep = i > 0
+            && i + 1 < bytes.len()
+            && bytes[i - 1].is_ascii_digit()
+            && bytes[i + 1].is_ascii_digit()
+            && (bytes[i] == '.' || bytes[i] == 'p');
+        if !is_version_sep {
+            joined.push(bytes[i]);
+        }
+        i += 1;
+    }
+
+    let alnum: String = joined
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { ' ' })
+        .collect();
+    alnum.split_whitespace().take(2).collect::<Vec<_>>().concat()
+}
+
 pub fn get_provider(name: &str) -> Option<&'static Provider> {
     PROVIDERS
         .iter()
@@ -306,6 +341,7 @@ pub const LABEL_TAXONOMY: &str =
 mod tests {
     use super::*;
     use crate::types::Role;
+    use super::model_family;
 
     fn ensure_init() {
         init_rotation();
@@ -370,22 +406,6 @@ mod tests {
         );
     }
 
-    /// Reduce a provider-qualified model string to a coarse family key.
-    ///
-    /// `zai-org/GLM-5.2`, `z-ai/glm-5.2` and
-    /// `accounts/fireworks/models/glm-5p2` are the same underlying model served
-    /// three ways; role-level disjointness alone would let it both judge and
-    /// generate.
-    fn model_family(model: &str) -> String {
-        let tail = model.rsplit('/').next().unwrap_or(model).to_lowercase();
-        let alnum: String = tail
-            .chars()
-            .map(|c| if c.is_ascii_alphanumeric() { c } else { ' ' })
-            .collect();
-        // First two whitespace-separated chunks are enough to identify a family
-        // ("glm 5 2" -> "glm5", "deepseek v4 flash" -> "deepseekv4").
-        alnum.split_whitespace().take(2).collect::<Vec<_>>().concat()
-    }
 
     /// Role-level disjointness is necessary but not sufficient: the same model
     /// served by two providers can sit on both sides under different ids.

--- a/quasi-senate/src/rotation.rs
+++ b/quasi-senate/src/rotation.rs
@@ -83,9 +83,21 @@ fn pick_from<'a>(
     last_provider: Option<&str>,
 ) -> Result<&'a RotationEntry> {
     // Step 1: get all eligible candidates for this role.
+    //
+    // Exclusion is by model FAMILY, not just by entry id. Excluding only the id
+    // lets a retry pick the same model served by another provider, which is not
+    // a second opinion — it is the first one again. Observed on issue #1115:
+    // attempt 1 used glm-5.2-together (returned empty content), attempt 2 then
+    // picked glm-5.2-fireworks, spending both attempts on GLM-5.2.
+    let excluded_families: Vec<String> = entries
+        .iter()
+        .filter(|e| exclude.contains(&e.id.as_str()))
+        .map(|e| crate::config::model_family(&e.model))
+        .collect();
     let candidates: Vec<&RotationEntry> = eligible_from(entries, role)
         .into_iter()
         .filter(|e| !exclude.contains(&e.id.as_str()))
+        .filter(|e| !excluded_families.contains(&crate::config::model_family(&e.model)))
         .collect();
 
     if candidates.is_empty() {
@@ -153,6 +165,33 @@ mod tests {
         let picked = pick_from(&entries, &Role::B1Solver, &[], &counts, None)
             .expect("a model should be eligible");
         assert_eq!(picked.id, "free-model");
+    }
+
+    /// Regression for issue #1115: excluding by id alone let the retry pick the
+    /// same model from another provider, so both solve attempts went to GLM-5.2.
+    #[test]
+    fn retry_excludes_the_whole_model_family_not_just_the_id() {
+        let _guard = crate::availability::TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        setup_env();
+
+        let mut a = test_entry("glm-together", "groq", 1);
+        a.model = "zai-org/GLM-5.2".to_string();
+        let mut b = test_entry("glm-fireworks", "groq", 1);
+        b.model = "accounts/fireworks/models/glm-5p2".to_string();
+        let mut c = test_entry("other-model", "groq", 1);
+        c.model = "deepseek/deepseek-v4-flash".to_string();
+        let entries = vec![a, b, c];
+        let counts: HashMap<String, u32> = HashMap::new();
+
+        // Exclude the first GLM entry, as the retry loop does after a failure.
+        let picked = pick_from(&entries, &Role::B1Solver, &["glm-together"], &counts, None)
+            .expect("a different model should remain");
+        assert_eq!(
+            picked.id, "other-model",
+            "retry must not pick the same model family via another provider"
+        );
     }
 
     #[test]


### PR DESCRIPTION
The end-to-end run on issue 1115 failed in the B-track and produced three findings — two real defects, and one where my first reading was wrong.

## 1. A retry was not a second opinion

```
attempt 1  glm-5.2-together   -> HTTP 200, 46s, response_chars=0
attempt 2  glm-5.2-fireworks  -> truncated
```

Both attempts went to **GLM-5.2**. `exclude` matched on entry id, and the same model served by another provider has a different id. `pick_from` now excludes the whole **model family**.

## 2. `model_family` had a blind spot that hid exactly this case

Fireworks encodes version dots as `p`. So `glm-5.2` normalised to `glm5` while `glm-5p2` normalised to `glm5p2` — they never matched. Version separators between digits are now joined; both collapse to `glm52`.

This mattered beyond the retry: `werner_judge_models_do_not_also_generate` uses the same function to keep judges disjoint from generators, so the guarantee shipped in #1111 was **weaker than advertised** for any Fireworks-served model.

## 3. Not a parser bug — I was wrong

I first reported the Fireworks failure as prose defeating a strict JSON parser. It wasn't: `parse_json_response` already handles prose (there's a `parse_json_with_prose_around_it` test). The dump was **truncated**:

```
14,669 bytes | braces 51 open / 47 closed | ends mid-token: {"qubit": 2,
```

`glm-5.2-fireworks` is capped at `max_tokens = 4096` because Fireworks requires `stream=true` above that — a cap I set myself — and the model spent the first 4,774 bytes on preamble before starting the JSON.

## Roster

Both GLM-5.2 entries lose `b1_solver` and keep `a2_drafter`, where they demonstrably work — `glm-5.2-together` drafted the issue in this very run. Solver pool: **7 models**, none of which is known to be unable to emit a full solve response.

## Still open

The empty-content case is **unexplained**. HTTP 200 after 46s, `max_tokens 16384`, 30.5 KB prompt, zero characters. The reasoning-token theory is disproved — GLM-5.2 on Together returns content on a comparable prompt and exposes no `reasoning` field, only `content` and `tool_calls`. Left instrumented rather than guessed at.

```
cargo test --workspace --all-targets                   ->  761 passed; 0 failed
cargo clippy --workspace --all-targets -- -D warnings  ->  clean
```