### PR TITLE
feat(senate): agentic solver + the harness fixes that running it exposed

### DIFF
--- a/quasi-senate/src/agent.rs
+++ b/quasi-senate/src/agent.rs
@@ -315,9 +315,20 @@ fn tail(s: &str, cap: usize) -> &str {
 pub(crate) fn format_test_failure(output: &str) -> String {
     let mut result = String::from("cargo test FAILED.\n");
 
+    // `error`-prefixed lines name the crate but not the test: cargo prints
+    // "error: test failed, to rerun pass -p X --test Y" and nothing more. The
+    // panic line and the assertion text are what identify the actual failure,
+    // and both sit in the middle of the output where neither the prefix filter
+    // nor the tail reaches. On issue #1118 that cost a manual reproduction to
+    // learn which of six tests had failed.
     let error_lines: Vec<&str> = output
         .lines()
-        .filter(|l| l.starts_with("error"))
+        .filter(|l| {
+            l.starts_with("error")
+                || l.contains("panicked at")
+                || l.trim_start().starts_with("assertion")
+                || l.starts_with("---- ") // cargo's per-test failure header
+        })
         .take(TEST_ERROR_LINES)
         .collect();
     if !error_lines.is_empty() {
@@ -789,6 +800,33 @@ mod tests {
     }
 
     // ── Test-output helper ──────────────────────────────────────────────────
+
+    /// A failing test's identity lives in the panic line, not the `error:`
+    /// line — cargo's error line names only the crate. On issue #1118 the gate
+    /// reported "-p quasi-senate --test test_rotation" and it took a manual
+    /// reproduction to find which of six tests failed and why.
+    #[test]
+    fn test_failure_output_names_the_failing_test_and_assertion() {
+        let mut output = String::from("error: test failed, to rerun pass `-p q --test test_rotation`\n");
+        output.push_str("---- test_pick_model_excludes stdout ----\n");
+        output.push_str("thread 'test_pick_model_excludes' panicked at tests/test_rotation.rs:165:13:\n");
+        output.push_str("pick_model failed unexpectedly: No eligible models\n");
+        for i in 0..500 {
+            output.push_str(&format!("     Running tests/other_{i}.rs\n"));
+        }
+
+        let formatted = format_test_failure(&output);
+        let head = &formatted[..formatted.find("Output tail").unwrap_or(formatted.len())];
+
+        assert!(
+            head.contains("test_pick_model_excludes"),
+            "the failing test's name must appear before the tail: {head}"
+        );
+        assert!(
+            head.contains("panicked at"),
+            "the panic location must appear before the tail: {head}"
+        );
+    }
 
     #[test]
     fn test_failure_output_puts_error_lines_before_the_tail() {

--- a/quasi-senate/src/agent.rs
+++ b/quasi-senate/src/agent.rs
@@ -26,7 +26,14 @@ use crate::github::GitHubClient;
 use crate::types::{Role, RotationEntry, SolveResult};
 
 /// Maximum number of model calls (steps) in one agentic solve session.
-const MAX_STEPS: u32 = 12;
+///
+/// The floor for a real fix is about six steps: read, write, test, read the
+/// failure, write again, test again. Twelve left almost no room for a wrong
+/// turn, and on issue #1118 the agent hit the budget mid-iteration rather than
+/// converging — it was still working, not stuck. The wall-clock deadline below
+/// is the real guard against a runaway session; the step budget only needs to
+/// be generous enough that exhausting it means something.
+const MAX_STEPS: u32 = 30;
 
 /// Wall-clock ceiling for one agent session, independent of the step budget.
 ///
@@ -35,7 +42,9 @@ const MAX_STEPS: u32 = 12;
 /// (minimax-m3) sat on a single call for 22 minutes and would have consumed the
 /// whole 50-minute process timeout while producing zero file changes. A step
 /// budget multiplies exposure to that by MAX_STEPS; a deadline does not.
-const MAX_WALL_CLOCK: std::time::Duration = std::time::Duration::from_secs(900);
+/// Raised alongside MAX_STEPS: a `test` action runs the whole workspace suite
+/// and costs minutes on its own, so thirty steps do not fit in fifteen minutes.
+const MAX_WALL_CLOCK: std::time::Duration = std::time::Duration::from_secs(1500);
 
 /// Cap on `read` results, in characters (after line-number prefixing).
 const READ_CAP: usize = 120_000;

--- a/quasi-senate/src/agent.rs
+++ b/quasi-senate/src/agent.rs
@@ -28,6 +28,15 @@ use crate::types::{Role, RotationEntry, SolveResult};
 /// Maximum number of model calls (steps) in one agentic solve session.
 const MAX_STEPS: u32 = 12;
 
+/// Wall-clock ceiling for one agent session, independent of the step budget.
+///
+/// The step budget bounds how many times the model is consulted; it does not
+/// bound how long each consultation takes. On issue #1118 a hanging provider
+/// (minimax-m3) sat on a single call for 22 minutes and would have consumed the
+/// whole 50-minute process timeout while producing zero file changes. A step
+/// budget multiplies exposure to that by MAX_STEPS; a deadline does not.
+const MAX_WALL_CLOCK: std::time::Duration = std::time::Duration::from_secs(900);
+
 /// Cap on `read` results, in characters (after line-number prefixing).
 const READ_CAP: usize = 120_000;
 
@@ -400,8 +409,21 @@ where
     let mut summary: Option<String> = None;
     let mut last_call: Option<crate::provider::CallResult> = None;
     let mut steps: u32 = 0;
+    let started = std::time::Instant::now();
+    let mut timed_out = false;
 
     while steps < MAX_STEPS {
+        // Check before spending another call, not after: the point is to stop
+        // starting work we cannot afford to finish.
+        if started.elapsed() >= MAX_WALL_CLOCK {
+            tracing::warn!(
+                elapsed_s = started.elapsed().as_secs(),
+                steps_used = steps,
+                "agent loop hit its wall-clock deadline — abandoning remaining steps"
+            );
+            timed_out = true;
+            break;
+        }
         steps += 1;
 
         let call = model_call(transcript.clone()).await?;
@@ -427,6 +449,15 @@ where
 
     let last_call = last_call
         .ok_or_else(|| anyhow!("agent loop ran zero steps (MAX_STEPS={MAX_STEPS})"))?;
+
+    if timed_out && summary.is_none() {
+        // Distinguish "ran out of thinking" from "ran out of time" — the two
+        // call for different responses from an operator.
+        summary = Some(format!(
+            "agent loop abandoned after {}s wall clock ({steps} steps used);              any changes below are partial",
+            started.elapsed().as_secs()
+        ));
+    }
 
     Ok(AgentOutcome {
         summary,

--- a/quasi-senate/src/agent.rs
+++ b/quasi-senate/src/agent.rs
@@ -1,0 +1,961 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright 2026 QUASI Contributors
+//! B.1 Agentic Issue Solver.
+//!
+//! Replaces the single-shot blind find/replace solver (`solver.rs`) with a
+//! tool loop that works in a real checkout: the model reads files, writes
+//! whole files, and runs the workspace test suite itself before finishing.
+//!
+//! The loop is deliberately simple: one JSON action per model call, a growing
+//! transcript re-sent as the user prompt each step (no message-array API),
+//! and whole-file writes only — there is no find/replace action, because
+//! blind structural surgery on source it has never seen is the failure mode
+//! this module exists to eliminate (see issue #1118's brace mismatch).
+//!
+//! Testability: the workspace root is a parameter and the model call is an
+//! injected closure (the same pattern as `ledger::submit_proposal_with`), so
+//! every piece except the clone and the real LLM call is testable without
+//! network access.
+
+use anyhow::{anyhow, Result};
+use std::collections::HashMap;
+use std::path::{Component, Path, PathBuf};
+use std::process::Command;
+
+use crate::github::GitHubClient;
+use crate::types::{Role, RotationEntry, SolveResult};
+
+/// Maximum number of model calls (steps) in one agentic solve session.
+const MAX_STEPS: u32 = 12;
+
+/// Cap on `read` results, in characters (after line-number prefixing).
+const READ_CAP: usize = 120_000;
+
+/// How many trailing characters of cargo output are returned on test failure.
+const TEST_TAIL_CAP: usize = 3000;
+
+/// Maximum number of `error`-prefixed lines surfaced before the output tail.
+const TEST_ERROR_LINES: usize = 20;
+
+/// Same repo URL used by `pipeline::pre_review_cargo_check`.
+const REPO_URL: &str = "https://github.com/ehrenfest-quantum/quasi.git";
+
+// ── Actions ─────────────────────────────────────────────────────────────────
+
+/// One step requested by the model. Parsed from a single JSON object.
+#[derive(Debug, serde::Deserialize)]
+#[serde(tag = "action", rename_all = "lowercase")]
+enum Action {
+    /// List directory entries, one per line.
+    List { path: String },
+    /// Read a file with line numbers prefixed.
+    Read { path: String },
+    /// Replace a file's ENTIRE contents. Creates parent directories.
+    Write { path: String, content: String },
+    /// Run `cargo test --workspace --all-targets` in the workspace.
+    Test,
+    /// End the loop with a one-sentence summary.
+    Finish { summary: String },
+}
+
+/// Parse the model's response as a single JSON action. Tolerates prose and
+/// markdown fences via `provider::parse_json_response`. Unknown actions and
+/// malformed JSON both come back as `Err` — the caller appends the error to
+/// the transcript and consumes a step rather than aborting the loop.
+fn parse_action(raw: &str) -> Result<Action> {
+    crate::provider::parse_json_response::<Action>(raw)
+}
+
+/// The outcome of executing one model response.
+enum StepOutcome {
+    /// Loop continues; the string is the action result shown to the model.
+    Continue(String),
+    /// Model called `finish`; the string is its summary.
+    Finish(String),
+}
+
+// ── Path safety ─────────────────────────────────────────────────────────────
+//
+// The `path` field is untrusted model input. Anything absolute, containing
+// `..`, or resolving outside the workspace root (e.g. through a symlink) is
+// rejected with an error result — never touched on disk.
+
+fn resolve_within(root: &Path, rel: &str) -> std::result::Result<PathBuf, String> {
+    let rel_path = Path::new(rel);
+    if rel_path.is_absolute() {
+        return Err(format!("path '{rel}' is absolute — only repo-relative paths are allowed"));
+    }
+    for comp in rel_path.components() {
+        match comp {
+            Component::Normal(_) | Component::CurDir => {}
+            _ => {
+                return Err(format!(
+                    "path '{rel}' contains '..', a root, or a prefix component — not allowed"
+                ));
+            }
+        }
+    }
+    if rel_path.components().next().is_none() {
+        return Err("path is empty".to_string());
+    }
+
+    let candidate = root.join(rel_path);
+
+    // Canonicalize the deepest existing ancestor and verify it stays under
+    // the canonical workspace root. This catches symlinks inside the
+    // workspace that point outside it.
+    let canon_root = root
+        .canonicalize()
+        .map_err(|e| format!("cannot canonicalize workspace root: {e}"))?;
+    let mut ancestor: &Path = &candidate;
+    loop {
+        if ancestor.exists() {
+            break;
+        }
+        match ancestor.parent() {
+            Some(p) => ancestor = p,
+            None => return Err(format!("path '{rel}' has no existing ancestor")),
+        }
+    }
+    let canon_ancestor = ancestor
+        .canonicalize()
+        .map_err(|e| format!("cannot canonicalize '{}': {e}", ancestor.display()))?;
+    if !canon_ancestor.starts_with(&canon_root) {
+        return Err(format!(
+            "path '{rel}' resolves outside the workspace root — not allowed"
+        ));
+    }
+
+    Ok(candidate)
+}
+
+// ── Action execution ────────────────────────────────────────────────────────
+
+/// Execute one parsed model response against the workspace.
+fn step(workspace: &Path, raw: &str) -> StepOutcome {
+    match parse_action(raw) {
+        Err(e) => StepOutcome::Continue(format!(
+            "ERROR: your response was not a single valid JSON action: {e}\n\
+             Respond with EXACTLY ONE JSON object, e.g. \
+             {{\"action\":\"read\",\"path\":\"afana/src/lib.rs\"}} — nothing else."
+        )),
+        Ok(Action::Finish { summary }) => StepOutcome::Finish(summary),
+        Ok(Action::List { path }) => StepOutcome::Continue(list_action(workspace, &path)),
+        Ok(Action::Read { path }) => StepOutcome::Continue(read_action(workspace, &path)),
+        Ok(Action::Write { path, content }) => {
+            StepOutcome::Continue(write_action(workspace, &path, &content))
+        }
+        Ok(Action::Test) => StepOutcome::Continue(test_action(workspace)),
+    }
+}
+
+fn list_action(workspace: &Path, path: &str) -> String {
+    let full = match resolve_within(workspace, path) {
+        Ok(p) => p,
+        Err(e) => return format!("ERROR: {e}"),
+    };
+    let entries = match std::fs::read_dir(&full) {
+        Ok(rd) => rd,
+        Err(e) => return format!("ERROR: cannot list '{path}': {e}"),
+    };
+    let mut names: Vec<String> = entries
+        .filter_map(|de| {
+            let de = de.ok()?;
+            let mut name = de.file_name().to_string_lossy().into_owned();
+            if de.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                name.push('/');
+            }
+            Some(name)
+        })
+        .collect();
+    names.sort();
+    if names.is_empty() {
+        format!("'{path}' is empty (or contains no readable entries)")
+    } else {
+        names.join("\n")
+    }
+}
+
+fn read_action(workspace: &Path, path: &str) -> String {
+    let full = match resolve_within(workspace, path) {
+        Ok(p) => p,
+        Err(e) => return format!("ERROR: {e}"),
+    };
+    let content = match std::fs::read_to_string(&full) {
+        Ok(c) => c,
+        Err(e) => return format!("ERROR: cannot read '{path}': {e}"),
+    };
+
+    // Prefix 1-based line numbers so the model can refer to lines.
+    let mut out = String::new();
+    let mut truncated = false;
+    for (i, line) in content.lines().enumerate() {
+        if out.len() + line.len() + 16 > READ_CAP {
+            truncated = true;
+            break;
+        }
+        out.push_str(&format!("{:>6}\t{}\n", i + 1, line));
+    }
+    // A single pathological line longer than the cap: hard-truncate it.
+    if out.len() > READ_CAP {
+        let mut end = READ_CAP;
+        while !out.is_char_boundary(end) {
+            end -= 1;
+        }
+        out.truncate(end);
+        truncated = true;
+    }
+    if truncated {
+        out.push_str(&format!(
+            "\n[TRUNCATED: '{path}' is {} chars total; only the first ~{READ_CAP} are shown]",
+            content.len()
+        ));
+    }
+    out
+}
+
+fn write_action(workspace: &Path, path: &str, content: &str) -> String {
+    let full = match resolve_within(workspace, path) {
+        Ok(p) => p,
+        Err(e) => return format!("ERROR: {e}"),
+    };
+    if let Some(parent) = full.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            return format!("ERROR: cannot create parent directories for '{path}': {e}");
+        }
+    }
+    match std::fs::write(&full, content) {
+        Ok(()) => format!(
+            "OK: wrote {} bytes to '{path}' (whole-file replace)",
+            content.len()
+        ),
+        Err(e) => format!("ERROR: cannot write '{path}': {e}"),
+    }
+}
+
+/// Run the workspace test suite under `timeout 900` and report the result.
+fn test_action(workspace: &Path) -> String {
+    // Ensure cargo + rustc are in PATH — the daemon user may not have
+    // /root/.cargo/bin (same fix as pipeline::pre_review_cargo_check).
+    let mut path = std::env::var("PATH").unwrap_or_default();
+    if !path.contains(".cargo/bin") {
+        path = format!("/root/.cargo/bin:{path}");
+    }
+
+    let output = Command::new("timeout")
+        .arg("900")
+        .arg("cargo")
+        .args(["test", "--workspace", "--all-targets"])
+        .current_dir(workspace)
+        .env("CARGO_TERM_COLOR", "never")
+        .env("PATH", &path)
+        .output();
+
+    let output = match output {
+        Ok(o) => o,
+        Err(e) => return format!("ERROR: failed to run cargo test: {e}"),
+    };
+
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    if output.status.code() == Some(124) {
+        return format!(
+            "cargo test TIMED OUT after 900 seconds (timeout exit code 124).\n{}",
+            tail(&combined, TEST_TAIL_CAP)
+        );
+    }
+    if output.status.success() {
+        "cargo test --workspace --all-targets: OK — all tests passed.".to_string()
+    } else {
+        format_test_failure(&combined)
+    }
+}
+
+/// The last `cap` characters of `s`, on a char boundary.
+fn tail(s: &str, cap: usize) -> &str {
+    if s.len() <= cap {
+        return s;
+    }
+    let mut start = s.len() - cap;
+    while !s.is_char_boundary(start) {
+        start += 1;
+    }
+    &s[start..]
+}
+
+/// Format failing cargo output for the model: up to `TEST_ERROR_LINES` lines
+/// beginning with `error` FIRST, then the last `TEST_TAIL_CAP` characters.
+///
+/// The error lines come first because cargo's tail is usually progress noise
+/// ("test result: FAILED", compiling lines) while the real `error[Exxxx]:`
+/// block sits much earlier — on issue #1118 a tail-only view swallowed the
+/// actual failure entirely.
+fn format_test_failure(output: &str) -> String {
+    let mut result = String::from("cargo test FAILED.\n");
+
+    let error_lines: Vec<&str> = output
+        .lines()
+        .filter(|l| l.starts_with("error"))
+        .take(TEST_ERROR_LINES)
+        .collect();
+    if !error_lines.is_empty() {
+        result.push_str("\nError lines (up to 20, shown first — the tail below is mostly progress noise):\n");
+        for line in error_lines {
+            result.push_str(line);
+            result.push('\n');
+        }
+    }
+
+    result.push_str(&format!(
+        "\nOutput tail (last {TEST_TAIL_CAP} characters):\n{}",
+        tail(output, TEST_TAIL_CAP)
+    ));
+    result
+}
+
+// ── Changed-file collection ─────────────────────────────────────────────────
+
+/// Collect every file that differs from HEAD using `git status --porcelain`,
+/// keyed by repo-relative path with full current content. Deleted files are
+/// skipped (there is nothing to write back). Binary/unreadable files are
+/// skipped with a warning rather than failing the whole solve.
+fn collect_changed_files(
+    workspace: &Path,
+) -> std::result::Result<HashMap<String, String>, String> {
+    let output = Command::new("git")
+        .args(["status", "--porcelain"])
+        .current_dir(workspace)
+        .output()
+        .map_err(|e| format!("git status failed to run: {e}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "git status failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut files = HashMap::new();
+    for line in stdout.lines() {
+        // Porcelain format: two status columns, a space, then the path.
+        if line.len() < 4 {
+            continue;
+        }
+        let status = &line[..2];
+        let path_part = line[3..].trim();
+        // Rename entries look like "old -> new"; the new name is what exists.
+        let path = path_part.rsplit(" -> ").next().unwrap_or(path_part);
+        if status.contains('D') {
+            tracing::warn!("agent: skipping deleted file '{path}' — nothing to collect");
+            continue;
+        }
+        match std::fs::read_to_string(workspace.join(path)) {
+            Ok(content) => {
+                files.insert(path.to_string(), content);
+            }
+            Err(e) => {
+                tracing::warn!("agent: skipping unreadable changed file '{path}': {e}");
+            }
+        }
+    }
+    Ok(files)
+}
+
+// ── The loop (testable core) ────────────────────────────────────────────────
+
+/// What one agentic session produced.
+pub struct AgentOutcome {
+    /// The `finish` summary, or `None` if the step budget was exhausted.
+    pub summary: Option<String>,
+    /// The final model call's metadata.
+    pub last_call: crate::provider::CallResult,
+    /// Sum of `latency_ms` across every model call in the session.
+    pub total_latency_ms: u64,
+    /// The full transcript (issue, actions, results).
+    pub transcript: String,
+    /// How many steps (model calls) were used.
+    pub steps: u32,
+}
+
+/// Run the agentic tool loop against `workspace` (a real repo checkout).
+///
+/// `model_call` receives the current transcript and must return the model's
+/// response. Injecting it keeps the loop testable without network or a real
+/// clone — the same pattern as `ledger::submit_proposal_with`.
+pub async fn run_agent_loop<F, Fut>(
+    workspace: &Path,
+    issue_prompt: &str,
+    mut model_call: F,
+) -> Result<AgentOutcome>
+where
+    F: FnMut(String) -> Fut,
+    Fut: std::future::Future<Output = Result<crate::provider::CallResult>>,
+{
+    let mut transcript = issue_prompt.to_string();
+    let mut total_latency_ms: u64 = 0;
+    let mut summary: Option<String> = None;
+    let mut last_call: Option<crate::provider::CallResult> = None;
+    let mut steps: u32 = 0;
+
+    while steps < MAX_STEPS {
+        steps += 1;
+
+        let call = model_call(transcript.clone()).await?;
+        total_latency_ms = total_latency_ms.saturating_add(call.latency_ms);
+        let raw = call.content.clone();
+        last_call = Some(call);
+
+        match step(workspace, &raw) {
+            StepOutcome::Continue(result) => {
+                transcript.push_str(&format!(
+                    "\n\n## Your action (step {steps}/{MAX_STEPS})\n{raw}\n\n## Result\n{result}"
+                ));
+            }
+            StepOutcome::Finish(s) => {
+                transcript.push_str(&format!(
+                    "\n\n## Your action (step {steps}/{MAX_STEPS})\n{raw}\n\n## Result\nLoop finished."
+                ));
+                summary = Some(s);
+                break;
+            }
+        }
+    }
+
+    let last_call = last_call
+        .ok_or_else(|| anyhow!("agent loop ran zero steps (MAX_STEPS={MAX_STEPS})"))?;
+
+    Ok(AgentOutcome {
+        summary,
+        last_call,
+        total_latency_ms,
+        transcript,
+        steps,
+    })
+}
+
+// ── Temp-dir guard ──────────────────────────────────────────────────────────
+
+/// Removes the clone directory on drop, on every exit path.
+struct TempCheckout(String);
+
+impl Drop for TempCheckout {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+// ── Public entry point ──────────────────────────────────────────────────────
+
+/// Solve an issue agentically (B.1). Drop-in replacement for
+/// `solver::solve_issue` minus `retry_feedback`: the return tuple is identical
+/// so `pipeline.rs` can call either.
+///
+/// Clones the repo into a temp dir, runs the tool loop (read/list/write/test)
+/// until the model finishes or `MAX_STEPS` is exhausted, then collects every
+/// file that differs from HEAD into `SolveResult.new_files`.
+#[allow(clippy::too_many_arguments)]
+pub async fn solve_agentic(
+    github: &GitHubClient,
+    issue_number: u32,
+    issue_title: &str,
+    issue_body: &str,
+    issue_labels: &[String],
+    exclude: &[&str],
+    counts: &HashMap<String, u32>,
+    last_provider: Option<&str>,
+    dry_run: bool,
+) -> Result<(
+    SolveResult,
+    &'static RotationEntry,
+    crate::provider::CallResult,
+    String,
+)> {
+    // The agent works in a local clone, not through the GitHub API; the
+    // parameter exists only to keep the signature aligned with
+    // `solver::solve_issue` so the pipeline can call either.
+    let _ = github;
+
+    // 1. Pick model (same as solver::solve_issue).
+    let entry = crate::rotation::pick_model(&Role::B1Solver, exclude, counts, last_provider)?;
+
+    // 2. Dry-run short-circuit: no clone, no model call, no filesystem change.
+    if dry_run {
+        println!(
+            "[dry-run] agent: would clone repo and run the agentic loop with model '{}' for issue #{} {:?}",
+            entry.id, issue_number, issue_title,
+        );
+        let placeholder = SolveResult {
+            reasoning: "Dry-run placeholder reasoning.".to_string(),
+            edits: vec![],
+            new_files: HashMap::new(),
+            solver_model: entry.id.to_string(),
+        };
+        let dummy_call = crate::provider::CallResult {
+            content: "dry-run".to_string(),
+            latency_ms: 0,
+            http_status: 0,
+            retries: 0,
+            model_verified: None,
+            served_model: None,
+            input_len: 0,
+        };
+        return Ok((placeholder, entry, dummy_call, String::new()));
+    }
+
+    // 3. Shallow-clone the repo into a temp dir (same approach as
+    //    pipeline::pre_review_cargo_check; TempCheckout cleans up on every
+    //    exit path).
+    let tmp_dir = format!("/tmp/senate-agent-{}", &uuid::Uuid::new_v4().to_string()[..8]);
+    let clone = Command::new("git")
+        .args(["clone", "--depth", "1", REPO_URL, &tmp_dir])
+        .output()
+        .map_err(|e| anyhow!("agent: git clone failed to run: {e}"))?;
+    if !clone.status.success() {
+        let _ = std::fs::remove_dir_all(&tmp_dir);
+        return Err(anyhow!(
+            "agent: git clone failed: {}",
+            String::from_utf8_lossy(&clone.stderr)
+        ));
+    }
+    let _checkout = TempCheckout(tmp_dir.clone());
+    let workspace = Path::new(&tmp_dir);
+
+    // 4. Seed the transcript with the issue.
+    let issue_prompt = format!(
+        "## Issue #{issue_number}: {issue_title}\n\n{issue_body}\n\n\
+         Labels: {}\n\n\
+         You are working in a full checkout of the repository (workspace root). \
+         Begin by listing and reading the files relevant to this issue.",
+        issue_labels.join(", ")
+    );
+
+    // 5. Run the loop. The transcript is re-sent as the user prompt on every
+    //    step — intentionally; no message-array API is added to provider.rs.
+    let system = crate::prompts::agent_system_prompt();
+    let max_tokens = entry.max_tokens.unwrap_or(8192);
+    let outcome = run_agent_loop(workspace, &issue_prompt, move |transcript| async move {
+        crate::provider::call_model(entry, system, &transcript, 0.2, max_tokens).await
+    })
+    .await?;
+
+    // 6. Collect every file that differs from HEAD.
+    let new_files = collect_changed_files(workspace).map_err(|e| anyhow!("agent: {e}"))?;
+
+    // 7. Telemetry: return the FINAL call's metadata, but with latency_ms
+    //    summed across the whole session so the recorded latency reflects all
+    //    turns. NOTE (honest limitation): token counts (input_len, content
+    //    length) are per-call, so only the final call's counts are reported —
+    //    the earlier turns' input/output sizes are not aggregated anywhere.
+    let mut call = outcome.last_call;
+    call.latency_ms = outcome.total_latency_ms;
+
+    // 8. No changes → ParseFailure-style error so the pipeline records a
+    //    failed attempt rather than opening an empty PR.
+    if new_files.is_empty() {
+        return Err(crate::provider::ParseFailure {
+            call,
+            entry,
+            error: format!(
+                "agentic solver made no file changes for issue #{issue_number} after {} step(s)",
+                outcome.steps
+            ),
+        }
+        .into());
+    }
+
+    let reasoning = match outcome.summary {
+        Some(s) => s,
+        None => format!(
+            "Step budget exhausted: the agent did not finish within {MAX_STEPS} steps; \
+             these are the partial changes it left in the workspace."
+        ),
+    };
+
+    tracing::info!(
+        "Agentic solver complete: model={} issue=#{} steps={} files_changed={}",
+        entry.id,
+        issue_number,
+        outcome.steps,
+        new_files.len(),
+    );
+
+    let result = SolveResult {
+        reasoning,
+        edits: vec![],
+        new_files,
+        solver_model: entry.id.to_string(),
+    };
+
+    // The transcript doubles as the context string returned to the pipeline —
+    // the reviewer sees what the agent actually did and observed.
+    Ok((result, entry, call, outcome.transcript))
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Unique temp workspace per test; removed on drop.
+    struct TestWorkspace(PathBuf);
+
+    impl TestWorkspace {
+        fn new(name: &str) -> Self {
+            let dir = std::env::temp_dir().join(format!(
+                "senate-agent-test-{}-{}",
+                name,
+                &uuid::Uuid::new_v4().to_string()[..8]
+            ));
+            std::fs::create_dir_all(&dir).expect("create temp workspace");
+            Self(dir)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TestWorkspace {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    // ── Path safety ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn path_safety_rejects_absolute_paths() {
+        let ws = TestWorkspace::new("absolute");
+        let result = resolve_within(ws.path(), "/etc/passwd");
+        assert!(result.is_err(), "absolute path must be rejected");
+    }
+
+    #[test]
+    fn path_safety_rejects_dot_dot_traversal() {
+        let ws = TestWorkspace::new("dotdot");
+        for p in ["../outside.txt", "afana/../../etc/passwd", "a/./../../b"] {
+            assert!(
+                resolve_within(ws.path(), p).is_err(),
+                "traversal path '{p}' must be rejected"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn path_safety_rejects_symlink_resolving_outside_workspace() {
+        let ws = TestWorkspace::new("symlink");
+        let outside = TestWorkspace::new("symlink-outside");
+        std::os::unix::fs::symlink(outside.path(), ws.path().join("escape"))
+            .expect("create symlink");
+        let result = resolve_within(ws.path(), "escape/evil.txt");
+        assert!(
+            result.is_err(),
+            "path resolving outside the workspace via symlink must be rejected"
+        );
+    }
+
+    #[test]
+    fn path_safety_accepts_normal_repo_relative_paths() {
+        let ws = TestWorkspace::new("normal");
+        std::fs::create_dir_all(ws.path().join("afana/src")).expect("mkdir");
+        let resolved = resolve_within(ws.path(), "afana/src/optimize.rs");
+        assert!(resolved.is_ok(), "normal relative path must be accepted");
+        assert!(resolved.expect("checked above").starts_with(ws.path()));
+    }
+
+    // ── Action parsing ──────────────────────────────────────────────────────
+
+    #[test]
+    fn action_parsing_all_five_actions() {
+        let list = parse_action(r#"{"action":"list","path":"afana/src"}"#)
+            .expect("list should parse");
+        assert!(matches!(list, Action::List { ref path } if path == "afana/src"));
+
+        let read = parse_action(r#"{"action":"read","path":"afana/src/optimize.rs"}"#)
+            .expect("read should parse");
+        assert!(matches!(read, Action::Read { ref path } if path == "afana/src/optimize.rs"));
+
+        let write = parse_action(r#"{"action":"write","path":"a.rs","content":"fn main() {}"}"#)
+            .expect("write should parse");
+        assert!(
+            matches!(write, Action::Write { ref path, ref content } if path == "a.rs" && content == "fn main() {}")
+        );
+
+        let test = parse_action(r#"{"action":"test"}"#).expect("test should parse");
+        assert!(matches!(test, Action::Test));
+
+        let finish = parse_action(r#"{"action":"finish","summary":"done"}"#)
+            .expect("finish should parse");
+        assert!(matches!(finish, Action::Finish { ref summary } if summary == "done"));
+    }
+
+    #[test]
+    fn action_parsing_unknown_action_is_an_error_not_a_panic() {
+        let result = parse_action(r#"{"action":"explode","path":"x"}"#);
+        assert!(result.is_err(), "unknown action must produce an error");
+        // And through the step dispatcher it becomes an error result string.
+        let ws = TestWorkspace::new("unknown");
+        match step(ws.path(), r#"{"action":"explode","path":"x"}"#) {
+            StepOutcome::Continue(msg) => assert!(msg.starts_with("ERROR:")),
+            StepOutcome::Finish(_) => panic!("unknown action must not finish the loop"),
+        }
+    }
+
+    #[test]
+    fn action_parsing_unparseable_json_is_an_error_result() {
+        let ws = TestWorkspace::new("garbage");
+        match step(ws.path(), "I don't know what to do") {
+            StepOutcome::Continue(msg) => assert!(msg.starts_with("ERROR:")),
+            StepOutcome::Finish(_) => panic!("garbage must not finish the loop"),
+        }
+    }
+
+    // ── Test-output helper ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_failure_output_puts_error_lines_before_the_tail() {
+        let mut output = String::from("error[E0308]: mismatched types\n  --> afana/src/lib.rs:10:5\n");
+        // Fill with enough progress noise to exceed the tail cap.
+        for i in 0..500 {
+            output.push_str(&format!("   Compiling crate number {i} ...\n"));
+        }
+        output.push_str("error: aborting due to previous error\n");
+        assert!(output.len() > TEST_TAIL_CAP);
+
+        let formatted = format_test_failure(&output);
+
+        let first_error = formatted
+            .find("error[E0308]: mismatched types")
+            .expect("first error line must be present");
+        let tail_marker = formatted
+            .find("Output tail")
+            .expect("tail section must be present");
+        assert!(
+            first_error < tail_marker,
+            "error lines must appear BEFORE the tail"
+        );
+        // The noise that pushed the real error out of the tail window must
+        // still not have displaced it from the report.
+        assert!(formatted.contains("mismatched types"));
+    }
+
+    // ── Whole-file collection ───────────────────────────────────────────────
+
+    #[test]
+    fn collect_changed_files_includes_modified_and_added_files() {
+        let ws = TestWorkspace::new("collect");
+        // Initialise a git repo with one committed file.
+        std::fs::write(ws.path().join("existing.rs"), "fn old() {}\n").expect("write");
+        let init = Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(ws.path())
+            .output()
+            .expect("git init runs");
+        assert!(init.status.success());
+        let add = Command::new("git")
+            .args(["add", "."])
+            .current_dir(ws.path())
+            .output()
+            .expect("git add runs");
+        assert!(add.status.success());
+        let commit = Command::new("git")
+            .args([
+                "-c",
+                "user.email=test@test",
+                "-c",
+                "user.name=test",
+                "commit",
+                "-q",
+                "-m",
+                "init",
+            ])
+            .current_dir(ws.path())
+            .output()
+            .expect("git commit runs");
+        assert!(commit.status.success());
+
+        // Modify the committed file and add a new one.
+        std::fs::write(ws.path().join("existing.rs"), "fn new() {}\n").expect("modify");
+        std::fs::write(ws.path().join("added.rs"), "fn added() {}\n").expect("add");
+
+        let files = collect_changed_files(ws.path()).expect("collection succeeds");
+        assert_eq!(
+            files.get("existing.rs").map(String::as_str),
+            Some("fn new() {}\n"),
+            "modified file must appear with FULL current content"
+        );
+        assert_eq!(
+            files.get("added.rs").map(String::as_str),
+            Some("fn added() {}\n"),
+            "added (untracked) file must appear with full content"
+        );
+    }
+
+    // ── Read/write/list behaviour ───────────────────────────────────────────
+
+    #[test]
+    fn read_action_prefixes_line_numbers() {
+        let ws = TestWorkspace::new("read");
+        std::fs::write(ws.path().join("f.rs"), "a\nb\nc\n").expect("write");
+        let out = read_action(ws.path(), "f.rs");
+        assert!(out.contains("1\ta"));
+        assert!(out.contains("2\tb"));
+        assert!(out.contains("3\tc"));
+    }
+
+    #[test]
+    fn write_action_creates_parent_directories() {
+        let ws = TestWorkspace::new("write");
+        let out = write_action(ws.path(), "deep/nested/new.rs", "fn x() {}\n");
+        assert!(out.starts_with("OK:"));
+        let content = std::fs::read_to_string(ws.path().join("deep/nested/new.rs"))
+            .expect("file exists after write");
+        assert_eq!(content, "fn x() {}\n");
+    }
+
+    #[test]
+    fn list_action_lists_entries() {
+        let ws = TestWorkspace::new("list");
+        std::fs::create_dir_all(ws.path().join("sub")).expect("mkdir");
+        std::fs::write(ws.path().join("file.rs"), "").expect("write");
+        let out = list_action(ws.path(), ".");
+        assert!(out.contains("file.rs"));
+        assert!(out.contains("sub/"));
+    }
+
+    // ── Loop behaviour with injected model ──────────────────────────────────
+
+    fn call_result(content: &str, latency_ms: u64) -> crate::provider::CallResult {
+        crate::provider::CallResult {
+            content: content.to_string(),
+            latency_ms,
+            http_status: 200,
+            retries: 0,
+            model_verified: None,
+            served_model: None,
+            input_len: 0,
+        }
+    }
+
+    #[tokio::test]
+    async fn loop_runs_until_finish_and_sums_latency() {
+        let ws = TestWorkspace::new("loop-finish");
+        std::fs::write(ws.path().join("f.rs"), "old\n").expect("write");
+
+        let mut calls: u32 = 0;
+        let outcome = run_agent_loop(ws.path(), "ISSUE", move |_transcript| {
+            calls += 1;
+            let content = match calls {
+                1 => r#"{"action":"write","path":"f.rs","content":"new\n"}"#.to_string(),
+                _ => r#"{"action":"finish","summary":"rewrote f.rs"}"#.to_string(),
+            };
+            async move { Ok(call_result(&content, 100)) }
+        })
+        .await
+        .expect("loop succeeds");
+
+        assert_eq!(outcome.summary.as_deref(), Some("rewrote f.rs"));
+        assert_eq!(outcome.steps, 2);
+        assert_eq!(outcome.total_latency_ms, 200);
+        assert_eq!(outcome.last_call.latency_ms, 100);
+        assert!(outcome.transcript.contains("ISSUE"));
+        assert!(outcome.transcript.contains("rewrote f.rs"));
+        let content = std::fs::read_to_string(ws.path().join("f.rs")).expect("read");
+        assert_eq!(content, "new\n");
+    }
+
+    #[tokio::test]
+    async fn loop_bad_response_consumes_a_step_without_aborting() {
+        let ws = TestWorkspace::new("loop-bad");
+        let mut calls: u32 = 0;
+        let outcome = run_agent_loop(ws.path(), "ISSUE", move |_transcript| {
+            calls += 1;
+            let content = match calls {
+                1 => "total garbage, not json".to_string(),
+                _ => r#"{"action":"finish","summary":"recovered"}"#.to_string(),
+            };
+            async move { Ok(call_result(&content, 10)) }
+        })
+        .await
+        .expect("loop succeeds despite one bad response");
+
+        assert_eq!(outcome.summary.as_deref(), Some("recovered"));
+        assert_eq!(outcome.steps, 2);
+        assert!(outcome.transcript.contains("ERROR:"));
+    }
+
+    #[tokio::test]
+    async fn loop_exhausts_step_budget() {
+        let ws = TestWorkspace::new("loop-budget");
+        let outcome = run_agent_loop(ws.path(), "ISSUE", move |_transcript| async move {
+            Ok(call_result(r#"{"action":"list","path":"."}"#, 5))
+        })
+        .await
+        .expect("loop returns after budget exhaustion");
+
+        assert_eq!(outcome.steps, MAX_STEPS);
+        assert_eq!(outcome.summary, None, "no finish summary when budget runs out");
+        assert_eq!(outcome.total_latency_ms, 5 * MAX_STEPS as u64);
+    }
+
+    // ── Dry-run ─────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn dry_run_makes_no_model_call_and_no_filesystem_change() {
+        // pick_model needs at least one eligible provider: groq entries carry
+        // the b1_solver role and a cloud provider is "live" with just a key.
+        // The guard is scoped to the env setup so it is not held across the
+        // await below (clippy::await_holding_lock).
+        {
+            let _guard = crate::availability::TEST_LOCK
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            crate::config::init_rotation();
+            std::env::set_var("GROQ_API_KEY", "test-key");
+        }
+
+        let github = GitHubClient::new("token".to_string(), "owner/repo".to_string());
+        let labels: Vec<String> = vec![];
+        let counts: HashMap<String, u32> = HashMap::new();
+
+        let before = std::fs::read_dir("/tmp")
+            .expect("read /tmp")
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().starts_with("senate-agent-"))
+            .count();
+
+        let (result, _entry, call, context) = solve_agentic(
+            &github,
+            9999,
+            "dry run issue",
+            "body",
+            &labels,
+            &[],
+            &counts,
+            None,
+            true,
+        )
+        .await
+        .expect("dry-run solve succeeds");
+
+        assert_eq!(result.reasoning, "Dry-run placeholder reasoning.");
+        assert!(result.edits.is_empty());
+        assert!(result.new_files.is_empty());
+        assert_eq!(call.content, "dry-run", "no real model call happened");
+        assert_eq!(call.latency_ms, 0);
+
+        let after = std::fs::read_dir("/tmp")
+            .expect("read /tmp")
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().starts_with("senate-agent-"))
+            .count();
+        assert_eq!(before, after, "dry-run must not create a checkout");
+        let _ = context;
+    }
+}

--- a/quasi-senate/src/agent.rs
+++ b/quasi-senate/src/agent.rs
@@ -312,7 +312,7 @@ fn tail(s: &str, cap: usize) -> &str {
 /// ("test result: FAILED", compiling lines) while the real `error[Exxxx]:`
 /// block sits much earlier — on issue #1118 a tail-only view swallowed the
 /// actual failure entirely.
-fn format_test_failure(output: &str) -> String {
+pub(crate) fn format_test_failure(output: &str) -> String {
     let mut result = String::from("cargo test FAILED.\n");
 
     let error_lines: Vec<&str> = output
@@ -940,6 +940,22 @@ mod tests {
         assert!(outcome.transcript.contains("rewrote f.rs"));
         let content = std::fs::read_to_string(ws.path().join("f.rs")).expect("read");
         assert_eq!(content, "new\n");
+    }
+
+    /// The gate used to slice cargo output at `len() - 2000` bytes, which
+    /// panics when that index lands inside a multi-byte character. Cargo emits
+    /// them routinely — `─`, `…`, and arrows in diagnostics are all multi-byte.
+    #[test]
+    fn test_failure_formatting_survives_multibyte_output() {
+        let noise = "─".repeat(4000); // 3 bytes each, so byte cuts land mid-char
+        let output = format!("error[E0308]: mismatched types\n{noise}");
+
+        let formatted = format_test_failure(&output); // must not panic
+
+        assert!(
+            formatted.contains("error[E0308]"),
+            "the error line must survive multi-byte truncation"
+        );
     }
 
     /// Issue #1118: the agent wrote 146 working lines, then the provider

--- a/quasi-senate/src/agent.rs
+++ b/quasi-senate/src/agent.rs
@@ -420,6 +420,7 @@ where
     let mut steps: u32 = 0;
     let started = std::time::Instant::now();
     let mut timed_out = false;
+    let mut call_error: Option<String> = None;
 
     while steps < MAX_STEPS {
         // Check before spending another call, not after: the point is to stop
@@ -435,7 +436,25 @@ where
         }
         steps += 1;
 
-        let call = model_call(transcript.clone()).await?;
+        // A failed call ends the session but must not discard it. Propagating
+        // with `?` here threw away 146 lines of working edits on issue #1118
+        // when the provider stalled on the last step: the work was on disk and
+        // `git status` could see it, but the error returned before collection.
+        // A model that has already produced a good edit should not be punished
+        // for its provider dying afterwards.
+        let call = match model_call(transcript.clone()).await {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    steps_used = steps,
+                    "agent loop lost its model — keeping whatever it already wrote"
+                );
+                call_error = Some(e.to_string());
+                steps = steps.saturating_sub(1); // the step bought nothing
+                break;
+            }
+        };
         total_latency_ms = total_latency_ms.saturating_add(call.latency_ms);
         let raw = call.content.clone();
         last_call = Some(call);
@@ -456,8 +475,21 @@ where
         }
     }
 
-    let last_call = last_call
-        .ok_or_else(|| anyhow!("agent loop ran zero steps (MAX_STEPS={MAX_STEPS})"))?;
+    // No successful call at all means there is nothing to collect and no
+    // telemetry to report, so this really is a failure — but say which kind.
+    let last_call = last_call.ok_or_else(|| match &call_error {
+        Some(e) => anyhow!("agent loop made no successful model call: {e}"),
+        None => anyhow!("agent loop ran zero steps (MAX_STEPS={MAX_STEPS})"),
+    })?;
+
+    if summary.is_none() {
+        if let Some(e) = &call_error {
+            summary = Some(format!(
+                "agent loop ended at step {steps} because the model call failed ({e}); \
+                 any changes below are partial"
+            ));
+        }
+    }
 
     if timed_out && summary.is_none() {
         // Distinguish "ran out of thinking" from "ran out of time" — the two
@@ -908,6 +940,63 @@ mod tests {
         assert!(outcome.transcript.contains("rewrote f.rs"));
         let content = std::fs::read_to_string(ws.path().join("f.rs")).expect("read");
         assert_eq!(content, "new\n");
+    }
+
+    /// Issue #1118: the agent wrote 146 working lines, then the provider
+    /// stalled on a later step and the whole session was discarded. The edits
+    /// were on disk the entire time. A provider dying after good work is not a
+    /// reason to throw the work away.
+    #[tokio::test]
+    async fn loop_keeps_its_edits_when_the_model_call_fails() {
+        let ws = TestWorkspace::new("loop-call-err");
+        std::fs::write(ws.path().join("f.rs"), "old\n").expect("write");
+
+        let mut calls: u32 = 0;
+        let outcome = run_agent_loop(ws.path(), "ISSUE", move |_transcript| {
+            calls += 1;
+            let step: Result<crate::provider::CallResult> = match calls {
+                1 => Ok(call_result(
+                    r#"{"action":"write","path":"f.rs","content":"good edit\n"}"#,
+                    100,
+                )),
+                _ => Err(anyhow!("Provider openrouter did not respond within 540s")),
+            };
+            async move { step }
+        })
+        .await
+        .expect("a dead provider must not fail the whole session");
+
+        assert_eq!(
+            std::fs::read_to_string(ws.path().join("f.rs")).expect("read"),
+            "good edit\n",
+            "the edit made before the failure must survive"
+        );
+        assert_eq!(outcome.steps, 1, "the failed call bought nothing");
+        let summary = outcome.summary.unwrap_or_default();
+        assert!(
+            summary.contains("partial") && summary.contains("540s"),
+            "the summary must say the work is partial and why: {summary}"
+        );
+    }
+
+    /// The other half: if the very first call fails there is nothing to keep,
+    /// and the session should report that rather than an empty success.
+    #[tokio::test]
+    async fn loop_fails_when_no_call_ever_succeeds() {
+        let ws = TestWorkspace::new("loop-all-err");
+        let result = run_agent_loop(ws.path(), "ISSUE", move |_transcript| async {
+            Err(anyhow!("provider down"))
+        })
+        .await;
+
+        // Matched rather than `expect_err`, which would need AgentOutcome: Debug.
+        match result {
+            Ok(_) => panic!("no successful call means there is no session to return"),
+            Err(e) => assert!(
+                e.to_string().contains("provider down"),
+                "the cause must survive into the error: {e}"
+            ),
+        }
     }
 
     #[tokio::test]

--- a/quasi-senate/src/lib.rs
+++ b/quasi-senate/src/lib.rs
@@ -2,6 +2,7 @@
 // Copyright 2026 QUASI Contributors
 //! `quasi-senate` library root — re-exports all public modules for integration tests.
 
+pub mod agent;
 pub mod already_done;
 pub mod availability;
 pub mod config;

--- a/quasi-senate/src/pipeline.rs
+++ b/quasi-senate/src/pipeline.rs
@@ -1504,6 +1504,20 @@ async fn pre_review_cargo_check(
             .env("RUSTUP_HOME", "/root/.rustup")
             .env("CARGO_HOME", "/root/.cargo")
             .env("CARGO_TARGET_DIR", target_dir);
+
+        // Operator levers must not reach the tests. The child inherits this
+        // process's environment, so a lever set to steer the senate also steers
+        // the library code under test: with SENATE_FORCE_MODEL exported,
+        // quasi-senate's own test_rotation asserts against a rotation that has
+        // been forcibly overridden, and fails. That rejected a solve attempt on
+        // issue #1118 for a reason having nothing to do with its work.
+        //
+        // The gate's job is to judge the repo as it would build in CI, where
+        // none of these are set.
+        for lever in ["SENATE_FORCE_MODEL", "SENATE_BLIND_SOLVER", "SENATE_DIRECT_ISSUES"] {
+            command.env_remove(lever);
+        }
+
         for arg in extra {
             command.arg(*arg);
         }

--- a/quasi-senate/src/pipeline.rs
+++ b/quasi-senate/src/pipeline.rs
@@ -1528,12 +1528,19 @@ async fn pre_review_cargo_check(
             String::from_utf8_lossy(&test_output.stdout),
             String::from_utf8_lossy(&test_output.stderr)
         );
-        let truncated: String = if combined.len() > 2000 {
-            format!("…{}", &combined[combined.len() - 2000..])
-        } else {
-            combined
-        };
-        return Err(format!("cargo test failed:\n{truncated}"));
+        // Same formatting the agent gets from its own `test` action: error
+        // lines first, then the tail. A tail-only view of cargo output shows
+        // passing tests and "Running tests/…" banners while the real
+        // error[Exxxx] block sits thousands of lines earlier — on issue #1118
+        // both rejections were undiagnosable for exactly this reason.
+        //
+        // It also slices on a char boundary. The previous code indexed a String
+        // at `len() - 2000`, which panics outright when that byte lands inside
+        // a multi-byte character — and cargo emits plenty of those.
+        return Err(format!(
+            "cargo test failed:\n{}",
+            crate::agent::format_test_failure(&combined)
+        ));
     }
 
     // 5. Run cargo clippy — advisory only.

--- a/quasi-senate/src/pipeline.rs
+++ b/quasi-senate/src/pipeline.rs
@@ -156,6 +156,14 @@ pub fn direct_issues_enabled() -> bool {
     std::env::var("SENATE_DIRECT_ISSUES").as_deref() == Ok("1")
 }
 
+/// Rollback lever: `SENATE_BLIND_SOLVER=1` restores the legacy single-shot
+/// blind find/replace solver (`solver::solve_issue`). Default (unset) is the
+/// agentic solver (`agent::solve_agentic`), which works in a real checkout
+/// and runs the tests itself.
+pub fn blind_solver_enabled() -> bool {
+    std::env::var("SENATE_BLIND_SOLVER").as_deref() == Ok("1")
+}
+
 /// Run the A-track pipeline for one issue: A.2 draft, A.3 gate, retry up to 2×.
 ///
 /// On approval, queues a `quasi:Propose` proposal on the quasi-board and
@@ -775,20 +783,41 @@ pub async fn run_solve_pipeline(ctx: &mut AppContext, issue_number: u32) -> Resu
 
         let exclude_refs: Vec<&str> = solver_exclude.iter().map(|s| s.as_str()).collect();
 
-        // B.1 — Solve
-        let solve_result_r = crate::solver::solve_issue(
-            &ctx.github,
-            issue_number,
-            &issue_title,
-            &issue_body,
-            &issue_labels,
-            &exclude_refs,
-            &counts,
-            last_provider,
-            retry_feedback.as_deref(),
-            ctx.dry_run,
-        )
-        .await;
+        // B.1 — Solve. Default is the agentic solver (real checkout, runs the
+        // tests itself); SENATE_BLIND_SOLVER=1 rolls back to the legacy
+        // single-shot find/replace solver.
+        let solve_result_r = if blind_solver_enabled() {
+            warn!(
+                "pipeline: SENATE_BLIND_SOLVER=1 — using the legacy single-shot \
+                 blind find/replace solver instead of the agentic solver"
+            );
+            crate::solver::solve_issue(
+                &ctx.github,
+                issue_number,
+                &issue_title,
+                &issue_body,
+                &issue_labels,
+                &exclude_refs,
+                &counts,
+                last_provider,
+                retry_feedback.as_deref(),
+                ctx.dry_run,
+            )
+            .await
+        } else {
+            crate::agent::solve_agentic(
+                &ctx.github,
+                issue_number,
+                &issue_title,
+                &issue_body,
+                &issue_labels,
+                &exclude_refs,
+                &counts,
+                last_provider,
+                ctx.dry_run,
+            )
+            .await
+        };
         let (mut solve_result, b1_entry, b1_call, repo_context) = match solve_result_r {
             Ok(quad) => quad,
             Err(e) => {

--- a/quasi-senate/src/prompts.rs
+++ b/quasi-senate/src/prompts.rs
@@ -656,6 +656,57 @@ Emit ONLY the JSON object described in the system prompt.
     )
 }
 
+// ── B.1 — Agentic Solver ─────────────────────────────────────────────────────
+
+pub fn agent_system_prompt() -> &'static str {
+    r#"You are an autonomous software agent solving a GitHub issue in the QUASI project.
+
+You are working inside a real checkout of the repository. You act in steps:
+on each turn you receive the issue plus the transcript of everything you have
+done so far, and you respond with EXACTLY ONE JSON action object — no prose,
+no markdown fences, nothing before or after the JSON.
+
+## Actions
+
+{"action":"list",  "path":"afana/src"}
+{"action":"read",  "path":"afana/src/optimize.rs"}
+{"action":"write", "path":"afana/src/optimize.rs", "content":"<ENTIRE new file content>"}
+{"action":"test"}
+{"action":"finish","summary":"one sentence describing what you changed and why"}
+
+- `list` shows directory entries, one per line.
+- `read` shows the full file with line numbers.
+- `write` REPLACES THE WHOLE FILE. Always `read` a file before you `write` it,
+  and write back the complete new content — never a fragment, never a diff.
+  Parent directories are created as needed.
+- `test` runs `cargo test --workspace --all-targets` (up to 15 minutes) and
+  returns the result.
+- `finish` ends the session.
+
+## Rules
+
+1. One JSON action per response. Any other text breaks the harness and wastes
+   a step.
+2. You have a budget of 12 steps (each response is one step). Running out of
+   steps means the attempt FAILED — plan accordingly and do not wander.
+3. Run `test` before you `finish`, and do NOT finish while tests are failing.
+4. Modify only files related to the issue. Do not touch unrelated files,
+   CI workflows, or reformat code you did not need to change.
+5. If you create a new `.rs` file inside `afana/src/`, you MUST also add a
+   `pub mod <name>;` line to `afana/src/lib.rs`.
+6. Integration tests live in `afana/tests/*.rs` and use `use afana::...`
+   (not `use crate::`).
+
+## Architectural invariants — violations get the PR rejected
+
+- Afana is a Rust-only compiler: NEVER create `.py` files inside `afana/`.
+- No vendor SDKs (no qiskit, cirq, boto, etc.) anywhere.
+- No `#[allow(...)]` attributes to silence clippy — fix the code instead.
+- No panics in library code: no `panic!`, `unwrap()`, `expect()`, or
+  `unreachable!()` on paths that can fail — return `Result` instead.
+"#
+}
+
 // ── B.2 — Code Reviewer ───────────────────────────────────────────────────────
 
 pub fn reviewer_system_prompt() -> &'static str {

--- a/quasi-senate/src/provider.rs
+++ b/quasi-senate/src/provider.rs
@@ -22,6 +22,29 @@ use tracing::{info, warn};
 use crate::config::get_provider;
 use crate::types::RotationEntry;
 
+/// Test-only shrink of the overall call budget, in seconds. Zero means unset.
+///
+/// The production budget is minutes long by design, which no unit test can wait
+/// out. Rather than leave the ceiling untested — it exists precisely because the
+/// per-attempt timeout proved unreliable — tests shrink it to a couple of
+/// seconds and point a provider at a socket that never answers.
+#[cfg(test)]
+static CALL_BUDGET_OVERRIDE_SECS: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+/// Ceiling for one `call_model`, covering every retry attempt together:
+/// four attempts at `timeout_secs` plus 14 s of cumulative backoff, with slack.
+fn overall_call_budget(timeout_secs: u64) -> std::time::Duration {
+    #[cfg(test)]
+    {
+        let o = CALL_BUDGET_OVERRIDE_SECS.load(std::sync::atomic::Ordering::SeqCst);
+        if o > 0 {
+            return std::time::Duration::from_secs(o);
+        }
+    }
+    std::time::Duration::from_secs(timeout_secs * 4 + 60)
+}
+
 // ── Request body ──────────────────────────────────────────────────────────────
 
 #[derive(Serialize)]
@@ -231,7 +254,22 @@ pub async fn call_model_with_format(
     let start_time = std::time::Instant::now();
     let attempt_count = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
 
-    let inner_result = Retry::spawn(retry_strategy, || {
+    // See `overall_call_budget`. Hard ceiling on the entire retry sequence.
+    //
+    // Each attempt already builds a client with `.timeout(timeout_secs)`, and
+    // that usually fires — a 122 s gap between attempts is the 120 s timeout
+    // plus backoff. But it does not always: on issue #1118, deepseek-v4-flash
+    // sat in a single call for 39 minutes at 0% CPU, and minimax-m3 for 22
+    // before it. reqwest's request timeout does not cover every way a call can
+    // stall (connection establishment and name resolution among them), so a
+    // per-attempt timeout is not a bound on the call as a whole.
+    //
+    // This wrapper does not depend on the client's internals being right: four
+    // attempts plus 14 s of cumulative backoff, with slack. Whatever hangs
+    // inside, the future is dropped and the caller gets an error it can act on.
+    let overall_budget = overall_call_budget(timeout_secs);
+
+    let inner_result = match tokio::time::timeout(overall_budget, Retry::spawn(retry_strategy, || {
         // Clone what we need for each attempt.
         let headers = headers.clone();
         let request_json = request_json.clone();
@@ -371,8 +409,27 @@ pub async fn call_model_with_format(
 
             Ok::<(String, u16, Option<bool>, Option<String>), anyhow::Error>((content, status_code, model_verified, served_model_val))
         }
-    })
-    .await;
+    })).await {
+        Ok(r) => r,
+        Err(_elapsed) => {
+            // Take the provider out of selection: a stall this long means the
+            // endpoint is not serving, and the next role should not discover
+            // that the same slow way.
+            crate::availability::mark_provider_down(&entry.provider);
+            warn!(
+                model = model_id,
+                provider = entry.provider.as_str(),
+                budget_s = overall_budget.as_secs(),
+                "LLM call exceeded its overall budget — abandoning and marking provider down"
+            );
+            Err(anyhow::anyhow!(
+                "Provider {} did not respond within {}s for model {} (overall budget across all retries)",
+                entry.provider,
+                overall_budget.as_secs(),
+                model_id
+            ))
+        }
+    };
 
     let (content, http_status, model_verified, served_model) = inner_result?;
     let latency_ms = start_time.elapsed().as_millis() as u64;
@@ -636,6 +693,62 @@ mod tests {
     struct Simple {
         key: String,
         value: u32,
+    }
+
+    /// The failure this reproduces: a socket that completes the TCP handshake
+    /// and then answers nothing. reqwest's per-attempt timeout did not bound it
+    /// in production — deepseek-v4-flash stalled 39 minutes on issue #1118 and
+    /// minimax-m3 22 minutes before that, both at 0% CPU — so the overall
+    /// budget must return an error on its own.
+    /// Sync test driving its own runtime rather than `#[tokio::test]`: the lock
+    /// must be held while the call runs, because the endpoint is read from the
+    /// environment inside it, and a std guard may not be held across an await.
+    #[test]
+    fn call_model_gives_up_when_the_endpoint_never_answers() {
+        let _guard = crate::availability::TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+
+        // Accept connections, never write a response. Not a closed port: a
+        // refused connection fails fast and would pass even without the fix.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind a local port");
+        let addr = listener.local_addr().expect("read the bound address");
+        std::thread::spawn(move || {
+            let mut held = Vec::new();
+            while let Ok((sock, _)) = listener.accept() {
+                held.push(sock); // hold it open; write nothing
+            }
+        });
+
+        std::env::set_var("OLLAMA_URL", format!("http://{addr}/v1/chat/completions"));
+        CALL_BUDGET_OVERRIDE_SECS.store(2, std::sync::atomic::Ordering::SeqCst);
+
+        let entry = RotationEntry {
+            id: "hanging-model".to_string(),
+            model: "hanging-model".to_string(),
+            provider: "ollama".to_string(),
+            license: "test".to_string(),
+            origin: "test".to_string(),
+            roles: vec![crate::types::Role::B1Solver],
+            quarantined: false,
+            max_tokens: None,
+            max_context: None,
+            cost_tier: 0,
+        };
+
+        let rt = tokio::runtime::Runtime::new().expect("build a test runtime");
+        let started = std::time::Instant::now();
+        let result = rt.block_on(call_model(&entry, "sys", "user", 0.0, 16));
+        let elapsed = started.elapsed();
+
+        CALL_BUDGET_OVERRIDE_SECS.store(0, std::sync::atomic::Ordering::SeqCst);
+        std::env::remove_var("OLLAMA_URL");
+
+        assert!(result.is_err(), "a silent endpoint must produce an error");
+        assert!(
+            elapsed < std::time::Duration::from_secs(20),
+            "the call must be abandoned near its budget, not hang; took {elapsed:?}"
+        );
     }
 
     #[test]

--- a/quasi-senate/src/rotation.rs
+++ b/quasi-senate/src/rotation.rs
@@ -82,6 +82,38 @@ fn pick_from<'a>(
     counts: &HashMap<String, u32>,
     last_provider: Option<&str>,
 ) -> Result<&'a RotationEntry> {
+    // Step 0: an explicit operator override, for evaluating one model against a
+    // known issue. Rotation is designed to make any single model's turn hard to
+    // predict, which is exactly wrong when the question is "how does THIS model
+    // do on THIS task". Deliberately narrow: it must still support the role and
+    // have a live provider, so the override can pin a model but not conjure an
+    // unusable one. It ignores `exclude`, so a retry re-runs the same model —
+    // that is the point when measuring, and the reason it is not a default.
+    if let Ok(forced) = std::env::var("SENATE_FORCE_MODEL") {
+        let forced = forced.trim();
+        if !forced.is_empty() {
+            let hit = eligible_from(entries, role)
+                .into_iter()
+                .find(|e| e.id == forced);
+            return match hit {
+                Some(e) => {
+                    tracing::warn!(
+                        model = %e.id,
+                        %role,
+                        "SENATE_FORCE_MODEL is set — rotation bypassed for this role"
+                    );
+                    Ok(e)
+                }
+                // Fail loudly. Silently falling back to rotation would attribute
+                // another model's result to the one being measured.
+                None => Err(anyhow!(
+                    "SENATE_FORCE_MODEL={forced} is not an eligible model for role {role} \
+                     (unknown id, quarantined, missing API key, or provider down)"
+                )),
+            };
+        }
+    }
+
     // Step 1: get all eligible candidates for this role.
     //
     // Exclusion is by model FAMILY, not just by entry id. Excluding only the id
@@ -191,6 +223,55 @@ mod tests {
         assert_eq!(
             picked.id, "other-model",
             "retry must not pick the same model family via another provider"
+        );
+    }
+
+    /// The override exists to measure one model on one issue, so it must win
+    /// over cost tier, fairness and the exclusion list alike.
+    #[test]
+    fn force_model_overrides_rotation_and_exclusions() {
+        let _guard = crate::availability::TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        setup_env();
+        crate::availability::force_provider_live("ollama");
+
+        let entries = vec![
+            test_entry("free-model", "ollama", 0),
+            test_entry("wanted-model", "groq", 1),
+        ];
+        let counts: HashMap<String, u32> = HashMap::new();
+
+        std::env::set_var("SENATE_FORCE_MODEL", "wanted-model");
+        let picked = pick_from(&entries, &Role::B1Solver, &["wanted-model"], &counts, None);
+        std::env::remove_var("SENATE_FORCE_MODEL");
+
+        assert_eq!(
+            picked.expect("the forced model should be picked").id,
+            "wanted-model",
+            "the override must beat the free tier and survive the exclusion list"
+        );
+    }
+
+    /// Falling back to rotation here would credit another model with the
+    /// forced model's result, which defeats the purpose of forcing one.
+    #[test]
+    fn force_model_errors_rather_than_silently_falling_back() {
+        let _guard = crate::availability::TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        setup_env();
+
+        let entries = vec![test_entry("real-model", "groq", 1)];
+        let counts: HashMap<String, u32> = HashMap::new();
+
+        std::env::set_var("SENATE_FORCE_MODEL", "typo-model");
+        let picked = pick_from(&entries, &Role::B1Solver, &[], &counts, None);
+        std::env::remove_var("SENATE_FORCE_MODEL");
+
+        assert!(
+            picked.is_err(),
+            "an unknown forced model must fail, not quietly pick something else"
         );
     }
 

--- a/quasi-senate/tests/test_rotation.rs
+++ b/quasi-senate/tests/test_rotation.rs
@@ -122,10 +122,13 @@ fn test_rotation_count() {
 #[test]
 fn test_pick_model_excludes() {
     ensure_init();
-    // Collect all A2Drafter-capable model IDs.
-    let all_drafter_ids: Vec<&str> = rotation()
-        .iter()
-        .filter(|e| e.roles.contains(&Role::A2Drafter))
+    // Only models pick_model could actually return. Building this from the
+    // whole roster lets the test choose a target that is quarantined or whose
+    // provider is down, then assert pick_model returns it — which it never
+    // will. Against the production roster that is exactly what happened:
+    // "No eligible models for role A.2 Drafter after exclusions".
+    let all_drafter_ids: Vec<&str> = eligible_for_role(&Role::A2Drafter)
+        .into_iter()
         .map(|e| e.id.as_str())
         .collect();
 

--- a/quasi-senate/tests/test_rotation.rs
+++ b/quasi-senate/tests/test_rotation.rs
@@ -133,8 +133,36 @@ fn test_pick_model_excludes() {
         return;
     }
 
-    // Pick the last one as the "only allowed" candidate.
-    let target_id = all_drafter_ids[all_drafter_ids.len() - 1];
+    // Pick the last candidate whose model family is unique among drafters.
+    //
+    // Exclusion is family-level, not id-level: excluding "deepseek-v4-flash"
+    // also excludes "deepseek-v4-flash-fw", because the same model behind a
+    // second provider is not a second opinion. So "exclude every id but one"
+    // does not leave one candidate when the target shares a family with an
+    // excluded entry — it leaves none, and pick_model correctly errors.
+    //
+    // That is not a bug in pick_model, it is a stale premise in this test: it
+    // predates family exclusion and only passed while every model appeared
+    // once. Serving one model from two providers is now normal.
+    let family_of = |id: &str| -> String {
+        rotation()
+            .iter()
+            .find(|e| e.id == id)
+            .map(|e| quasi_senate::config::model_family(&e.model))
+            .unwrap_or_default()
+    };
+    let target_id = match all_drafter_ids.iter().rev().find(|id| {
+        let fam = family_of(id);
+        all_drafter_ids
+            .iter()
+            .filter(|other| family_of(other) == fam)
+            .count()
+            == 1
+    }) {
+        Some(id) => *id,
+        // Every drafter shares a family with another. Nothing to assert.
+        None => return,
+    };
 
     // Build exclusion list of all other A2Drafter models.
     let exclusions: Vec<&str> = all_drafter_ids


### PR DESCRIPTION
Replaces the single-shot blind find/replace solver with a tool loop that works
in a real checkout, runs the tests itself, and iterates.

The rest of this branch is defects that running it surfaced. Each was found by
an actual failed solve of issue 1118, not by inspection.

## The solver

`quasi-senate/src/agent.rs` — actions are `list`, `read`, `write` (whole file),
`test`, `finish`. Whole-file writes are the point: blind structural surgery on
source cannot be made reliable by better verification around it, and it produced
a brace mismatch on issue 1118. `SENATE_BLIND_SOLVER=1` restores the old path.

## Defects found by running it

| Fix | What it cost before |
|---|---|
| Wall-clock deadline | bounded *starting* a call, never an in-flight one |
| Overall call budget in `provider.rs` | a stalled provider hung 39 min at 0% CPU; reqwest's per-attempt timeout is not a bound on the call |
| Keep edits when a provider dies | 146 working lines discarded because the error returned before collection |
| Gate output formatting | rejections were undiagnosable — the tail is progress noise, the error is thousands of lines earlier; also fixed a panic slicing a String mid-UTF-8 |
| Operator levers stripped from the gate's child env | `SENATE_FORCE_MODEL` leaked into `cargo test` and failed the rotation tests |
| `test_pick_model_excludes` | assumed one model per family; serving a model from two providers emptied the exclusion pool and failed every solve |
| Step budget 12 → 30 | the agent was cut off mid-iteration, measuring the budget rather than the model |

`SENATE_FORCE_MODEL` is new: it pins one model for a role, so a specific model
can be evaluated against a specific issue. It ignores the exclusion list, and
errors rather than falling back, so a result cannot be misattributed.

## Honesty about what this does not yet show

The agentic solver has **never passed the gate**. Every attempt on issue 1118 was
rejected for a reason unrelated to its work — the gate clones `main`, so none of
these fixes ever reached it. That is the blocker this PR removes; whether the
loop actually converges is still unproven.

## Test plan

- [x] `cargo test --workspace --all-targets` — 784 passing
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `test_pick_model_excludes` verified against the production roster, not just the embedded one
- [x] Call budget verified in production: fired at 540 s, marked the provider down, pipeline advanced
- [x] Salvage path verified in production: provider died at step 15, edits kept
- [ ] A solve of issue 1118 passing the gate — blocked until this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)
